### PR TITLE
Feature/enable tx on dual vfo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,15 @@ jobs:
           Write-Host "OK: $('{0:N0}' -f (Get-Item Yaesu_Web_Control_Setup.exe).Length) bytes"
         shell: pwsh
 
+      - name: Upload installer as workflow artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Yaesu_Web_Control_Setup
+          path: Yaesu_Web_Control_Setup.exe
+
       - name: Upload installer to GitHub Release
+        if: github.event_name == 'release' || github.event.inputs.tag != ''
         run: |
           # release event carries tag in GITHUB_REF_NAME; dispatch uses the input
           if ("${{ github.event_name }}" -eq "release") {

--- a/Models/ApplicationSettings.cs
+++ b/Models/ApplicationSettings.cs
@@ -167,6 +167,12 @@
         // Yuri W4YSW request 2026-06-17.
         public bool ShowFrequencyArrowButtons { get; set; } = false;
 
+        // Browser key that toggles TX (transmit). Empty string = disabled.
+        // Stored as a KeyboardEvent.key value such as "t", "F8", or " ".
+        // Ignored while typing in inputs to avoid accidental keying during
+        // form entry or frequency editing.
+        public string TxToggleKey { get; set; } = "";
+
         // ── Voice Control (in-process SAPI) ───────────────────────────────
         // When true, the navbar mic button is shown and the SAPI recogniser
         // engages on PTT. Default OFF -- voice control is opt-in so users

--- a/Models/ApplicationSettings.cs
+++ b/Models/ApplicationSettings.cs
@@ -168,7 +168,9 @@
         public bool ShowFrequencyArrowButtons { get; set; } = false;
 
         // Browser key that toggles TX (transmit). Empty string = disabled.
-        // Stored as a KeyboardEvent.key value such as "t", "F8", or " ".
+        // Stored as a KeyboardEvent.key value such as "t" or "F8", except
+        // Space which is stored as the token "Space" (a lone " " cannot
+        // survive HTML form / input value round-trips).
         // Ignored while typing in inputs to avoid accidental keying during
         // form entry or frequency editing.
         public string TxToggleKey { get; set; } = "";

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -127,54 +127,47 @@
     #saveMemBtnA, #saveMemBtnB { font-weight: 700 !important; font-size: 0.85rem !important; color: #212529 !important; }
 
     /* Single-receiver radios (FTdx10, FT-710, FTDX3000): the inactive VFO
-       panel and its corresponding spectrum panel are greyed and made
-       non-interactive. Editing any control on the inactive section via
-       CAT would silently swap the radio's active VFO, which is jarring
-       UX — better to disable visually and require an explicit A/B swap
-       on the rig first.
-       Single rule kills ALL pointer interactions (clicks, wheel, hover,
-       focus) so band buttons, frequency-display wheel-tuning, spectrum
-       click-to-tune, and every form control all become inert together.
-       The text/numbers remain VISIBLE — only interaction is suppressed.
+       card BODY is greyed and made non-interactive. The card HEADER stays
+       normal so TX / ZIN / badges remain full-colour and clickable — dimming
+       the whole column (including the header) made the TX button look
+       disabled in split mode even though it was still active (CSS cannot
+       undo a parent's opacity/filter on a child).
+       Editing body controls on the inactive section via CAT would silently
+       swap the radio's active VFO; better to disable visually and require
+       an explicit A/B swap on the rig first.
        See docs/decisions/0003-single-vs-dual-receiver-ui.md
        Reported by Jacek SP3L on #34. */
-    .vfo-inactive {
+    .vfo-inactive > .card > .card-body {
+        pointer-events: none;
+    }
+    .vfo-inactive > .card > .card-body > * {
+        opacity: 0.55;
+        filter: grayscale(0.5);
+        transition: opacity 0.25s ease, filter 0.25s ease;
+    }
+    /* R10/R11 (Jacek SP3L #34): in split mode the inactive panel IS the TX
+       VFO and its frequency must remain interactive so operators can set
+       the TX frequency from YWC without un-splitting first. .vfo-tx-editable
+       is added by applyVfoActiveStyling() only when splitMode>0. The freq
+       row is undimmed as a unit (parent opacity cannot be undone on nested
+       children), then non-frequency siblings in that row (roofing, AF gain)
+       are re-dimmed. */
+    .vfo-inactive.vfo-tx-editable > .card > .card-body > .vfo-freq-row {
+        opacity: 1;
+        filter: none;
+    }
+    .vfo-inactive.vfo-tx-editable > .card > .card-body > .vfo-freq-row > *:not(.frequency-display):not(.freq-step-controls):not(.fkb-open-btn) {
         opacity: 0.55;
         filter: grayscale(0.5);
         pointer-events: none;
-        transition: opacity 0.25s ease, filter 0.25s ease;
     }
-    /* R10/R11 (Jacek SP3L #34): in split mode the grey panel IS the TX VFO
-       and its frequency must remain interactive so operators can set the TX
-       frequency from YWC without un-splitting first. The .vfo-tx-editable
-       class is added by applyVfoActiveStyling() only to the inactive panel
-       and only when splitMode>0; it carves out an exception to .vfo-inactive
-       for the frequency display + up/down controls. Every other control on
-       the grey panel stays at the parent's reduced opacity + pointer-events:
-       none so it shows-but-doesn't-respond (R5/R9 read-only-but-displaying). */
     .vfo-inactive.vfo-tx-editable .frequency-display,
-    .vfo-inactive.vfo-tx-editable [id$="-controls"],
+    .vfo-inactive.vfo-tx-editable .freq-step-controls,
     .vfo-inactive.vfo-tx-editable .fkb-open-btn {
-        /* !important is necessary on the button specifically: the freq
-           display (a <span>) accepts the override at normal specificity,
-           but the <button> computes pointer-events: none even with the
-           same selector pattern -- suspected interaction with a UA or
-           Bootstrap rule that beats ordinary specificity on <button>
-           elements. Forcing the carve-out is the pragmatic fix.  */
+        /* pointer-events:auto on a child overrides pointer-events:none on
+           an ancestor — that is the CSS exception that makes the carve-out
+           work. !important is needed on <button> (fkb-open / ▲▼). */
         pointer-events: auto !important;
-        opacity: 1 !important;
-        filter: none !important;
-    }
-    /* The TX button is the transmit control: whenever it is visible on a
-       greyed panel (split mode on single-receiver radios, or the non-active
-       VFO panel on dual-receiver radios) it must stay full-colour and
-       clickable — a dimmed transmit button reads as disabled. This carve-out
-       is deliberately independent of .vfo-tx-editable so it applies in every
-       case the button is shown, not only in split mode. */
-    .vfo-inactive [id^="txButton"] {
-        pointer-events: auto !important;
-        opacity: 1 !important;
-        filter: none !important;
     }
 
     /* Hide live receive indicators on the inactive VFO panel — on a real
@@ -959,7 +952,7 @@
                     </div>
 
                     <!-- Frequency + Roofing + AF Gain on one row -->
-                    <div class="d-flex align-items-center flex-wrap gap-2 mb-1" style="margin-top: -2px;">
+                    <div class="vfo-freq-row d-flex align-items-center flex-wrap gap-2 mb-1" style="margin-top: -2px;">
                         <span id="freqA" class="fw-bold frequency-display digit-display" role="spinbutton" aria-label="VFO A frequency" title="VFO A frequency" data-a11y-key="vfo.a.frequency" tabindex="0" aria-valuemin="0.03" aria-valuemax="75" aria-valuenow="0"></span>
                         <span class="frequency-display digit-display">MHz</span>
                         <div id="freqA-controls" class="freq-step-controls" style="display:@(Model.ShowFrequencyArrowButtons ? "inline-flex" : "none");">
@@ -1363,7 +1356,7 @@
                     </div>
 
                     <!-- Frequency + Roofing + AF Gain on one row -->
-                    <div class="d-flex align-items-center flex-wrap gap-2 mb-1" style="margin-top: -2px;">
+                    <div class="vfo-freq-row d-flex align-items-center flex-wrap gap-2 mb-1" style="margin-top: -2px;">
                         <span id="freqB" class="fw-bold frequency-display digit-display" role="spinbutton" aria-label="VFO B frequency" title="VFO B frequency" data-a11y-key="vfo.b.frequency" tabindex="0" aria-valuemin="0.03" aria-valuemax="75" aria-valuenow="0"></span>
                         <span class="frequency-display digit-display">MHz</span>
                         <div id="freqB-controls" class="freq-step-controls" style="display:@(Model.ShowFrequencyArrowButtons ? "inline-flex" : "none");">

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -154,14 +154,24 @@
        none so it shows-but-doesn't-respond (R5/R9 read-only-but-displaying). */
     .vfo-inactive.vfo-tx-editable .frequency-display,
     .vfo-inactive.vfo-tx-editable [id$="-controls"],
-    .vfo-inactive.vfo-tx-editable .fkb-open-btn,
-    .vfo-inactive.vfo-tx-editable [id^="txButton"] {
+    .vfo-inactive.vfo-tx-editable .fkb-open-btn {
         /* !important is necessary on the button specifically: the freq
            display (a <span>) accepts the override at normal specificity,
            but the <button> computes pointer-events: none even with the
            same selector pattern -- suspected interaction with a UA or
            Bootstrap rule that beats ordinary specificity on <button>
            elements. Forcing the carve-out is the pragmatic fix.  */
+        pointer-events: auto !important;
+        opacity: 1 !important;
+        filter: none !important;
+    }
+    /* The TX button is the transmit control: whenever it is visible on a
+       greyed panel (split mode on single-receiver radios, or the non-active
+       VFO panel on dual-receiver radios) it must stay full-colour and
+       clickable — a dimmed transmit button reads as disabled. This carve-out
+       is deliberately independent of .vfo-tx-editable so it applies in every
+       case the button is shown, not only in split mode. */
+    .vfo-inactive [id^="txButton"] {
         pointer-events: auto !important;
         opacity: 1 !important;
         filter: none !important;

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -154,7 +154,8 @@
        none so it shows-but-doesn't-respond (R5/R9 read-only-but-displaying). */
     .vfo-inactive.vfo-tx-editable .frequency-display,
     .vfo-inactive.vfo-tx-editable [id$="-controls"],
-    .vfo-inactive.vfo-tx-editable .fkb-open-btn {
+    .vfo-inactive.vfo-tx-editable .fkb-open-btn,
+    .vfo-inactive.vfo-tx-editable [id^="txButton"] {
         /* !important is necessary on the button specifically: the freq
            display (a <span>) accepts the override at normal specificity,
            but the <button> computes pointer-events: none even with the
@@ -1995,6 +1996,7 @@
     <!-- Cache-busted JS reference, placed BEFORE your inline script if you use window.radioControl, etc. -->
     <script>window.bandPlan = '@Model.BandPlan';</script>
     <script>
+        window.ywcTxToggleKey = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.TxToggleKey));
         window.ywcVoiceNudgeStepHzA = @Model.VoiceNudgeStepHzA;
         window.ywcVoiceNudgeStepHzB = @Model.VoiceNudgeStepHzB;
     </script>

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -133,7 +133,7 @@ namespace Yaesu_Web_Control.Pages
             ShowApp4Button = settings.ShowGridtrackerButton;
             ShowApp5Button = settings.ShowFldigiButton;
             ShowFrequencyArrowButtons = settings.ShowFrequencyArrowButtons;
-            TxToggleKey = settings.TxToggleKey;
+            TxToggleKey = settings.TxToggleKey == " " ? "Space" : settings.TxToggleKey;
             App1Name = settings.App1Name;
             App2Name = settings.App2Name;
             App3Name = settings.App3Name;

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -98,6 +98,9 @@ namespace Yaesu_Web_Control.Pages
         // Default false; user enables via Settings > Accessibility.
         public bool ShowFrequencyArrowButtons { get; set; } = false;
 
+        // Optional browser key that toggles TX. Empty = disabled.
+        public string TxToggleKey { get; set; } = string.Empty;
+
         // Voice control nudge step defaults for each VFO's mic button
         // dropdown, server-rendered so voice-control.js has a starting
         // value before it can fetch/receive anything.
@@ -130,6 +133,7 @@ namespace Yaesu_Web_Control.Pages
             ShowApp4Button = settings.ShowGridtrackerButton;
             ShowApp5Button = settings.ShowFldigiButton;
             ShowFrequencyArrowButtons = settings.ShowFrequencyArrowButtons;
+            TxToggleKey = settings.TxToggleKey;
             App1Name = settings.App1Name;
             App2Name = settings.App2Name;
             App3Name = settings.App3Name;

--- a/Pages/Settings.cshtml
+++ b/Pages/Settings.cshtml
@@ -2686,6 +2686,14 @@
             const display = document.getElementById('txToggleKeyDisplay');
             if (!input || !setBtn || !clearBtn || !badge || !display) return;
 
+            // Seed the field from a JSON-encoded server value. asp-for drops a
+            // whitespace-only value attribute (a Space key round-trips to ""),
+            // so relying on input.value alone made a Space shortcut render as
+            // "Disabled" after every Settings save/refresh. JsonSerializer
+            // preserves the exact characters, including a lone space.
+            const serverKey = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.Settings.TxToggleKey ?? string.Empty));
+            input.value = serverKey;
+
             let captureActive = false;
 
             function friendlyKeyLabel(key) {
@@ -2713,6 +2721,11 @@
                 badge.style.display = 'inline-block';
                 setBtn.classList.remove('btn-outline-primary');
                 setBtn.classList.add('btn-primary');
+                // Drop focus from the button so pressing Space to choose the
+                // shortcut doesn't also re-activate the focused "Set key"
+                // button (Space/Enter fire a click on a focused button),
+                // which would immediately re-arm capture.
+                setBtn.blur();
             }
 
             setBtn.addEventListener('click', function () {

--- a/Pages/Settings.cshtml
+++ b/Pages/Settings.cshtml
@@ -2686,19 +2686,20 @@
             const display = document.getElementById('txToggleKeyDisplay');
             if (!input || !setBtn || !clearBtn || !badge || !display) return;
 
-            // Seed the field from a JSON-encoded server value. asp-for drops a
-            // whitespace-only value attribute (a Space key round-trips to ""),
-            // so relying on input.value alone made a Space shortcut render as
-            // "Disabled" after every Settings save/refresh. JsonSerializer
-            // preserves the exact characters, including a lone space.
-            const serverKey = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.Settings.TxToggleKey ?? string.Empty));
-            input.value = serverKey;
+            // Seed from a JSON-encoded server value (not the asp-for attribute).
+            // A lone space character cannot round-trip through an HTML form /
+            // input value attribute — browsers and Tag Helpers treat
+            // whitespace-only as empty, so Space used to save as "" and show
+            // "Disabled". We store the KeyboardEvent.code token "Space"
+            // instead; migrate any legacy " " on load.
+            const serverKeyRaw = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.Settings.TxToggleKey ?? string.Empty));
+            input.value = (serverKeyRaw === ' ') ? 'Space' : serverKeyRaw;
 
             let captureActive = false;
 
             function friendlyKeyLabel(key) {
                 if (!key) return 'Disabled';
-                if (key === ' ') return 'Space';
+                if (key === ' ' || key === 'Space') return 'Space';
                 if (key === 'Escape') return 'Esc';
                 return key.length === 1 ? key.toUpperCase() : key;
             }
@@ -2753,7 +2754,9 @@
                     return;
                 }
 
-                input.value = e.key;
+                // e.key for Space is " "; store "Space" so the value survives
+                // HTML form post / asp-for round-trips (whitespace-only does not).
+                input.value = (e.key === ' ') ? 'Space' : e.key;
                 stopCapture();
                 renderCurrentKey();
             }, true);

--- a/Pages/Settings.cshtml
+++ b/Pages/Settings.cshtml
@@ -220,6 +220,35 @@
                     the main screen uncluttered for users who don't need them.
                 </div>
             </div>
+            <div class="mb-3">
+                <label class="form-label fw-semibold" for="Settings_TxToggleKey">TX toggle key</label>
+                <div class="d-flex flex-wrap align-items-center gap-2">
+                    <input asp-for="Settings.TxToggleKey"
+                           class="form-control"
+                           id="Settings_TxToggleKey"
+                           style="max-width: 220px;"
+                           readonly
+                           autocomplete="off"
+                           aria-describedby="txToggleKeyHelp txToggleKeyDisplay" />
+                    <button type="button" class="btn btn-outline-primary btn-sm" id="txToggleKeySetBtn">
+                        Set key
+                    </button>
+                    <button type="button" class="btn btn-outline-secondary btn-sm" id="txToggleKeyClearBtn">
+                        Clear
+                    </button>
+                    <span class="badge text-bg-warning" id="txToggleKeyCaptureBadge" style="display:none;">
+                        Press a key now
+                    </span>
+                </div>
+                <div class="form-text" id="txToggleKeyHelp">
+                    Optional browser shortcut for toggling transmit. Disabled when blank. For safety,
+                    YWC ignores this shortcut while you are typing in an input or text box.
+                </div>
+                <div class="form-text text-warning">
+                    Warning: this directly keys the transmitter. Choose a key you will not press by accident.
+                </div>
+                <div class="form-text" id="txToggleKeyDisplay"></div>
+            </div>
         </div>
     </details>
 
@@ -2646,6 +2675,77 @@
                 if (ft710Section)    ft710Section.style.display    = v === 'FT-710'    ? 'block' : 'none';
                 if (ftdx3000Section) ftdx3000Section.style.display = v === 'FTDX3000'  ? 'block' : 'none';
             });
+        })();
+    </script>
+    <script>
+        (function () {
+            const input = document.getElementById('Settings_TxToggleKey');
+            const setBtn = document.getElementById('txToggleKeySetBtn');
+            const clearBtn = document.getElementById('txToggleKeyClearBtn');
+            const badge = document.getElementById('txToggleKeyCaptureBadge');
+            const display = document.getElementById('txToggleKeyDisplay');
+            if (!input || !setBtn || !clearBtn || !badge || !display) return;
+
+            let captureActive = false;
+
+            function friendlyKeyLabel(key) {
+                if (!key) return 'Disabled';
+                if (key === ' ') return 'Space';
+                if (key === 'Escape') return 'Esc';
+                return key.length === 1 ? key.toUpperCase() : key;
+            }
+
+            function renderCurrentKey() {
+                display.textContent = input.value
+                    ? `Current shortcut: ${friendlyKeyLabel(input.value)}`
+                    : 'Current shortcut: Disabled';
+            }
+
+            function stopCapture() {
+                captureActive = false;
+                badge.style.display = 'none';
+                setBtn.classList.remove('btn-primary');
+                setBtn.classList.add('btn-outline-primary');
+            }
+
+            function startCapture() {
+                captureActive = true;
+                badge.style.display = 'inline-block';
+                setBtn.classList.remove('btn-outline-primary');
+                setBtn.classList.add('btn-primary');
+            }
+
+            setBtn.addEventListener('click', function () {
+                if (captureActive) {
+                    stopCapture();
+                    return;
+                }
+                startCapture();
+            });
+
+            clearBtn.addEventListener('click', function () {
+                input.value = '';
+                stopCapture();
+                renderCurrentKey();
+            });
+
+            document.addEventListener('keydown', function (e) {
+                if (!captureActive) return;
+                e.preventDefault();
+                e.stopPropagation();
+
+                if (e.key === 'Tab') {
+                    stopCapture();
+                    renderCurrentKey();
+                    return;
+                }
+
+                input.value = e.key;
+                stopCapture();
+                renderCurrentKey();
+            }, true);
+
+            renderCurrentKey();
         })();
     </script>
 }

--- a/Pages/Settings.cshtml.cs
+++ b/Pages/Settings.cshtml.cs
@@ -81,6 +81,7 @@ namespace Yaesu_Web_Control.Pages
         {
             Settings = await _settingsService.GetSettingsAsync();
             Settings.BandPlan = Settings.BandPlan switch { "UK" => "Region1", "USA" => "Region2", var v => v };
+            Settings.TxToggleKey = NormalizeTxToggleKey(Settings.TxToggleKey);
             // The Settings page binds a single Sample Rate dropdown that
             // represents 'reset both VFOs to this rate'. Show the current
             // A-side rate as the pre-selected option so the dropdown reflects
@@ -246,7 +247,9 @@ namespace Yaesu_Web_Control.Pages
 
                 // Accessibility
                 current.ShowFrequencyArrowButtons = Settings.ShowFrequencyArrowButtons;
-                current.TxToggleKey = Settings.TxToggleKey ?? string.Empty;
+                // Space cannot round-trip as a lone " " through HTML form posts —
+                // store the KeyboardEvent.code token "Space" (and migrate legacy " ").
+                current.TxToggleKey = NormalizeTxToggleKey(Settings.TxToggleKey);
 
                 // Voice Control (v1)
                 current.VoiceControlEnabled = Settings.VoiceControlEnabled;
@@ -431,6 +434,19 @@ namespace Yaesu_Web_Control.Pages
             }
 
             return addresses;
+        }
+
+        /// <summary>
+        /// Space cannot round-trip through an HTML form as a lone " " (Tag Helpers
+        /// and browsers treat whitespace-only input values as empty). Persist the
+        /// KeyboardEvent.code token instead; migrate any legacy " " on save.
+        /// </summary>
+        private static string NormalizeTxToggleKey(string? key)
+        {
+            if (string.IsNullOrEmpty(key)) return string.Empty;
+            if (key == " " || key.Equals("Space", StringComparison.OrdinalIgnoreCase))
+                return "Space";
+            return key;
         }
     }
 }

--- a/Pages/Settings.cshtml.cs
+++ b/Pages/Settings.cshtml.cs
@@ -111,6 +111,8 @@ namespace Yaesu_Web_Control.Pages
             ModelState.Remove("Settings.DxClusterHost");
             ModelState.Remove("Settings.DxClusterLoginCallsign");
             ModelState.Remove("Settings.DxClusterPostLoginCommands");
+            // Accessibility TX shortcut is optional — empty = disabled.
+            ModelState.Remove("Settings.TxToggleKey");
 
             if (!ModelState.IsValid)
             {
@@ -244,6 +246,7 @@ namespace Yaesu_Web_Control.Pages
 
                 // Accessibility
                 current.ShowFrequencyArrowButtons = Settings.ShowFrequencyArrowButtons;
+                current.TxToggleKey = Settings.TxToggleKey ?? string.Empty;
 
                 // Voice Control (v1)
                 current.VoiceControlEnabled = Settings.VoiceControlEnabled;

--- a/Services/MeterPollingService.cs
+++ b/Services/MeterPollingService.cs
@@ -15,11 +15,15 @@ namespace Yaesu_Web_Control.Services
         private readonly ILogger<MeterPollingService> _logger;
         private readonly ISettingsService _settingsService;
 
-        // TX debounce: require 2 consecutive TX=false readings before declaring not-transmitting.
-        // A single TX=false poll (e.g. from a stale CAT response mid-burst) would otherwise
-        // clear the SWR rolling-average history and cause a momentary spike on the next reading.
+        // TX debounce: require 2 consecutive TX0 readings before declaring not-transmitting
+        // when we currently believe TX is on. A single TX0 mid-burst would otherwise clear
+        // the SWR rolling-average and cause a momentary spike on the next reading.
+        // Authoritative TX-off (web button / voice / etc. already cleared IsTransmitting)
+        // is accepted on the first confirming TX0 — otherwise this poller would overwrite
+        // that false back to true and the UI would stay on TX for several poll cycles.
         private int _txFalseCount = 0;
         private bool _stableIsTransmitting = false;
+        private const int TxOffDebounceCount = 2;
 
         // Antenna sync: the radio doesn't broadcast AN auto-information messages when the
         // operator changes the antenna on the front panel, so we have to poll. Polling on
@@ -98,7 +102,9 @@ namespace Yaesu_Web_Control.Services
                             _stateService.IsConnected = true;
                     }
 
-                    bool rawIsTransmitting = !string.IsNullOrEmpty(txResponse) && txResponse.Contains("TX1");
+                    // TX1 = keyed; TX2 = keyed (mic) on some Yaesu models — treat both as TX.
+                    bool rawIsTransmitting = !string.IsNullOrEmpty(txResponse)
+                        && (txResponse.Contains("TX1") || txResponse.Contains("TX2"));
                     if (rawIsTransmitting)
                     {
                         _txFalseCount = 0;
@@ -106,11 +112,15 @@ namespace Yaesu_Web_Control.Services
                     }
                     else if (txResponse != null)
                     {
-                        // Only count an explicit TX0 response toward the debounce — a null response
-                        // (radio busy / no reply) should not be treated as "not transmitting".
+                        // Explicit TX0 only — null (radio busy) must not count as unkey.
                         _txFalseCount++;
-                        if (_txFalseCount >= 5)
+                        if (_txFalseCount >= TxOffDebounceCount || !_stateService.IsTransmitting)
                             _stableIsTransmitting = false;
+                    }
+                    else if (!_stateService.IsTransmitting)
+                    {
+                        // Authoritative TX-off already applied; a null poll must not resurrect TX.
+                        _stableIsTransmitting = false;
                     }
                     bool isTransmitting = _stableIsTransmitting;
                     _stateService.IsTransmitting = isTransmitting;

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -361,8 +361,8 @@ There are two VFO panels side by side:
 
 **Greying behaviour on single-receiver radios** (FTdx10, FT-710, FTDX3000, FT-991A):
 
-- **Normal mode** (split off): the **active** VFO is white, the **inactive** VFO is grey. The grey VFO's controls (Mode, IF Width, Notch, etc.) still display their stored values for reference, but cannot be edited — those values only apply when you swap that VFO to be active via the **A↔B** button.
-- **Split mode**: the **receive** VFO is white, the **transmit** VFO is grey — opposite of normal mode. This makes sense because in split you spend most of your time receiving on the white panel and only occasionally transmit on the grey one. The grey (TX) panel's **frequency field is still editable** so you can set the TX frequency from YWC without un-splitting first — click a digit and scroll the mouse wheel, or use the keyboard icon next to MHz to type one in. The TX button and the SPLIT badge appear on the grey panel.
+- **Normal mode** (split off): the **active** VFO panel is fully usable; the **inactive** VFO's card body is greyed. Mode, IF Width, Notch, and the rest still display their stored values for reference, but cannot be edited — those values only apply when you swap that VFO to be active via the **A↔B** button. The card header (title, ZIN, TX when shown) stays normal colour.
+- **Split mode**: the **receive** VFO is fully usable; the **transmit** VFO's card body is greyed — opposite of normal mode for which panel is inactive. The TX panel's **frequency field is still editable** so you can set the TX frequency from YWC without un-splitting first — click a digit and scroll the mouse wheel, or use the keyboard icon next to MHz to type one in. Everything else in that card body stays read-only. The card header stays normal, so the TX button and SPLIT badge on the transmit panel remain full-colour and clearly active.
 
 On **dual-receiver radios** (FTdx101MP / FTdx101D) neither panel is greyed at any time — both VFOs are real physical receiver chains and are always independently usable.
 
@@ -372,7 +372,7 @@ On **dual-receiver radios** (FTdx101MP / FTdx101D) there are **two** S-meter gau
 
 **Antenna selector visibility:** the per-VFO antenna dropdown is hidden on radios with a single antenna jack (**FTdx10, FT-991A**) since there is nothing to select between. Radios with multiple antenna jacks (FTdx101MP, FTdx101D, FT-710, FTDX3000) keep the selector.
 
-Both panels have identical controls — changing a control on the white panel writes to the radio immediately; changing a control on the grey panel does nothing (apart from the TX frequency in split, as noted).
+Both panels have identical controls — changing a control on the active (fully usable) panel writes to the radio immediately; changing a control on the inactive panel's greyed body does nothing (apart from the TX frequency in split, as noted).
 
 **VFO-B toggle** — the **VFO-B** button in the toolbar shows or hides the VFO B panel. The last state is remembered across sessions.
 

--- a/wwwroot/js/ui/site.js
+++ b/wwwroot/js/ui/site.js
@@ -53,11 +53,19 @@ function showServerStoppedOverlay() {
     try { window.sMeterHistoryB?.stop?.();   } catch { /* ignore */ }
 }
 
+function isTypingIntoEditable() {
+    const active = document.activeElement;
+    return !!(active && (
+        active.tagName === 'INPUT' ||
+        active.tagName === 'TEXTAREA' ||
+        active.isContentEditable
+    ));
+}
+
 // --- Fullscreen Toggle: 'f' or 'F' to enter, 'Esc' to exit ---
 document.addEventListener('keydown', function (e) {
     // Ignore if typing in an input, textarea, or contenteditable
-    const active = document.activeElement;
-    if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)) return;
+    if (isTypingIntoEditable()) return;
     if ((e.key === 'f' || e.key === 'F') && !e.ctrlKey && !e.metaKey && !e.altKey) {
         // Bare F only — guarding against modifiers stops YWC from stealing
         // Ctrl+F (browser find-in-page) and Cmd+F on Mac.
@@ -73,6 +81,23 @@ document.addEventListener('keydown', function (e) {
             e.preventDefault();
         }
     }
+});
+
+// Optional browser TX shortcut. Disabled by default; when configured, it
+// toggles transmit using the same /api/cat/tx flow as the on-screen button.
+document.addEventListener('keydown', function (e) {
+    const configuredKey = window.ywcTxToggleKey;
+    if (!configuredKey || isTypingIntoEditable()) return;
+    if (e.ctrlKey || e.metaKey || e.altKey || e.repeat) return;
+
+    const isSingleChar = configuredKey.length === 1 && e.key.length === 1;
+    const keyMatches = isSingleChar
+        ? e.key.toLowerCase() === configuredKey.toLowerCase()
+        : e.key === configuredKey;
+    if (!keyMatches) return;
+
+    e.preventDefault();
+    toggleTx();
 });
 
 // Add/remove fullscreen-mode class on body when entering/exiting fullscreen

--- a/wwwroot/js/ui/site.js
+++ b/wwwroot/js/ui/site.js
@@ -87,13 +87,18 @@ document.addEventListener('keydown', function (e) {
 // toggles transmit using the same /api/cat/tx flow as the on-screen button.
 document.addEventListener('keydown', function (e) {
     const configuredKey = window.ywcTxToggleKey;
-    if (!configuredKey || isTypingIntoEditable()) return;
+    // Empty string only — do not use falsy check; a legacy " " must still match.
+    if (configuredKey == null || configuredKey === '' || isTypingIntoEditable()) return;
     if (e.ctrlKey || e.metaKey || e.altKey || e.repeat) return;
 
-    const isSingleChar = configuredKey.length === 1 && e.key.length === 1;
-    const keyMatches = isSingleChar
-        ? e.key.toLowerCase() === configuredKey.toLowerCase()
-        : e.key === configuredKey;
+    // Settings stores Space as the token "Space" (HTML cannot round-trip " ").
+    // Accept both the token and a legacy lone-space value.
+    const isSpaceShortcut = configuredKey === 'Space' || configuredKey === ' ';
+    const keyMatches = isSpaceShortcut
+        ? (e.key === ' ')
+        : (configuredKey.length === 1 && e.key.length === 1
+            ? e.key.toLowerCase() === configuredKey.toLowerCase()
+            : e.key === configuredKey);
     if (!keyMatches) return;
 
     e.preventDefault();
@@ -614,8 +619,9 @@ let txVfo = 0; // 0 = VFO A, 1 = VFO B (the TX VFO — only flips with split)
 let activeVfo = 0;
 
 // Apply the .vfo-inactive class to whichever VFO panel is NOT the active
-// (TX) one — but only on single-receiver radios (FTdx10, FT-710, FTDX3000).
-// Dual-receiver radios (FTdx101MP/D) leave both panels active because each
+// (RX) one — but only on single-receiver radios (FTdx10, FT-710, FTDX3000).
+// CSS greys only that panel's .card-body (header stays normal so TX looks
+// enabled). Dual-receiver radios leave both panels active because each
 // VFO is its own physical receiver chain. The data-single-receiver
 // attribute on #vfoRow is rendered server-side from RadioCapabilities.cs.
 // See docs/decisions/0003-single-vs-dual-receiver-ui.md.
@@ -661,9 +667,10 @@ function applyVfoActiveStyling() {
     // (VS command) for both cases is deterministic and matches what the
     // radio is actually doing.
     //
-    // The TX button and SPLIT badge land on the grey panel in split mode
-    // (R8) automatically because updateTxButton / updateSplitButton derive
-    // the TX position as "opposite of active" on single-receiver radios.
+    // The TX button and SPLIT badge land on the inactive panel in split
+    // mode (R8) because updateTxButton / updateSplitButton derive the TX
+    // position as "opposite of active" on single-receiver radios. The
+    // card header is not greyed, so TX stays full-colour and clickable.
     //
     // The spectrum panel is NOT greyed — on single-receiver radios the
     // single spectrum always shows the live receive signal. The second
@@ -674,10 +681,10 @@ function applyVfoActiveStyling() {
 
     activeCol.classList.remove('vfo-inactive', 'vfo-tx-editable');
     inactiveCol.classList.add('vfo-inactive');
-    // R10/R11: in split mode the grey panel IS the TX VFO — operators must
-    // still be able to set the TX frequency from YWC without un-splitting.
-    // The .vfo-tx-editable class re-enables pointer-events on the frequency
-    // display while leaving every other control on the grey panel read-only.
+    // R10/R11: in split mode the inactive panel IS the TX VFO — operators
+    // must still be able to set the TX frequency from YWC without
+    // un-splitting. .vfo-tx-editable re-enables the frequency field while
+    // leaving every other card-body control read-only.
     inactiveCol.classList.toggle('vfo-tx-editable', splitOn);
 
     // Make sure neither spectrum carries a stale inactive class from a
@@ -723,7 +730,7 @@ async function toggleTx() {
             const data = await response.json();
             isTransmitting = data.transmitting;
             updateTxButton();
-
+            updateTxIndicators(isTransmitting);
         } else {
 
         }
@@ -797,10 +804,10 @@ function updateSplitButton() {
         btn.textContent = active ? 'Split ON' : 'Split';
     }
 
-    // R8: the SPLIT TX badge belongs on the TX VFO's header — the grey
-    // panel. On single-receiver radios the TX VFO is the OPPOSITE of the
-    // active VFO; on dual-receiver radios it's whichever VFO the FT
-    // command points to. Show one badge, hide the other.
+    // R8: the SPLIT TX badge belongs on the TX VFO's header. On
+    // single-receiver radios the TX VFO is the OPPOSITE of the active VFO;
+    // on dual-receiver radios it's whichever VFO the FT command points to.
+    // Show one badge, hide the other.
     let txVfoIdx;
     if (isSingleReceiver) {
         txVfoIdx = (activeVfo === 0) ? 1 : 0;   // opposite of RX


### PR DESCRIPTION

# Enable TX on dual VFO + browser TX toggle shortcut

## Summary

This branch adds

* an optional **browser keyboard shortcut for toggling transmit**, 
* fixes several **TX state / split-mode UI issues**
* hardens the **TX-off debounce** in the meter poller.


Context: During this morning while testing my fully remote setup game across a odd behaviour where triggering TX wasn't possible when using split (RX on VFO A and TX on VFO B), did a few small fixes 

Notes: 
* **This was only tested on the FT-DX-10** and am not sure what's the behaviour on dual receiver units
* MR opened against main as this is where I've branched from, please provide guidance if you'd like it against develop instead


## Changes

### New: configurable TX toggle key (accessibility)
- Added `ApplicationSettings.TxToggleKey` — an optional browser key that toggles transmit. Empty = disabled.
- New Settings UI (`Pages/Settings.cshtml`) with a "Set key" capture flow, a "Clear" button, live capture badge, and a friendly current-shortcut display. Includes a warning that the shortcut directly keys the transmitter.
- Frontend handler in `wwwroot/js/ui/site.js` wires the configured key to the existing `toggleTx()` / `/api/cat/tx` flow. Ignored while typing in an input, textarea, or contenteditable to avoid accidental keying.
- Space handling: a lone `" "` cannot round-trip through an HTML form/input value, so it is persisted as the token `"Space"`. `Settings.cshtml.cs` adds `NormalizeTxToggleKey()` and the required `ModelState.Remove("Settings.TxToggleKey")` (empty is a valid value under `<Nullable>enable</Nullable>`). `Index.cshtml.cs` maps `" "` → `"Space"` and exposes the value via `window.ywcTxToggleKey`.

### Split-mode / inactive-VFO UI fix
- On single-receiver radios, only the **card body** of the inactive VFO is now greyed; the **card header stays full-colour** so the TX button, ZIN, and badges remain clearly active and clickable in split mode (a parent's `opacity`/`filter` could not be undone on nested children before).
- Reworked `.vfo-inactive` CSS to target `.card-body`, with a `.vfo-freq-row` carve-out so the TX VFO's frequency field stays editable in split while other body controls stay read-only.
- `applyVfoActiveStyling()` comments/logic updated accordingly; `toggleTx()` now also calls `updateTxIndicators()`.
- `USER_MANUAL.md` greying-behaviour section updated to match.

### TX-off debounce hardening (`MeterPollingService`)
- Treat both `TX1` and `TX2` as transmitting (mic-keyed on some Yaesu models).
- Accept an authoritative TX-off (web button / voice already cleared `IsTransmitting`) on the first confirming `TX0`, instead of overwriting it back to true for several poll cycles.
- A null poll (radio busy) no longer resurrects a TX state that was already turned off. Debounce threshold factored into `TxOffDebounceCount`.

### CI
- `release.yml` now uploads `Yaesu_Web_Control_Setup.exe` as a workflow artifact on `workflow_dispatch`, and only uploads to a GitHub Release on `release` / tagged dispatch.


## Test plan
- [ ] Set a TX toggle key in Settings (letter, F-key, and Space); confirm it persists across reload and shows the correct current shortcut.
- [ ] Confirm the shortcut toggles TX and is ignored while typing in inputs/text boxes.
- [ ] On a single-receiver radio, verify the inactive VFO body is greyed but the header/TX button stays full-colour and clickable in both normal and split mode.
- [ ] In split mode, confirm the TX VFO frequency field remains editable while other body controls stay read-only.
- [ ] Verify TX-off from the web button clears immediately and is not resurrected by the meter poller.
- [ ] Trigger a manual `workflow_dispatch` and confirm the installer uploads as a workflow artifact.


## Ui Changes
### home
<img width="1627" height="759" alt="image" src="https://github.com/user-attachments/assets/dd807e8c-6179-4b85-bb85-1d4d2e9a077d" />

### Settings
<img width="1621" height="419" alt="image" src="https://github.com/user-attachments/assets/458ba429-bb42-4b8d-ab56-3d5b292748d7" />
