### PR TITLE
FTdx10 roofing filter support

### DIFF
--- a/Controllers/CatController.cs
+++ b/Controllers/CatController.cs
@@ -717,19 +717,22 @@ namespace Yaesu_Web_Control.Controllers
             { "A", "5" }   // 300 Hz (option)
         };
 
-        // FTdx10 roofing filter display names (RU command code -> display name)
+        // FTdx10 roofing filter display names (RF read code P3 -> display name)
         private static readonly Dictionary<string, string> FtdxTenRoofingFilterNames = new()
         {
-            { "1", "15 kHz" },
-            { "2", "6 kHz" },
-            { "3", "3 kHz" }
+            { "6", "12 kHz" },
+            { "7", "3 kHz" },
+            { "9", "500 Hz" },
+            { "A", "300 Hz" }
         };
 
-        // FTDX3000 roofing filter display names (RF0x code -> display name)
-        private static readonly Dictionary<string, string> Ftdx3000RoofingFilterNames = new()
+        // FTdx10 roofing filter set codes (read code P3 -> set code P2 used in RF command)
+        private static readonly Dictionary<string, string> FtdxTenRoofingFilterSetCodes = new()
         {
-            { "0", "Auto" }, { "1", "15 kHz" }, { "2", "6 kHz" },
-            { "3", "3 kHz" }, { "4", "600 Hz" }, { "5", "300 Hz" }
+            { "6", "1" },  // 12 kHz
+            { "7", "2" },  // 3 kHz
+            { "9", "4" },  // 500 Hz
+            { "A", "5" }   // 300 Hz (optional)
         };
 
         [HttpPost("roofingfilter/a")]
@@ -747,21 +750,14 @@ namespace Yaesu_Web_Control.Controllers
                 bool isFt710   = settings.RadioModel == "FT-710";
                 bool isFtdx3000 = settings.RadioModel == "FTDX3000";
 
-                if (isFtdx10 || isFt710)
+                if (isFt710)
                     return Ok(new { message = "Roofing filter is selected automatically by the radio" });
 
+                if (isFtdx10)
+                    return await SetFtdx10RoofingFilterAsync(request);
+
                 if (isFtdx3000)
-                {
-                    // FTDX3000: P1 is always 0 (single receiver); code is the filter number directly
-                    await _catClient.SendCommandAsync($"RF0{request.Filter};", "WebUI", CancellationToken.None);
-                    await Task.Delay(100);
-                    var readback = await _catClient.SendCommandAsync("RF0;", "WebUI", CancellationToken.None);
-                    var actualCode = readback?.Length >= 4 ? readback[3].ToString() : request.Filter;
-                    var displayName = Ftdx3000RoofingFilterNames.GetValueOrDefault(actualCode, actualCode);
-                    _radioStateService.RoofingFilterA = actualCode;
-                    _logger.LogInformation("Set Main roofing filter (FTDX3000) to {Filter}", displayName);
-                    return Ok(new { message = $"Roofing filter set to {displayName}", filter = actualCode, filterName = displayName });
-                }
+                    return await SetFtdx3000RoofingFilterAsync(request);
 
                 // FTdx101MP/D: RF command with set code conversion
                 if (!RoofingFilterSetCodes.TryGetValue(request.Filter, out var setCode))
@@ -823,21 +819,14 @@ namespace Yaesu_Web_Control.Controllers
                 bool isFt710   = settings.RadioModel == "FT-710";
                 bool isFtdx3000 = settings.RadioModel == "FTDX3000";
 
-                if (isFtdx10 || isFt710)
+                if (isFt710)
                     return Ok(new { message = "Roofing filter is selected automatically by the radio" });
 
+                if (isFtdx10)
+                    return await SetFtdx10RoofingFilterAsync(request);
+
                 if (isFtdx3000)
-                {
-                    // FTDX3000 has a single receiver — P1 is always 0; VFO B shares the same filter
-                    await _catClient.SendCommandAsync($"RF0{request.Filter};", "WebUI", CancellationToken.None);
-                    await Task.Delay(100);
-                    var readback = await _catClient.SendCommandAsync("RF0;", "WebUI", CancellationToken.None);
-                    var actualCode = readback?.Length >= 4 ? readback[3].ToString() : request.Filter;
-                    var displayName = Ftdx3000RoofingFilterNames.GetValueOrDefault(actualCode, actualCode);
-                    _radioStateService.RoofingFilterB = actualCode;
-                    _logger.LogInformation("Set Sub roofing filter (FTDX3000) to {Filter}", displayName);
-                    return Ok(new { message = $"Roofing filter set to {displayName}", filter = actualCode, filterName = displayName });
-                }
+                    return await SetFtdx3000RoofingFilterAsync(request);
 
                 // FTdx101MP/D: RF command with set code conversion
                 if (!RoofingFilterSetCodes.TryGetValue(request.Filter, out var setCode))
@@ -882,6 +871,74 @@ namespace Yaesu_Web_Control.Controllers
             {
                 _requestSemaphore.Release();
             }
+        }
+
+        /// <summary>
+        /// FTdx10 single-receiver roofing filter: RF0 P2 set / RF0 P3 read.
+        /// Mirrors the result to both VFO slots so both panels stay in sync.
+        /// </summary>
+        private async Task<IActionResult> SetFtdx10RoofingFilterAsync(RoofingFilterRequest request)
+        {
+            if (!FtdxTenRoofingFilterSetCodes.TryGetValue(request.Filter, out var setCode))
+                return BadRequest(new { error = $"Invalid filter code: {request.Filter}" });
+
+            var rfCommand = $"RF0{setCode};";
+            _logger.LogInformation("Sending roofing filter command (FTdx10): {Command}", rfCommand);
+            await _catClient.SendCommandAsync(rfCommand, "WebUI", CancellationToken.None);
+
+            await Task.Delay(100);
+            var rfReadResponse = await _catClient.SendCommandAsync("RF0;", "WebUI", CancellationToken.None);
+            _logger.LogInformation("Read back roofing filter response (FTdx10): {Response}", rfReadResponse);
+
+            if (!string.IsNullOrEmpty(rfReadResponse) && rfReadResponse.Length >= 4)
+            {
+                var actualFilter = rfReadResponse[3].ToString();
+                _radioStateService.RoofingFilterA = actualFilter;
+                _radioStateService.RoofingFilterB = actualFilter;
+
+                if (actualFilter != request.Filter)
+                {
+                    var requestedName = FtdxTenRoofingFilterNames.GetValueOrDefault(request.Filter, request.Filter);
+                    var actualName = FtdxTenRoofingFilterNames.GetValueOrDefault(actualFilter, actualFilter);
+                    _logger.LogWarning("Roofing filter {Requested} not available, radio returned {Actual}", requestedName, actualName);
+                    return Ok(new { message = $"Filter {requestedName} not installed. Using {actualName}.", warning = true, filter = actualFilter, filterName = actualName });
+                }
+
+                var filterName = FtdxTenRoofingFilterNames.GetValueOrDefault(actualFilter, actualFilter);
+                _logger.LogInformation("Set roofing filter (FTdx10) to {Filter}", filterName);
+                return Ok(new { message = $"Roofing filter {filterName} selected", filter = actualFilter, filterName });
+            }
+
+            _radioStateService.RoofingFilterA = request.Filter;
+            _radioStateService.RoofingFilterB = request.Filter;
+            var fallbackName = FtdxTenRoofingFilterNames.GetValueOrDefault(request.Filter, request.Filter);
+            return Ok(new { message = $"Roofing filter {fallbackName} selected", filter = request.Filter, filterName = fallbackName });
+        }
+
+        /// <summary>
+        /// FTDX3000 single-receiver roofing filter: RF0 P2 set / RF0 P3 read.
+        /// The read-back code (P3) uses a different value space than the set code
+        /// (P2) — 600 Hz reads back as 7, 300 Hz as 8, and AUTO reports the
+        /// filter in circuit (4/5/6/9/A) — so the read code is normalised back
+        /// to the dropdown's set-code space and mirrored to both VFO slots
+        /// (single receiver). See <see cref="Ftdx3000Roofing"/>.
+        /// </summary>
+        private async Task<IActionResult> SetFtdx3000RoofingFilterAsync(RoofingFilterRequest request)
+        {
+            // P1 is always 0 (single receiver); the set code is the filter number directly.
+            await _catClient.SendCommandAsync($"RF0{request.Filter};", "WebUI", CancellationToken.None);
+            await Task.Delay(100);
+            var readback = await _catClient.SendCommandAsync("RF0;", "WebUI", CancellationToken.None);
+
+            var readCode = readback?.Length >= 4 ? readback[3].ToString() : request.Filter;
+            var stateCode = Ftdx3000Roofing.NormalizeReadCode(readCode);
+            var displayName = Ftdx3000Roofing.ReadCodeNames.GetValueOrDefault(readCode,
+                              Ftdx3000Roofing.SetCodeNames.GetValueOrDefault(stateCode, stateCode));
+
+            _radioStateService.RoofingFilterA = stateCode;
+            _radioStateService.RoofingFilterB = stateCode;
+            _logger.LogInformation("Set roofing filter (FTDX3000) to {Filter} (read code {ReadCode})", displayName, readCode);
+            return Ok(new { message = $"Roofing filter set to {displayName}", filter = stateCode, filterName = displayName });
         }
 
         [HttpPost("mode/{receiver}")]

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -90,11 +90,18 @@
     string ifWidthDefaultA = isFtdx10 ? "0" : isFt710 ? "12" : isFtdx3000 ? "14" : "0";
     string ifWidthDefaultB = isFtdx10 ? "0" : isFt710 ? "12" : isFtdx3000 ? "14" : "0";
 
-    // Roofing filter options: FTdx101MP/D only (FTdx10 and FT-710 have no CAT roofing filter control).
+    // Roofing filter options: FTdx101MP/D only (FT-710 has no CAT roofing filter control).
     // RF command codes 6-A, filtered to only fitted filters per Settings.
     var roofingOptions = new (string Value, string Label)[]
             { ("A","300 Hz"), ("9","600 Hz"), ("8","1.2 kHz"), ("7","3 kHz"), ("6","12 kHz") }
             .Where(o => Model.InstalledRoofingFilters.Contains(o.Value))
+            .ToArray();
+
+    // FTdx10 roofing filter options (RF read codes 6/7/9 standard, A optional).
+    var roofingOptionsFtdx10 = new (string Value, string Label)[]
+            { ("6","12 kHz"), ("7","3 kHz"), ("9","500 Hz"), ("A","300 Hz") }
+            .Where(o => o.Value == "6" || o.Value == "7" || o.Value == "9"
+                     || Model.InstalledRoofingFilters.Contains(o.Value))
             .ToArray();
 
     // FTDX3000 roofing filter options (codes 0-5; always show standard 0-3, optional 4-5 if fitted).
@@ -966,7 +973,7 @@
                                 title="Keyboard — enter VFO A frequency">
                             <strong>123</strong>
                         </button>
-                        @if (!isFtdx10 && !isFt710)
+                        @if (!isFt710)
                         {
                         <label class="mb-0 text-nowrap ms-1 fw-bold">Roofing:</label>
                         <select class="form-select form-select-sm fw-bold flex-shrink-0" id="roofingFilterSelectA"
@@ -974,7 +981,14 @@
                                 title="VFO A roofing filter"
                                 style="width: auto;"
                                 onchange="window.radioControl.setRoofingFilter('A', this.value)">
-                            @if (isFtdx3000)
+                            @if (isFtdx10)
+                            {
+                                @foreach (var opt in roofingOptionsFtdx10)
+                                {
+                                    <option value="@opt.Value" selected="@(Model.RadioState.RoofingFilterA==opt.Value ? "selected" : null)">@opt.Label</option>
+                                }
+                            }
+                            else if (isFtdx3000)
                             {
                                 @foreach (var opt in roofingOptions3000)
                                 {
@@ -1370,7 +1384,7 @@
                                 title="Keyboard — enter VFO B frequency">
                             <strong>123</strong>
                         </button>
-                        @if (!isFtdx10 && !isFt710)
+                        @if (!isFt710)
                         {
                         <label class="mb-0 text-nowrap ms-1 fw-bold">Roofing:</label>
                         <select class="form-select form-select-sm fw-bold flex-shrink-0" id="roofingFilterSelectB"
@@ -1378,7 +1392,14 @@
                                 title="VFO B roofing filter"
                                 style="width: auto;"
                                 onchange="window.radioControl.setRoofingFilter('B', this.value)">
-                            @if (isFtdx3000)
+                            @if (isFtdx10)
+                            {
+                                @foreach (var opt in roofingOptionsFtdx10)
+                                {
+                                    <option value="@opt.Value" selected="@(Model.RadioState.RoofingFilterB==opt.Value ? "selected" : null)">@opt.Label</option>
+                                }
+                            }
+                            else if (isFtdx3000)
                             {
                                 @foreach (var opt in roofingOptions3000)
                                 {

--- a/Pages/Settings.cshtml
+++ b/Pages/Settings.cshtml
@@ -1589,21 +1589,16 @@
                                 </div>
                             </div>
                             <div id="filtersFtdx10Section" style="display:@(Model.Settings.RadioModel == "FTdx10" ? "block" : "none")">
-                                <div class="alert alert-info py-2 mb-2">
-                                    The FTdx10 selects its roofing filter automatically — there is no CAT command to control it.
-                                    The radio switches to the appropriate filter based on DSP bandwidth and mode.
-                                    Tick any optional filters you have installed for your own reference.
+                                <div class="form-text mb-2">
+                                    The FTdx10 roofing filter is selectable via CAT. 12 kHz, 3 kHz, and 500 Hz
+                                    are fitted as standard. Tick the optional filter if you have it installed.
                                 </div>
                                 <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="filter4" name="Settings.InstalledRoofingFilters" value="4"
-                                           @(Model.Settings.InstalledRoofingFilters.Contains("4") ? "checked" : "") />
-                                    <label class="form-check-label" for="filter4">1.2 kHz installed (optional — YF-130CN)</label>
+                                    <input class="form-check-input" type="checkbox" id="filterFtdx10A" name="Settings.InstalledRoofingFilters" value="A"
+                                           @(Model.Settings.InstalledRoofingFilters.Contains("A") ? "checked" : "") />
+                                    <label class="form-check-label" for="filterFtdx10A">300 Hz (optional — YF-130CW)</label>
                                 </div>
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="filter5" name="Settings.InstalledRoofingFilters" value="5"
-                                           @(Model.Settings.InstalledRoofingFilters.Contains("5") ? "checked" : "") />
-                                    <label class="form-check-label" for="filter5">300 Hz installed (optional — YF-130CW)</label>
-                                </div>
+                                <div class="form-text text-muted mt-1">12 kHz, 3 kHz, and 500 Hz are always shown.</div>
                             </div>
                             <div id="filtersFt710Section" style="display:@(Model.Settings.RadioModel == "FT-710" ? "block" : "none")">
                                 <div class="alert alert-info py-2 mb-0">

--- a/Services/CatMessageDispatcher.cs
+++ b/Services/CatMessageDispatcher.cs
@@ -174,24 +174,27 @@
                     case "RF":
                         // Example: RF06; (VFO A, 12kHz filter), RF19; (VFO B, 600Hz filter)
                         // Response format: RF + P1 (0=Main/A, 1=Sub/B) + P3 (filter code 6-A)
+                        // Single-receiver radios (FTdx10 etc.): P1 is always 0 — mirror to both VFOs.
                         if (message.Length >= 4)
                         {
                             var vfo = message[2]; // '0' for A, '1' for B
                             var filterCode = message[3].ToString();
-                            if (vfo == '0')
+                            if (_stateService.IsSingleReceiver)
+                            {
+                                // FTDX3000 answers RF in a read-code space (P3) that
+                                // differs from its dropdown set codes (P2); normalise
+                                // so the UI stays in sync. Other single-receiver
+                                // radios (FTdx10) already report in dropdown codes.
+                                var code = _stateService.RadioModel == "FTDX3000"
+                                    ? Ftdx3000Roofing.NormalizeReadCode(filterCode)
+                                    : filterCode;
+                                _stateService.RoofingFilterA = code;
+                                _stateService.RoofingFilterB = code;
+                            }
+                            else if (vfo == '0')
                                 _stateService.RoofingFilterA = filterCode;
                             else if (vfo == '1')
                                 _stateService.RoofingFilterB = filterCode;
-                        }
-                        break;
-                    case "RU":
-                        // FTdx10 roofing filter. Response: RU{n}; n=0(Auto),1(15kHz),2(6kHz),3(3kHz)
-                        // Single shared filter — store in both A and B so both dropdowns stay in sync.
-                        if (message.Length >= 3)
-                        {
-                            var ruCode = message[2].ToString();
-                            _stateService.RoofingFilterA = ruCode;
-                            _stateService.RoofingFilterB = ruCode;
                         }
                         break;
                     case "GT":

--- a/Services/CatMultiplexerService.cs
+++ b/Services/CatMultiplexerService.cs
@@ -512,7 +512,9 @@ namespace Yaesu_Web_Control.Services
             await SendCommand("PA0;", true);
             await SendCommand("PA1;", true);
             await SendCommand("RF0;", true);
-            await SendCommand("RF1;", true);
+            var initSettings = await _settingsService.GetSettingsAsync();
+            if (RadioCapabilities.IsDualReceiver(initSettings.RadioModel))
+                await SendCommand("RF1;", true);
             await SendCommand("ID;", true);
             await SendCommand("CS;", true);
             await SendCommand("ML0;", true);

--- a/Services/Ftdx3000Roofing.cs
+++ b/Services/Ftdx3000Roofing.cs
@@ -1,0 +1,55 @@
+namespace Yaesu_Web_Control.Services;
+
+/// <summary>
+/// FTDX3000 roofing-filter CAT code tables.
+///
+/// The FTDX3000 uses a different value space for the RF <b>set</b> parameter
+/// (P2) than for the RF <b>read</b> answer (P3). Notably 600 Hz is set with 4
+/// but reads back as 7, 300 Hz is set with 5 but reads back as 8, and while in
+/// AUTO the radio reports the filter actually in circuit via codes 4/5/6/9/A.
+/// Treating the read answer as if it were a set code (as the earlier inline
+/// implementation did) mislabels 600 Hz / 300 Hz and desyncs the dropdown in
+/// AUTO. Verified against the FTDX3000 CAT Operation Reference Book and
+/// Hamlib's rigs/yaesu/ft3000.c roofing_filters table.
+/// </summary>
+public static class Ftdx3000Roofing
+{
+    /// <summary>Dropdown / RF set code (P2) -> display name.</summary>
+    public static readonly IReadOnlyDictionary<string, string> SetCodeNames =
+        new Dictionary<string, string>
+        {
+            ["0"] = "Auto", ["1"] = "15 kHz", ["2"] = "6 kHz",
+            ["3"] = "3 kHz", ["4"] = "600 Hz", ["5"] = "300 Hz",
+        };
+
+    /// <summary>
+    /// RF read answer (P3) -> display name. AUTO variants report the filter
+    /// currently in circuit while the radio is in AUTO mode.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, string> ReadCodeNames =
+        new Dictionary<string, string>
+        {
+            ["1"] = "15 kHz", ["2"] = "6 kHz", ["3"] = "3 kHz",
+            ["4"] = "Auto (15 kHz)", ["5"] = "Auto (6 kHz)", ["6"] = "Auto (3 kHz)",
+            ["7"] = "600 Hz", ["8"] = "300 Hz",
+            ["9"] = "Auto (600 Hz)", ["A"] = "Auto (300 Hz)",
+        };
+
+    // RF read answer (P3) -> dropdown set code (P2) so the UI stays in sync.
+    // All AUTO variants collapse to the AUTO set code (0); the dropdown only
+    // offers the six set codes.
+    private static readonly IReadOnlyDictionary<string, string> ReadToSetCode =
+        new Dictionary<string, string>
+        {
+            ["1"] = "1", ["2"] = "2", ["3"] = "3",
+            ["7"] = "4", ["8"] = "5",
+            ["4"] = "0", ["5"] = "0", ["6"] = "0", ["9"] = "0", ["A"] = "0",
+        };
+
+    /// <summary>
+    /// Normalise an RF read-back code (P3) to the dropdown set code (P2).
+    /// Unknown codes pass through unchanged so nothing is silently dropped.
+    /// </summary>
+    public static string NormalizeReadCode(string readCode) =>
+        ReadToSetCode.GetValueOrDefault(readCode, readCode);
+}

--- a/Services/RadioInitializationService.cs
+++ b/Services/RadioInitializationService.cs
@@ -130,6 +130,7 @@ namespace Yaesu_Web_Control.Services
                 // currently active per VS, instead of always writing to *A
                 // state. See #34 R2 controls-bleed fix.
                 radioStateService.IsSingleReceiver = RadioCapabilities.IsSingleReceiver(settings.RadioModel);
+                radioStateService.RadioModel = settings.RadioModel;
                 logger.LogInformation("[RadioInitializationService] Radio responded to FA;: {Response}", faResponse);
 
                 // Safety: force the radio into RX before doing anything else.

--- a/Services/RadioStateService.cs
+++ b/Services/RadioStateService.cs
@@ -22,6 +22,12 @@ namespace Yaesu_Web_Control.Services
         // writing to *A state — see #34 R2 controls-bleed-across-panels fix.
         public bool IsSingleReceiver { get; set; } = false;
 
+        // Configured radio model (e.g. "FTDX3000"). Set by RadioInitialization-
+        // Service at startup. The dispatcher uses this to normalise model-
+        // specific CAT read codes — notably the FTDX3000 roofing-filter answer,
+        // whose read code space differs from its set code space.
+        public string RadioModel { get; set; } = "";
+
         private RadioState _initialState;
 
         public RadioStateService(

--- a/wwwroot/js/ui/filter-scope-panel.js
+++ b/wwwroot/js/ui/filter-scope-panel.js
@@ -25,8 +25,14 @@ const IF_WIDTH_TABLES = {
 // Roofing filter code → Hz (FTdx101MP/D)
 const ROOFING_HZ = { '6':12000,'7':3000,'8':1200,'9':600,'A':300,'a':300 };
 
-// FTDX3000 roofing filter codes 0-5
-const ROOFING_HZ_3000 = { '0':15000,'1':6000,'2':3000,'3':600,'4':300,'5':150 };
+// FTdx10 roofing filter read codes 6/7/9/A (500 Hz standard, not 600 Hz)
+const ROOFING_HZ_FTDX10 = { '6':12000,'7':3000,'9':500,'A':300,'a':300 };
+
+// FTDX3000 roofing filter set codes (P2): 0=Auto (no fixed width), 1=15k,
+// 2=6k, 3=3k, 4=600, 5=300. Keyed to match the dropdown values in Index.cshtml
+// and the normalised state code from the backend. Auto (0) has no single width
+// so it falls through to null and no roofing outline is drawn.
+const ROOFING_HZ_3000 = { '1':15000,'2':6000,'3':3000,'4':600,'5':300 };
 
 export class FilterScopePanel {
     constructor(canvasId, radioModel, initialState = {}) {
@@ -154,6 +160,9 @@ export class FilterScopePanel {
     _roofingHz() {
         if (this._model === 'FTDX3000') {
             return ROOFING_HZ_3000[String(this._state.roofingCode)] || null;
+        }
+        if (this._model === 'FTdx10') {
+            return ROOFING_HZ_FTDX10[String(this._state.roofingCode)] || null;
         }
         return ROOFING_HZ[String(this._state.roofingCode)] || null;
     }


### PR DESCRIPTION
# Roofing filter CAT control: FTdx10 support + FTDX3000 read-code fix

## Summary

This branch adds working CAT control of the roofing filter on the **FTdx10**,
and corrects the roofing-filter read-back handling on the **FTDX3000**. Both
radios use the same `RF` CAT command as the FTdx101 family, but each has a
model-specific quirk that the previous code got wrong.

- **FTdx10:** roofing filter is now selectable from the VFO panels (it was
  previously assumed to be automatic / uncontrollable). A dead, incorrect `RU`
  handler was removed.
- **FTDX3000:** roofing control already existed but mislabelled 600 Hz / 300 Hz
  and desynced the dropdown in AUTO, because the RF *read* code space differs
  from the RF *set* code space. Read-backs are now normalised.

Verified against the FTdx10 and FTDX3000 CAT Operating Manuals and Hamlib's
`rigs/yaesu/ft3000.c` roofing-filter table.


<img width="1728" height="389" alt="Screenshot 2026-07-17 at 09 15 25" src="https://github.com/user-attachments/assets/95947938-72df-483e-aedc-0ca4ccda3cdc" />


---

## FTdx10

### The bug
The code assumed the FtdX10 selects its roofing filter automatically and offered
no control. It also carried a `case "RU"` handler in `CatMessageDispatcher` that
claimed `RU` was the FtdX10 roofing filter (Auto/15k/6k/3k). Per the manual, `RU`
on the FtdX10 is actually **RX Clarifier Plus Offset** — nothing to do with
roofing — so that handler was dead and wrong.

### The truth (from the manual)
The FtdX10 controls its roofing filter with the `RF` command, single-receiver
style (P1 always `0`):

- Set: `RF0 P2;` — P2 set codes `1`=12 kHz, `2`=3 kHz, `4`=500 Hz, `5`=300 Hz (optional)
- Read: `RF0;` -> `RF0 P3;` — P3 read codes `6`=12 kHz, `7`=3 kHz, `9`=500 Hz, `A`=300 Hz

Note the FtdX10 has **no 1.2 kHz** filter, and its narrow standard filter is
**500 Hz**, not 600 Hz like the FTdx101.

### The fix
- `CatController`: removed FtdX10 from the "selected automatically" early-return
  (FT-710 stays there — it genuinely has no roofing CAT command); added
  `SetFtdx10RoofingFilterAsync` which maps read code -> set code, sends
  `RF0{setCode};`, reads back `RF0;`, and mirrors the result to **both** VFO
  slots (single receiver).
- `CatMessageDispatcher`: deleted the bogus `RU` handler; the `RF` read-back
  path now mirrors to both VFOs on single-receiver radios.
- `Index.cshtml`: roofing dropdown now shown for the FtdX10 (12 kHz / 3 kHz /
  500 Hz standard, 300 Hz optional).
- `Settings.cshtml`: FtdX10 section rewritten — CAT-selectable, single optional
  300 Hz checkbox (value `A`), replacing the previous wrong 1.2 kHz / 300 Hz
  checkboxes.
- `filter-scope-panel.js`: added an FtdX10 roofing Hz map (500 Hz, not 600 Hz).
- `CatMultiplexerService`: init only sends `RF1;` on dual-receiver models.

---

## FTDX3000 (conservative fix)

### The bug
The FTDX3000 roofing path treated the RF *read* answer (P3) as if it were the
*set* code (P2). Those two spaces differ on the FTDX3000: 600 Hz is set with `4`
but reads back as `7`, 300 Hz is set with `5` but reads back as `8`, and while in
AUTO the radio reports the filter currently in circuit via `4/5/6/9/A`. The
result: after selecting 600 Hz / 300 Hz, or when in AUTO, the read-back code
didn't match any dropdown value, so the control mislabelled the filter and the
dropdown desynced. The filter-scope panel's `ROOFING_HZ_3000` map was also
shifted/wrong (`3=600`, plus a bogus `5=150`).

### The fix (send path deliberately unchanged)
- New shared table `Services/Ftdx3000Roofing.cs` — single source of truth for the
  set-code names (P2), read-code names (P3), and a read->set normaliser, matching
  the CAT manual and Hamlib's `ft3000.c`.
- `CatController`: both VFO handlers now call `SetFtdx3000RoofingFilterAsync`,
  which still **sends the same `RF0{code};` for codes 0-5 as before** (so 15k/6k/
  3k are byte-for-byte unchanged), then normalises the read-back to the dropdown
  set-code space and mirrors to both VFO slots.
- `CatMessageDispatcher`: single-receiver `RF` read-backs are normalised for the
  FTDX3000 (via a new `RadioModel` field on `RadioStateService`) so init/AI
  broadcasts of 600/300/AUTO no longer desync the dropdown. FtdX10 is untouched.
- `RadioStateService` / `RadioInitializationService`: added a `RadioModel` field,
  set at startup, so the dispatcher can distinguish FTDX3000 from other
  single-receiver radios.
- `filter-scope-panel.js`: `ROOFING_HZ_3000` corrected to match the dropdown set
  codes (`1=15k, 2=6k, 3=3k, 4=600, 5=300`); Auto (`0`) draws no roofing outline.

### Not changed
- The FTDX3000 send codes for `1`/`2`/`3` (and all others) are untouched, so the
  common case cannot regress.
- No FTDX3000 dropdown option changes.

---

## Files changed
- `Controllers/CatController.cs`
- `Services/CatMessageDispatcher.cs`
- `Services/RadioStateService.cs`
- `Services/RadioInitializationService.cs`
- `Services/CatMultiplexerService.cs`
- `Services/Ftdx3000Roofing.cs` (new)
- `Pages/Index.cshtml`
- `Pages/Settings.cshtml`
- `wwwroot/js/ui/filter-scope-panel.js`
