### PR TITLE
Single-receiver VFO routing fixes: memory recall, roofing filter, A/B re-query + full state replay for late-joining clients

### DIFF
--- a/Controllers/CatController.cs
+++ b/Controllers/CatController.cs
@@ -875,7 +875,8 @@ namespace Yaesu_Web_Control.Controllers
 
         /// <summary>
         /// FTdx10 single-receiver roofing filter: RF0 P2 set / RF0 P3 read.
-        /// Mirrors the result to both VFO slots so both panels stay in sync.
+        /// Per-VFO state is tracked in the active VFO slot (inactive panel is
+        /// not editable on single-receiver radios).
         /// </summary>
         private async Task<IActionResult> SetFtdx10RoofingFilterAsync(RoofingFilterRequest request)
         {
@@ -893,8 +894,8 @@ namespace Yaesu_Web_Control.Controllers
             if (!string.IsNullOrEmpty(rfReadResponse) && rfReadResponse.Length >= 4)
             {
                 var actualFilter = rfReadResponse[3].ToString();
-                _radioStateService.RoofingFilterA = actualFilter;
-                _radioStateService.RoofingFilterB = actualFilter;
+                if (_radioStateService.ActiveVfo == 1) _radioStateService.RoofingFilterB = actualFilter;
+                else                                   _radioStateService.RoofingFilterA = actualFilter;
 
                 if (actualFilter != request.Filter)
                 {
@@ -909,8 +910,8 @@ namespace Yaesu_Web_Control.Controllers
                 return Ok(new { message = $"Roofing filter {filterName} selected", filter = actualFilter, filterName });
             }
 
-            _radioStateService.RoofingFilterA = request.Filter;
-            _radioStateService.RoofingFilterB = request.Filter;
+            if (_radioStateService.ActiveVfo == 1) _radioStateService.RoofingFilterB = request.Filter;
+            else                                   _radioStateService.RoofingFilterA = request.Filter;
             var fallbackName = FtdxTenRoofingFilterNames.GetValueOrDefault(request.Filter, request.Filter);
             return Ok(new { message = $"Roofing filter {fallbackName} selected", filter = request.Filter, filterName = fallbackName });
         }
@@ -920,8 +921,8 @@ namespace Yaesu_Web_Control.Controllers
         /// The read-back code (P3) uses a different value space than the set code
         /// (P2) — 600 Hz reads back as 7, 300 Hz as 8, and AUTO reports the
         /// filter in circuit (4/5/6/9/A) — so the read code is normalised back
-        /// to the dropdown's set-code space and mirrored to both VFO slots
-        /// (single receiver). See <see cref="Ftdx3000Roofing"/>.
+        /// to the dropdown's set-code space. Per-VFO state is tracked in the
+        /// active VFO slot. See <see cref="Ftdx3000Roofing"/>.
         /// </summary>
         private async Task<IActionResult> SetFtdx3000RoofingFilterAsync(RoofingFilterRequest request)
         {
@@ -935,8 +936,8 @@ namespace Yaesu_Web_Control.Controllers
             var displayName = Ftdx3000Roofing.ReadCodeNames.GetValueOrDefault(readCode,
                               Ftdx3000Roofing.SetCodeNames.GetValueOrDefault(stateCode, stateCode));
 
-            _radioStateService.RoofingFilterA = stateCode;
-            _radioStateService.RoofingFilterB = stateCode;
+            if (_radioStateService.ActiveVfo == 1) _radioStateService.RoofingFilterB = stateCode;
+            else                                   _radioStateService.RoofingFilterA = stateCode;
             _logger.LogInformation("Set roofing filter (FTDX3000) to {Filter} (read code {ReadCode})", displayName, readCode);
             return Ok(new { message = $"Roofing filter set to {displayName}", filter = stateCode, filterName = displayName });
         }

--- a/Controllers/CatController.cs
+++ b/Controllers/CatController.cs
@@ -953,29 +953,22 @@ namespace Yaesu_Web_Control.Controllers
                 await EnsureConnectedAsync();
                 string displayMode = CatCodeToMode.TryGetValue(request.Mode, out var modeName) ? modeName : request.Mode;
 
-                bool vfoIsA = receiver.ToUpper() == "A";
-                if (vfoIsA)
-                {
-                    await _catClient.SendCommandAsync($"MD0{request.Mode};", "User");
-                    _radioStateService.ModeA = displayMode;
-                }
-                else if (receiver.ToUpper() == "B")
-                {
-                    await _catClient.SendCommandAsync($"MD1{request.Mode};", "User");
-                    _radioStateService.ModeB = displayMode;
-                }
-                else
-                {
+                var recv = receiver.ToUpperInvariant();
+                if (recv != "A" && recv != "B")
                     return BadRequest(new { error = "Invalid receiver specified" });
-                }
+
+                await _catClient.SendCommandAsync($"MD{VfoP1Outgoing(recv)}{request.Mode};", "User");
+                if (VfoIsB(recv)) _radioStateService.ModeB = displayMode;
+                else               _radioStateService.ModeA = displayMode;
 
                 // Re-apply Contour and APF state — mode changes on the FTdx101 cause the
                 // radio to restore its per-mode Contour/APF settings, overriding what we have set.
                 var modeSettings = await _settingsService.GetSettingsAsync();
                 bool isFtdx3000 = modeSettings.RadioModel == "FTDX3000";
+                bool targetB = VfoIsB(recv);
                 // P1=0 on FTDX3000 (special CO format) and on every single-receiver
                 // model (P1 Fixed=0). Dual-receiver -> P1 by VFO.
-                string p1 = isFtdx3000 ? "0" : VfoP1Outgoing(vfoIsA ? "A" : "B");
+                string p1 = isFtdx3000 ? "0" : VfoP1Outgoing(recv);
 
                 if (isFtdx3000)
                 {
@@ -1000,10 +993,10 @@ namespace Yaesu_Web_Control.Controllers
                 }
                 else
                 {
-                    bool contourOn  = vfoIsA ? _radioStateService.ContourOnA  : _radioStateService.ContourOnB;
-                    int  contourHz  = vfoIsA ? _radioStateService.ContourFreqA : _radioStateService.ContourFreqB;
-                    bool apfOn      = vfoIsA ? _radioStateService.ApfOnA       : _radioStateService.ApfOnB;
-                    int  apfHz      = vfoIsA ? _radioStateService.ApfFreqA     : _radioStateService.ApfFreqB;
+                    bool contourOn  = targetB ? _radioStateService.ContourOnB  : _radioStateService.ContourOnA;
+                    int  contourHz  = targetB ? _radioStateService.ContourFreqB : _radioStateService.ContourFreqA;
+                    bool apfOn      = targetB ? _radioStateService.ApfOnB       : _radioStateService.ApfOnA;
+                    int  apfHz      = targetB ? _radioStateService.ApfFreqB     : _radioStateService.ApfFreqA;
 
                     int  cFreq = Math.Max(100, Math.Min(3200, contourHz));
                     await _catClient.SendCommandAsync($"CO{p1}0000{(contourOn ? 1 : 0)};", "User");
@@ -1014,7 +1007,7 @@ namespace Yaesu_Web_Control.Controllers
                     await _catClient.SendCommandAsync($"CO{p1}3{aVvvv:D4};", "User");
                 }
 
-                _logger.LogInformation("Sending CAT command: MD{Vfo}{Mode}; for Receiver {Receiver}", vfoIsA ? "0" : "1", request.Mode, receiver);
+                _logger.LogInformation("Sending CAT command: MD{Vfo}{Mode}; for Receiver {Receiver}", VfoP1Outgoing(recv), request.Mode, recv);
                 return Ok(new { message = $"Mode {displayMode} selected for Receiver {receiver}" });
             }
             catch (Exception ex)

--- a/Controllers/MemoryController.cs
+++ b/Controllers/MemoryController.cs
@@ -81,7 +81,7 @@ namespace Yaesu_Web_Control.Controllers
             return Ok();
         }
 
-        // ── Recall (tune VFO A to a memory) ─────────────────────────────────
+        // ── Recall (tune the active VFO to a memory) ────────────────────────
 
         [HttpPost("{id:int}/recall")]
         public async Task<IActionResult> Recall(int id)
@@ -91,20 +91,28 @@ namespace Yaesu_Web_Control.Controllers
 
             var settings = await _settingsService.GetSettingsAsync();
             bool useCf = settings.RadioModel is "FTdx10" or "FT-710";
+            bool targetB = RadioCapabilities.VfoIsB(
+                _radioStateService.IsSingleReceiver,
+                _radioStateService.ActiveVfo,
+                "A");
 
             // Set mode before frequency so the radio applies any pitch/carrier offset
             // (e.g. CW sidetone offset) before the VFO is tuned — prevents ~700 Hz landing error.
             if (ModeToCode.TryGetValue(memory.Mode, out char modeCode))
             {
-                await _catClient.SendCommandAsync($"MD0{modeCode};", "MemRecall", CancellationToken.None);
-                _radioStateService.ModeA = memory.Mode;
+                char mdP1 = targetB ? '1' : '0';
+                await _catClient.SendCommandAsync($"MD{mdP1}{modeCode};", "MemRecall", CancellationToken.None);
+                if (targetB) _radioStateService.ModeB = memory.Mode;
+                else _radioStateService.ModeA = memory.Mode;
                 await Task.Delay(50);
             }
 
             // Set frequency
             string freqStr = memory.FrequencyHz.ToString("D9");
-            await _catClient.SendCommandAsync($"FA{freqStr};", "MemRecall", CancellationToken.None);
-            _radioStateService.FrequencyA = memory.FrequencyHz;
+            string freqCmd = targetB ? "FB" : "FA";
+            await _catClient.SendCommandAsync($"{freqCmd}{freqStr};", "MemRecall", CancellationToken.None);
+            if (targetB) _radioStateService.FrequencyB = memory.FrequencyHz;
+            else _radioStateService.FrequencyA = memory.FrequencyHz;
 
             // Set clarifier
             if (useCf)
@@ -126,7 +134,8 @@ namespace Yaesu_Web_Control.Controllers
                     await _catClient.SendCommandAsync($"RD{Math.Abs(memory.ClarifierOffsetHz):D4};", "MemRecall", CancellationToken.None);
             }
 
-            _radioStateService.ClarifierOffsetA = memory.ClarifierOffsetHz;
+            if (targetB) _radioStateService.ClarifierOffsetB = memory.ClarifierOffsetHz;
+            else _radioStateService.ClarifierOffsetA = memory.ClarifierOffsetHz;
             _radioStateService.RxClarOn = memory.RxClarOn;
             _radioStateService.TxClarOn = memory.TxClarOn;
 
@@ -135,19 +144,22 @@ namespace Yaesu_Web_Control.Controllers
             if (!string.IsNullOrEmpty(memory.Antenna))
             {
                 await _catClient.SendCommandAsync($"AN0{memory.Antenna};", "MemRecall", CancellationToken.None);
-                _radioStateService.AntennaA = memory.Antenna;
+                if (targetB) _radioStateService.AntennaB = memory.Antenna;
+                else _radioStateService.AntennaA = memory.Antenna;
             }
             if (!string.IsNullOrEmpty(memory.IfWidthCode) && int.TryParse(memory.IfWidthCode, out int ifw))
             {
                 await _catClient.SendCommandAsync($"SH00{ifw:D2};", "MemRecall", CancellationToken.None);
-                _radioStateService.IfWidthA = memory.IfWidthCode;
+                if (targetB) _radioStateService.IfWidthB = memory.IfWidthCode;
+                else _radioStateService.IfWidthA = memory.IfWidthCode;
             }
             if (memory.IfShiftHz.HasValue)
             {
                 int shift = memory.IfShiftHz.Value;
                 char sign = shift >= 0 ? '+' : '-';
                 await _catClient.SendCommandAsync($"IS00{sign}{Math.Abs(shift):D4};", "MemRecall", CancellationToken.None);
-                _radioStateService.IfShiftA = shift;
+                if (targetB) _radioStateService.IfShiftB = shift;
+                else _radioStateService.IfShiftA = shift;
             }
             if (!string.IsNullOrEmpty(memory.RoofingCode))
             {
@@ -155,29 +167,35 @@ namespace Yaesu_Web_Control.Controllers
                 if (settings.RadioModel is not ("FTdx10" or "FT-710"))
                 {
                     await _catClient.SendCommandAsync($"RF0{memory.RoofingCode};", "MemRecall", CancellationToken.None);
-                    _radioStateService.RoofingFilterA = memory.RoofingCode;
+                    if (targetB) _radioStateService.RoofingFilterB = memory.RoofingCode;
+                    else _radioStateService.RoofingFilterA = memory.RoofingCode;
                 }
             }
             if (memory.NbOn.HasValue)
             {
                 await _catClient.SendCommandAsync($"NB0{(memory.NbOn.Value ? 1 : 0)};", "MemRecall", CancellationToken.None);
-                _radioStateService.NbA = memory.NbOn.Value ? "1" : "0";
+                string nbVal = memory.NbOn.Value ? "1" : "0";
+                if (targetB) _radioStateService.NbB = nbVal;
+                else _radioStateService.NbA = nbVal;
             }
             if (memory.NbLevel.HasValue)
             {
                 int nbl = Math.Clamp(memory.NbLevel.Value, 1, 20);
                 await _catClient.SendCommandAsync($"NL0{nbl:D3};", "MemRecall", CancellationToken.None);
-                _radioStateService.NbLevelA = nbl;
+                if (targetB) _radioStateService.NbLevelB = nbl;
+                else _radioStateService.NbLevelA = nbl;
             }
             if (!string.IsNullOrEmpty(memory.NrLevel))
             {
                 await _catClient.SendCommandAsync($"NR0{memory.NrLevel};", "MemRecall", CancellationToken.None);
-                _radioStateService.NrA = memory.NrLevel;
+                if (targetB) _radioStateService.NrB = memory.NrLevel;
+                else _radioStateService.NrA = memory.NrLevel;
             }
             if (!string.IsNullOrEmpty(memory.AgcMode))
             {
                 await _catClient.SendCommandAsync($"GT0{memory.AgcMode};", "MemRecall", CancellationToken.None);
-                _radioStateService.AgcA = memory.AgcMode;
+                if (targetB) _radioStateService.AgcB = memory.AgcMode;
+                else _radioStateService.AgcA = memory.AgcMode;
             }
             if (memory.PowerWatts.HasValue)
             {

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -717,7 +717,8 @@
                         <!-- Middle: Band buttons + Mode/Antenna below + filter scope -->
                         <div class="flex-grow-1 d-flex flex-column gap-1">
                             @await Html.PartialAsync("_BandButtonsPartial", Tuple.Create("unused", "A", Model.SelectedBandA))
-                            <div class="d-flex gap-2 mt-1">
+                            <div class="d-flex align-items-center gap-2 mt-1">
+                                <label class="vfo-control-label" for="modeSelectA">Mode</label>
                                 <select class="form-select form-select-sm vfo-mode-select" id="modeSelectA"
                                         aria-label="VFO A mode"
                                         title="VFO A mode"
@@ -1125,7 +1126,8 @@
                         <!-- Middle: Band buttons + Mode/Antenna below -->
                         <div class="flex-grow-1 band-buttons-shifted d-flex flex-column gap-1">
                             @await Html.PartialAsync("_BandButtonsPartial", Tuple.Create("unused", "B", Model.SelectedBandB))
-                            <div class="d-flex gap-2 mt-1">
+                            <div class="d-flex align-items-center gap-2 mt-1">
+                                <label class="vfo-control-label" for="modeSelectB">Mode</label>
                                 <select class="form-select form-select-sm vfo-mode-select" id="modeSelectB"
                                         aria-label="VFO B mode"
                                         title="VFO B mode"

--- a/Pages/Shared/_BandButtonsPartial.cshtml
+++ b/Pages/Shared/_BandButtonsPartial.cshtml
@@ -20,6 +20,7 @@
     var selectedBand = (Model.Item3 ?? "").Trim().ToLowerInvariant();
 }
 <div class="band-buttons-container">
+    <span class="vfo-control-label d-block mb-1" aria-hidden="true">Band</span>
     <div class="band-radio-grid" id="bandRadioGroup@(receiver)" role="radiogroup" aria-label="Band — use arrow keys to change band">
         @for (int idx = 0; idx < bands.Length; idx++)
         {

--- a/RadioHub.cs
+++ b/RadioHub.cs
@@ -34,10 +34,18 @@ namespace Yaesu_Web_Control.Hubs
         {
             _connections.TryAdd(Context.ConnectionId, 0);
             CancelShutdown();
-            await Clients.Caller.SendAsync("RadioStateUpdate",
-                new { property = "FrequencyA", value = _radioState.FrequencyA });
-            await Clients.Caller.SendAsync("RadioStateUpdate",
-                new { property = "FrequencyB", value = _radioState.FrequencyB });
+
+            // Replay the full state snapshot to this client only. Regular
+            // broadcasts fire on change, so without this a browser that
+            // connects after startup (second tab, another computer) keeps the
+            // frontend JS defaults for everything not server-rendered in the
+            // Razor page — most visibly ActiveVfo/TxVfo/SplitMode, which made
+            // VFO A always appear active on late-joining clients.
+            foreach (var (property, value) in _radioState.GetClientStateSnapshot())
+            {
+                await Clients.Caller.SendAsync("RadioStateUpdate", new { property, value });
+            }
+
             await base.OnConnectedAsync();
         }
 

--- a/Services/CatCommands.cs
+++ b/Services/CatCommands.cs
@@ -287,6 +287,29 @@
             // Init completion signal — must be last
             "DT0;"
         };
+
+        // P1=0-Fixed receive-control queries for single-receiver radios.
+        // Used by the init ping-pong (temporarily switch VS to read the
+        // inactive VFO's stored settings) and by the debounced post-VS
+        // re-query burst after front-panel A/B presses.
+        public static readonly string[] SingleReceiverPerVfoQueries =
+        {
+            "MD0;",          // mode — per-VFO at CAT level; re-read after VS for safety
+            "RF0;",          // roofing filter
+            "GT0;",          // AGC
+            "PA0;",          // IPO/AMP
+            "RA0;",          // Attenuator
+            "NR0;", "RL0;",  // NR + DNR level
+            "NB0;", "NL0;",  // NB + NB level
+            "BC0;",          // Auto Notch
+            "BP00;", "BP01;",// Manual Notch on/off + freq
+            "CO00;", "CO01;", "CO02;", "CO03;", // Contour + APF
+            "SH0;",          // IF Width
+            "IS0;",          // IF Shift
+            "AG0;",          // AF Gain
+            "RG0;",          // RF Gain
+            "SQ0;",          // Squelch
+        };
     }
 
     public static class IFCommandParser

--- a/Services/CatMessageDispatcher.cs
+++ b/Services/CatMessageDispatcher.cs
@@ -124,9 +124,10 @@
                         break;
                     case "MD":
                         // Example: MD01; (VFO A, LSB), MD12; (VFO B, USB)
+                        // Single-receiver: P1 is "0 Fixed" — routes via SetPerVfo's
+                        // 300 ms buffer so A/B-press broadcasts land on ActiveVfo.
                         if (message.Length >= 5)
                         {
-                            var vfo = message[2]; // '0' for A, '1' for B
                             var modeCode = message[3];
                             string? mode = modeCode switch
                             {
@@ -149,10 +150,10 @@
                             };
                             if (mode != null)
                             {
-                                if (vfo == '0')
-                                    _stateService.ModeA = mode;
-                                else if (vfo == '1')
-                                    _stateService.ModeB = mode;
+                                SetPerVfo(message[2], routeB => {
+                                    if (routeB) _stateService.ModeB = mode;
+                                    else        _stateService.ModeA = mode;
+                                });
                             }
                         }
                         break;

--- a/Services/CatMessageDispatcher.cs
+++ b/Services/CatMessageDispatcher.cs
@@ -6,13 +6,21 @@
     public class CatMessageDispatcher
     {
         private readonly RadioStateService _stateService;
+        private readonly ILogger<CatMessageDispatcher> _logger;
 
         // Callback for initialization complete
         public Action? OnInitializationComplete { get; set; }
 
-        public CatMessageDispatcher(RadioStateService stateService)
+        // Invoked after a VS change on single-receiver radios once init is
+        // complete. CatMultiplexerService wires a debounced per-VFO re-query.
+        public Action? OnActiveVfoChanged { get; set; }
+
+        public CatMessageDispatcher(
+            RadioStateService stateService,
+            ILogger<CatMessageDispatcher> logger)
         {
             _stateService = stateService;
+            _logger = logger;
             _ = ProcessPendingAsync();
         }
 
@@ -28,17 +36,22 @@
         // write the new VFO's values to the OLD ActiveVfo's slot.
         //
         // Pre5 fix (Jacek SP3L #34, after pre4): buffer single-receiver
-        // P1=0-Fixed broadcasts for 300 ms before applying. If VS arrives
-        // during the buffer window (indicating a swap), the queued updates
-        // route to the NEW ActiveVfo when they're applied. Dual-receiver
-        // (FTdx101) routes immediately by P1 -- no race possible there.
+        // P1=0-Fixed broadcasts for 300 ms before applying so A/B-press
+        // broadcasts that arrive before VS can settle. Updates whose
+        // ActiveVfo changed between enqueue and flush are dropped — any
+        // broadcast spanning a VS boundary is ambiguous; ground truth comes
+        // from the post-VS re-query burst. Dual-receiver (FTdx101) routes
+        // immediately by P1 — no race possible there.
         //
         // Items process in arrival order on a single consumer task so
         // last-write-wins semantics for the same property are preserved.
 
         private const int BufferDelayMs = 300;
 
-        private sealed record PendingDispatch(DateTimeOffset EnqueuedAt, Action<bool> Apply);
+        private sealed record PendingDispatch(
+            DateTimeOffset EnqueuedAt,
+            int ActiveVfoAtEnqueue,
+            Action<bool> Apply);
 
         private readonly System.Threading.Channels.Channel<PendingDispatch> _pending
             = System.Threading.Channels.Channel.CreateUnbounded<PendingDispatch>();
@@ -50,6 +63,13 @@
                 var age = DateTimeOffset.UtcNow - item.EnqueuedAt;
                 var wait = TimeSpan.FromMilliseconds(BufferDelayMs) - age;
                 if (wait > TimeSpan.Zero) await Task.Delay(wait);
+                if (_stateService.ActiveVfo != item.ActiveVfoAtEnqueue)
+                {
+                    _logger.LogDebug(
+                        "Dropped buffered P1=0-Fixed update: ActiveVfo changed {Old} → {New} during {DelayMs} ms buffer",
+                        item.ActiveVfoAtEnqueue, _stateService.ActiveVfo, BufferDelayMs);
+                    continue;
+                }
                 try { item.Apply(_stateService.ActiveVfo == 1); }
                 catch { /* per-item failures shouldn't break the consumer */ }
             }
@@ -58,9 +78,9 @@
         /// <summary>
         /// Apply a per-VFO receive-control update. On dual-receiver radios,
         /// writes immediately using the message's P1. On single-receiver
-        /// radios, buffers the update for 300 ms then applies using whichever
-        /// ActiveVfo is current at apply-time (after any VS broadcast that
-        /// arrived during the buffer window). See class comment above.
+        /// radios, buffers the update for 300 ms then applies using ActiveVfo
+        /// at apply-time unless ActiveVfo changed since enqueue (drop). See
+        /// class comment above.
         /// </summary>
         /// <param name="p1Char">The P1 character from the CAT message (used
         /// on dual-receiver only).</param>
@@ -70,7 +90,10 @@
         {
             if (_stateService.IsSingleReceiver)
             {
-                _pending.Writer.TryWrite(new PendingDispatch(DateTimeOffset.UtcNow, apply));
+                _pending.Writer.TryWrite(new PendingDispatch(
+                    DateTimeOffset.UtcNow,
+                    _stateService.ActiveVfo,
+                    apply));
             }
             else
             {
@@ -459,7 +482,16 @@
                         // R2 root cause: dispatcher had no case for VS so the
                         // radio's broadcast was silently dropped.
                         if (message.Length >= 4 && int.TryParse(message.Substring(2, 1), out int activeVfo))
+                        {
+                            var previous = _stateService.ActiveVfo;
                             _stateService.ActiveVfo = activeVfo;
+                            if (_stateService.IsSingleReceiver
+                                && _stateService.IsInitialized
+                                && previous != activeVfo)
+                            {
+                                OnActiveVfoChanged?.Invoke();
+                            }
+                        }
                         break;
                     case "AC":
                         // AC{P1}{P2}{P3}; per FTdx10 / FTdx101MP CAT manual page 6:

--- a/Services/CatMessageDispatcher.cs
+++ b/Services/CatMessageDispatcher.cs
@@ -174,27 +174,22 @@
                     case "RF":
                         // Example: RF06; (VFO A, 12kHz filter), RF19; (VFO B, 600Hz filter)
                         // Response format: RF + P1 (0=Main/A, 1=Sub/B) + P3 (filter code 6-A)
-                        // Single-receiver radios (FTdx10 etc.): P1 is always 0 — mirror to both VFOs.
+                        // Single-receiver: P1 is "0 Fixed" — routes via SetPerVfo's 300 ms
+                        // buffer so A/B-press broadcasts land on the new ActiveVfo.
                         if (message.Length >= 4)
                         {
-                            var vfo = message[2]; // '0' for A, '1' for B
                             var filterCode = message[3].ToString();
-                            if (_stateService.IsSingleReceiver)
-                            {
-                                // FTDX3000 answers RF in a read-code space (P3) that
-                                // differs from its dropdown set codes (P2); normalise
-                                // so the UI stays in sync. Other single-receiver
-                                // radios (FTdx10) already report in dropdown codes.
-                                var code = _stateService.RadioModel == "FTDX3000"
-                                    ? Ftdx3000Roofing.NormalizeReadCode(filterCode)
-                                    : filterCode;
-                                _stateService.RoofingFilterA = code;
-                                _stateService.RoofingFilterB = code;
-                            }
-                            else if (vfo == '0')
-                                _stateService.RoofingFilterA = filterCode;
-                            else if (vfo == '1')
-                                _stateService.RoofingFilterB = filterCode;
+                            // FTDX3000 answers RF in a read-code space (P3) that
+                            // differs from its dropdown set codes (P2); normalise
+                            // so the UI stays in sync. Other single-receiver
+                            // radios (FTdx10) already report in dropdown codes.
+                            var code = _stateService.RadioModel == "FTDX3000"
+                                ? Ftdx3000Roofing.NormalizeReadCode(filterCode)
+                                : filterCode;
+                            SetPerVfo(message[2], routeB => {
+                                if (routeB) _stateService.RoofingFilterB = code;
+                                else        _stateService.RoofingFilterA = code;
+                            });
                         }
                         break;
                     case "GT":

--- a/Services/CatMultiplexerService.cs
+++ b/Services/CatMultiplexerService.cs
@@ -24,10 +24,16 @@ namespace Yaesu_Web_Control.Services
         // Auto-Information support
         private readonly CatMessageBuffer _messageBuffer;
         private readonly CatMessageDispatcher _messageDispatcher;
+        private readonly RadioStateService _radioStateService;
         private bool _autoInformationEnabled = false;
 
         private readonly ConcurrentDictionary<string, TaskCompletionSource<string>> _pendingResponses = new();
         private TaskCompletionSource<bool>? _initializationCompletionSource;
+
+        // Debounced post-VS re-query for single-receiver radios (cancel-and-
+        // restart on rapid A/B flips).
+        private CancellationTokenSource? _vsRequeryCts;
+        private const int VsRequerySettleMs = 500;
 
         public bool IsConnected => _serialPort?.IsOpen ?? false;
 
@@ -37,15 +43,50 @@ namespace Yaesu_Web_Control.Services
             ILogger<CatMultiplexerService> logger,
             CatMessageBuffer messageBuffer,
             CatMessageDispatcher messageDispatcher,
-            ISettingsService settingsService)
+            ISettingsService settingsService,
+            RadioStateService radioStateService)
         {
             _logger = logger;
             _messageBuffer = messageBuffer;
             _messageDispatcher = messageDispatcher;
             _settingsService = settingsService;
+            _radioStateService = radioStateService;
 
             _messageBuffer.MessageReceived += OnMessageReceived;
             _messageDispatcher.OnInitializationComplete = SignalInitializationComplete;
+            _messageDispatcher.OnActiveVfoChanged = SchedulePostVsRequery;
+        }
+
+        private void SchedulePostVsRequery()
+        {
+            if (!_radioStateService.IsSingleReceiver || !_radioStateService.IsInitialized)
+                return;
+
+            _vsRequeryCts?.Cancel();
+            _vsRequeryCts?.Dispose();
+            _vsRequeryCts = new CancellationTokenSource();
+            var token = _vsRequeryCts.Token;
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await Task.Delay(VsRequerySettleMs, token);
+                    _logger.LogDebug(
+                        "Post-VS re-query: reading active VFO {Vfo} receive controls after A/B switch",
+                        _radioStateService.ActiveVfo == 0 ? "A" : "B");
+                    foreach (var q in CatCommands.SingleReceiverPerVfoQueries)
+                        await SendCommandAndDispatchAsync(q, "VsRequery", token);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Rapid A/B flip — a newer re-query superseded this one.
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Post-VS per-VFO re-query failed");
+                }
+            }, token);
         }
 
         private void OnMessageReceived(object? sender, CatMessageReceivedEventArgs e)
@@ -396,10 +437,16 @@ namespace Yaesu_Web_Control.Services
             // gets a fresh, non-cancelled token.
             _cancellationTokenSource.Dispose();
             _cancellationTokenSource = new CancellationTokenSource();
+
+            _vsRequeryCts?.Cancel();
+            _vsRequeryCts?.Dispose();
+            _vsRequeryCts = null;
         }
 
         public void Dispose()
         {
+            _vsRequeryCts?.Cancel();
+            _vsRequeryCts?.Dispose();
             DisconnectAsync().GetAwaiter().GetResult();
             _serialSemaphore?.Dispose();
             _cancellationTokenSource?.Dispose();

--- a/Services/RadioInitializationService.cs
+++ b/Services/RadioInitializationService.cs
@@ -198,18 +198,22 @@ namespace Yaesu_Web_Control.Services
                     stateTasks.Add(multiplexer.SendCommandAsync($"AN1{persistedState.AntennaB};", "Initialization", stoppingToken)
                         .ContinueWith(t => { if (!t.IsFaulted) radioStateService.AntennaB = persistedState.AntennaB; }));
                 }
-                // Restore AF Gain — only if the user previously saved a non-zero value.
-                // 0 is the int default (never saved), so sending AG0000; on every fresh start
-                // would silence the radio.
-                if (persistedState.AfGainA > 0 && persistedState.AfGainA <= 255)
+                // Restore AF Gain — only on dual-receiver radios. On
+                // single-receiver the radio is the source of truth (same
+                // precedent as Mode #38, RF Power #35, MIC Gain #16); the
+                // AG0;/AG1; readQueries and ping-pong AG0; populate the UI.
+                if (!radioStateService.IsSingleReceiver)
                 {
-                    stateTasks.Add(multiplexer.SendCommandAsync($"AG0{persistedState.AfGainA:D3};", "Initialization", stoppingToken)
-                        .ContinueWith(t => { if (!t.IsFaulted) radioStateService.AfGainA = persistedState.AfGainA; }));
-                }
-                if (persistedState.AfGainB > 0 && persistedState.AfGainB <= 255)
-                {
-                    stateTasks.Add(multiplexer.SendCommandAsync($"AG1{persistedState.AfGainB:D3};", "Initialization", stoppingToken)
-                        .ContinueWith(t => { if (!t.IsFaulted) radioStateService.AfGainB = persistedState.AfGainB; }));
+                    if (persistedState.AfGainA > 0 && persistedState.AfGainA <= 255)
+                    {
+                        stateTasks.Add(multiplexer.SendCommandAsync($"AG0{persistedState.AfGainA:D3};", "Initialization", stoppingToken)
+                            .ContinueWith(t => { if (!t.IsFaulted) radioStateService.AfGainA = persistedState.AfGainA; }));
+                    }
+                    if (persistedState.AfGainB > 0 && persistedState.AfGainB <= 255)
+                    {
+                        stateTasks.Add(multiplexer.SendCommandAsync($"AG1{persistedState.AfGainB:D3};", "Initialization", stoppingToken)
+                            .ContinueWith(t => { if (!t.IsFaulted) radioStateService.AfGainB = persistedState.AfGainB; }));
+                    }
                 }
                 // MIC GAIN, Speech Processor ON/OFF, and PROC LEVEL are
                 // deliberately NOT restored from persisted state on connect
@@ -410,25 +414,7 @@ namespace Yaesu_Web_Control.Services
                     // routes through SetPerVfo's 300 ms buffer; by the time
                     // the buffer flushes, ActiveVfo is still = otherVfo, so
                     // they land in the right slot.
-                    string[] perVfoQueries = {
-                        "MD0;",          // mode is per-VFO at the CAT level but the radio
-                                         // updates display mode on swap so re-read for safety
-                        "RF0;",          // roofing filter (per-VFO on single-receiver)
-                        "GT0;",          // AGC
-                        "PA0;",          // IPO/AMP
-                        "RA0;",          // Attenuator
-                        "NR0;", "RL0;",  // NR + DNR level
-                        "NB0;", "NL0;",  // NB + NB level
-                        "BC0;",          // Auto Notch
-                        "BP00;", "BP01;",// Manual Notch on/off + freq
-                        "CO00;", "CO01;", "CO02;", "CO03;", // Contour + APF
-                        "SH0;",          // IF Width
-                        "IS0;",          // IF Shift
-                        "AG0;",          // AF Gain
-                        "RG0;",          // RF Gain
-                        "SQ0;",          // Squelch
-                    };
-                    foreach (var q in perVfoQueries)
+                    foreach (var q in CatCommands.SingleReceiverPerVfoQueries)
                         await multiplexer.SendCommandAndDispatchAsync(q, "Initialization", stoppingToken);
 
                     // Wait for the buffered dispatches to drain (BufferDelayMs

--- a/Services/RadioInitializationService.cs
+++ b/Services/RadioInitializationService.cs
@@ -413,6 +413,7 @@ namespace Yaesu_Web_Control.Services
                     string[] perVfoQueries = {
                         "MD0;",          // mode is per-VFO at the CAT level but the radio
                                          // updates display mode on swap so re-read for safety
+                        "RF0;",          // roofing filter (per-VFO on single-receiver)
                         "GT0;",          // AGC
                         "PA0;",          // IPO/AMP
                         "RA0;",          // Attenuator

--- a/Services/RadioStateService.cs
+++ b/Services/RadioStateService.cs
@@ -65,6 +65,8 @@ namespace Yaesu_Web_Control.Services
             IfWidthB = _initialState.IfWidthB ?? "8";
             IfShiftA = _initialState.IfShiftA;
             IfShiftB = _initialState.IfShiftB;
+            AfGainA = _initialState.AfGainA;
+            AfGainB = _initialState.AfGainB;
         }
 
         public RadioState InitialState => _initialState;
@@ -457,9 +459,9 @@ namespace Yaesu_Web_Control.Services
         private int? _temperature;
         public int? Temperature { get => _temperature; set => SetField(ref _temperature, value); }
 
-        private int _afGainA = 128;
+        private int _afGainA;
         public int AfGainA { get => _afGainA; set => SetField(ref _afGainA, value); }
-        private int _afGainB = 128;
+        private int _afGainB;
         public int AfGainB { get => _afGainB; set => SetField(ref _afGainB, value); }
 
         private int _micGain = 50;

--- a/Services/RadioStateService.cs
+++ b/Services/RadioStateService.cs
@@ -573,6 +573,99 @@ namespace Yaesu_Web_Control.Services
         private int _splitMode = 0;
         public int SplitMode { get => _splitMode; set => SetField(ref _splitMode, value); }
 
+        // Snapshot of every UI-relevant state property, replayed to each newly
+        // connected SignalR client by RadioHub.OnConnectedAsync through the
+        // normal RadioStateUpdate envelope. Broadcasts only fire on *change*,
+        // so a browser that connects after initialization (second tab, another
+        // computer) would otherwise keep the frontend's JS defaults for any
+        // property not server-rendered in Index.cshtml — most visibly
+        // ActiveVfo/TxVfo/SplitMode, which made VFO A always look active on
+        // late-joining clients. Property names must match the handlers in
+        // wwwroot/js/ui/site.js. Meters are excluded (they stream at ~10 Hz).
+        public IReadOnlyList<KeyValuePair<string, object>> GetClientStateSnapshot()
+        {
+            return new List<KeyValuePair<string, object>>
+            {
+                new("IsConnected", IsConnected),
+                new("RadioPowerOn", RadioPowerOn),
+                new("FrequencyA", FrequencyA),
+                new("FrequencyB", FrequencyB),
+                new("BandA", BandA),
+                new("BandB", BandB),
+                new("ModeA", ModeA ?? ""),
+                new("ModeB", ModeB ?? ""),
+                new("AntennaA", AntennaA ?? ""),
+                new("AntennaB", AntennaB ?? ""),
+                new("ActiveVfo", ActiveVfo),
+                new("TxVfo", TxVfo),
+                new("SplitMode", SplitMode),
+                new("IsTransmitting", IsTransmitting),
+                new("Power", Power),
+                new("RoofingFilterA", RoofingFilterA ?? ""),
+                new("RoofingFilterB", RoofingFilterB ?? ""),
+                new("AgcA", AgcA),
+                new("AgcB", AgcB),
+                new("IpoA", IpoA),
+                new("IpoB", IpoB),
+                new("AttA", AttA),
+                new("AttB", AttB),
+                new("NrA", NrA),
+                new("NrB", NrB),
+                new("NrLevelA", NrLevelA),
+                new("NrLevelB", NrLevelB),
+                new("NbA", NbA),
+                new("NbB", NbB),
+                new("NbLevelA", NbLevelA),
+                new("NbLevelB", NbLevelB),
+                new("AutoNotchA", AutoNotchA),
+                new("AutoNotchB", AutoNotchB),
+                new("ManualNotchA", ManualNotchA),
+                new("ManualNotchB", ManualNotchB),
+                new("ManualNotchFreqA", ManualNotchFreqA),
+                new("ManualNotchFreqB", ManualNotchFreqB),
+                new("IfWidthA", IfWidthA),
+                new("IfWidthB", IfWidthB),
+                new("IfShiftA", IfShiftA),
+                new("IfShiftB", IfShiftB),
+                new("RxClarOn", RxClarOn),
+                new("TxClarOn", TxClarOn),
+                new("ClarifierOffsetA", ClarifierOffsetA),
+                new("ClarifierOffsetB", ClarifierOffsetB),
+                new("ContourOnA", ContourOnA),
+                new("ContourOnB", ContourOnB),
+                new("ContourFreqA", ContourFreqA),
+                new("ContourFreqB", ContourFreqB),
+                new("ApfOnA", ApfOnA),
+                new("ApfOnB", ApfOnB),
+                new("ApfFreqA", ApfFreqA),
+                new("ApfFreqB", ApfFreqB),
+                new("AfGainA", AfGainA),
+                new("AfGainB", AfGainB),
+                new("RfGainA", RfGainA),
+                new("RfGainB", RfGainB),
+                new("SquelchA", SquelchA),
+                new("SquelchB", SquelchB),
+                new("ProcEnabled", ProcEnabled),
+                new("ProcLevel", ProcLevel),
+                new("AtuEnabled", AtuEnabled),
+                new("AtuTuning", AtuTuning),
+                new("MonitorOn", MonitorOn),
+                new("MonitorLevelA", MonitorLevelA),
+                new("MonitorLevelB", MonitorLevelB),
+                new("VoxOn", VoxOn),
+                new("VoxGain", VoxGain),
+                new("VoxDelay", VoxDelay),
+                new("CwPitch", CwPitch),
+                new("CwSpeed", CwSpeed),
+                new("CwBreakIn", CwBreakIn),
+                new("CwBreakInDelay", CwBreakInDelay),
+                new("FmShiftDir", FmShiftDir),
+                new("FmOffsetHz", FmOffsetHz),
+                new("CtcssMode", CtcssMode),
+                new("CtcssTone", CtcssTone),
+            };
+        }
+
         public RadioState GetState()
         {
             return new RadioState


### PR DESCRIPTION
# Single-receiver VFO routing fixes: memory recall, roofing filter, A/B re-query + full state replay for late-joining clients

TL,DR: Fix some state drift between what the radio have and what YWC reports

Add labels in the VFOs for `band` and `mode`
<img width="384" height="193" alt="image" src="https://github.com/user-attachments/assets/f0a80252-56cd-4d19-b290-abce40a19df4" />


## Summary

On single-receiver radios (FTdx10, FT-710, FTDX3000, FT-991A), VFO A and B are frequency/mode slots for one receiver; the operating VFO is tracked by `ActiveVfo` (from the `VS` CAT command). Several code paths still ignored that and hard-wired VFO A. This branch fixes them, plus a related state-sync bug for browsers that connect after startup.

### Memory recall tunes the active VFO (`Controllers/MemoryController.cs`)

- Recall (`POST /api/memory/{id}/recall`) was hard-coded to VFO A — always sending `FA`/`MD0` and writing only `*A` state fields. Recalling a memory while VFO B was active updated the wrong slot, so the receiver did not move.
- `Recall` now uses `RadioCapabilities.VfoIsB` — the same routing helper used throughout `CatController` — to target the active VFO. Mode and frequency commands switch between `MD0`/`FA` and `MD1`/`FB`, and every per-VFO state write (clarifier, antenna, IF width/shift, roofing, NB, NR, AGC) routes to the matching A or B property. Dual-receiver behaviour is unchanged (recall still targets VFO A).

### Roofing filter is per-VFO state on single-receiver radios (`CatController`, `CatMessageDispatcher`, `RadioInitializationService`)

- The FTdx10/FTDX3000 roofing setters and the `RF` read-back handler used to mirror the filter code to both `RoofingFilterA` and `RoofingFilterB`. But the radio stores the roofing filter per VFO slot, so mirroring corrupted the inactive slot's value.
- Setters now write only the active VFO's slot, and the dispatcher's `RF` case routes through `SetPerVfo` like the other P1=0-Fixed receive controls (including the FTDX3000 read-code normalisation). `RF0;` was added to the init per-VFO query list so both slots are populated at connect.

### `SetMode` consolidation (`CatController`)

- Refactored to build the CAT command from `VfoP1Outgoing` and route state writes via `VfoIsB` instead of duplicated A/B branches — same fix pattern as the other receive-control endpoints, and the Contour/APF re-apply after a mode change now reads the correct per-VFO state.

### Front-panel A/B press re-syncs per-VFO controls (`CatMessageDispatcher`, `CatMultiplexerService`, `CatCommands`)

- Pressing A/B on the rig fires a burst of P1=0-Fixed auto-info broadcasts racing the `VS` answer. The 300 ms dispatch buffer previously applied any queued update to whichever `ActiveVfo` was current at flush time — updates spanning the VS boundary could land in the wrong slot. Buffered updates whose `ActiveVfo` changed between enqueue and flush are now dropped as ambiguous.
- Ground truth is restored by a new debounced post-VS re-query: 500 ms after a `VS` change (cancel-and-restart on rapid flips), the multiplexer re-reads the full per-VFO control set for the newly active VFO. The query list is now shared as `CatCommands.SingleReceiverPerVfoQueries` between init ping-pong and the re-query. `MD` read-back also routes via `SetPerVfo` now.
- AF Gain persisted-state restore at init is skipped on single-receiver radios — the radio is the source of truth there (same precedent as Mode #38, RF Power #35, MIC Gain #16); the `AG0;` queries populate the UI instead.

### Late-joining browsers get the full radio state (`RadioHub`, `RadioStateService`)

- SignalR broadcasts only fire on *change*, and `OnConnectedAsync` replayed only `FrequencyA`/`FrequencyB`. A browser connecting after startup (second tab, another computer) kept the frontend JS defaults for anything not server-rendered in the Razor page — most visibly `ActiveVfo`/`TxVfo`/`SplitMode`, which made VFO A always look active on late-joining clients.
- `RadioStateService.GetClientStateSnapshot()` returns every UI-relevant property (meters excluded), and the hub replays it to the connecting client through the normal `RadioStateUpdate` envelope. No frontend changes needed; voice announcements are unaffected (initial-load suppression already swallows first values).

## Test plan

- [x] On FTdx10: with VFO B active, recall a memory — VFO B retunes and the UI updates
- [x] On FTdx10: with VFO A active, recall a memory — VFO A retunes (regression)
- [ ] On FTdx10: press A/B on the rig — after ~0.5 s all per-VFO controls (mode, roofing, AGC, IF width/shift, NB/NR, contour/APF, AF/RF gain, squelch) show the newly active VFO's values
- [ ] On FTdx10: change the roofing filter with VFO B active, press A/B — each panel keeps its own filter (no mirroring)
- [ ] On FTdx10: with VFO B active, open the UI in a second browser/computer — VFO B shows as active; split/TX state also correct
- [ ] On FTdx101 (dual receiver): memory recall still targets VFO A; mode/roofing per-VFO commands unchanged; second-browser state still correct

