### PR TITLE
Fix/tx toggle key on save

### DIFF
--- a/Models/ApplicationSettings.cs
+++ b/Models/ApplicationSettings.cs
@@ -167,13 +167,17 @@
         // Yuri W4YSW request 2026-06-17.
         public bool ShowFrequencyArrowButtons { get; set; } = false;
 
-        // Browser key that toggles TX (transmit). Empty string = disabled.
+        // Browser key that toggles TX (transmit). Empty / null = disabled.
         // Stored as a KeyboardEvent.key value such as "t" or "F8", except
         // Space which is stored as the token "Space" (a lone " " cannot
         // survive HTML form / input value round-trips).
         // Ignored while typing in inputs to avoid accidental keying during
         // form entry or frequency editing.
-        public string TxToggleKey { get; set; } = "";
+        // Nullable so an empty input does not get an implicit [Required] from
+        // <Nullable>enable</Nullable> — that would make jQuery unobtrusive
+        // validation silently block the entire Settings form (same class of
+        // bug as #65 / SdrplayInstallPath and the DX-cluster fields).
+        public string? TxToggleKey { get; set; } = "";
 
         // ── Voice Control (in-process SAPI) ───────────────────────────────
         // When true, the navbar mic button is shown and the SAPI recogniser

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -133,7 +133,7 @@ namespace Yaesu_Web_Control.Pages
             ShowApp4Button = settings.ShowGridtrackerButton;
             ShowApp5Button = settings.ShowFldigiButton;
             ShowFrequencyArrowButtons = settings.ShowFrequencyArrowButtons;
-            TxToggleKey = settings.TxToggleKey == " " ? "Space" : settings.TxToggleKey;
+            TxToggleKey = settings.TxToggleKey == " " ? "Space" : (settings.TxToggleKey ?? string.Empty);
             App1Name = settings.App1Name;
             App2Name = settings.App2Name;
             App3Name = settings.App3Name;

--- a/Pages/Settings.cshtml
+++ b/Pages/Settings.cshtml
@@ -223,12 +223,16 @@
             <div class="mb-3">
                 <label class="form-label fw-semibold" for="Settings_TxToggleKey">TX toggle key</label>
                 <div class="d-flex flex-wrap align-items-center gap-2">
+                    @* data-val="false": optional blank must never get client-side
+                       required (same silent-block class of bug as #65). Server
+                       already ModelState.Remove's this field. *@
                     <input asp-for="Settings.TxToggleKey"
                            class="form-control"
                            id="Settings_TxToggleKey"
                            style="max-width: 220px;"
                            readonly
                            autocomplete="off"
+                           data-val="false"
                            aria-describedby="txToggleKeyHelp txToggleKeyDisplay" />
                     <button type="button" class="btn btn-outline-primary btn-sm" id="txToggleKeySetBtn">
                         Set key
@@ -2142,34 +2146,6 @@
     </div>
     </form>
 
-    <script>
-        // Save button feedback: "Saving…" the instant the form is submitted
-        // (the POST → redirect → reload round trip takes a few seconds, and
-        // without this the button just sits there looking unresponsive),
-        // then "Saved ✓" on the reloaded page after a successful save,
-        // reverting back to normal after a few seconds. #65 follow-up.
-        (function () {
-            var form = document.getElementById('settingsForm');
-            var btn = document.getElementById('saveSettingsBtn');
-            var icon = document.getElementById('saveSettingsIcon');
-            var label = document.getElementById('saveSettingsLabel');
-            if (!form || !btn || !icon || !label) return;
-
-            form.addEventListener('submit', function () {
-                btn.disabled = true;
-                icon.className = 'spinner-border spinner-border-sm';
-                label.textContent = 'Saving…';
-            });
-
-            if (btn.dataset.saveSuccess === '1') {
-                setTimeout(function () {
-                    icon.className = 'bi bi-save';
-                    label.textContent = 'Save Settings';
-                }, 3000);
-            }
-        })();
-    </script>
-
     <!-- Backup / Restore — outside the main form so the import button doesn't trigger a save -->
     <details class="settings-section" @(ViewContext.ModelState.IsValid ? "" : "open")>
         <summary><i class="bi bi-box-arrow-up" aria-hidden="true"></i>&nbsp;Backup &amp; Restore</summary>
@@ -2315,6 +2291,75 @@
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
+    <script>
+        // Must run AFTER _ValidationScriptsPartial so jQuery Validate is present.
+        // "Saving…" only when the form will actually POST. Previously the spinner
+        // ran even when unobtrusive validation cancelled the post (blank optional
+        // fields with implicit [Required]) — looked like a save that "didn't persist".
+        (function () {
+            var form = document.getElementById('settingsForm');
+            var btn = document.getElementById('saveSettingsBtn');
+            var icon = document.getElementById('saveSettingsIcon');
+            var label = document.getElementById('saveSettingsLabel');
+            if (!form || !btn || !icon || !label) return;
+
+            function resetSaveButton() {
+                btn.disabled = false;
+                icon.className = 'bi bi-save';
+                label.textContent = 'Save Settings';
+            }
+
+            function markSaving() {
+                btn.disabled = true;
+                icon.className = 'spinner-border spinner-border-sm';
+                label.textContent = 'Saving…';
+            }
+
+            function revealFirstInvalid() {
+                var invalid = form.querySelector('.input-validation-error, :invalid');
+                if (!invalid) return;
+                var section = invalid.closest('details.settings-section');
+                if (section) section.open = true;
+                invalid.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                if (typeof invalid.focus === 'function') invalid.focus();
+            }
+
+            if (window.jQuery) {
+                var $form = window.jQuery(form);
+                $form.on('invalid-form.validate', function () {
+                    resetSaveButton();
+                    revealFirstInvalid();
+                });
+                // Only flip the button to Saving… when Validate says the post may proceed.
+                $form.on('submit', function (e) {
+                    if ($form.data('validator') && !$form.valid()) {
+                        e.preventDefault();
+                        resetSaveButton();
+                        revealFirstInvalid();
+                        return;
+                    }
+                    markSaving();
+                });
+            } else {
+                form.addEventListener('submit', function (e) {
+                    if (typeof form.checkValidity === 'function' && !form.checkValidity()) {
+                        e.preventDefault();
+                        resetSaveButton();
+                        revealFirstInvalid();
+                        return;
+                    }
+                    markSaving();
+                });
+            }
+
+            if (btn.dataset.saveSuccess === '1') {
+                setTimeout(function () {
+                    icon.className = 'bi bi-save';
+                    label.textContent = 'Save Settings';
+                }, 3000);
+            }
+        })();
+    </script>
     <script type="module">
         // hwVer (per SDRplay API header) → friendly model name. Kept in sync
         // with the C# HwVerToModel in Services/Sdr/SdrplayDevice.cs.


### PR DESCRIPTION
Hi @mm5agm , its me again

This PR fixes a bug induced by my tx toggle key change, where YWC would not save the profile on fresh installs if TX Toggle key isnt set

## Summary

- Fixes Settings **Save** silently failing on a fresh install (and whenever TX Toggle Key was left blank).
- Same class of bug as [#65](https://github.com/mm5agm/Yaesu_Web_Control/issues/65): with `<Nullable>enable</Nullable>`, a non-nullable empty `TxToggleKey` got an implicit `[Required]`, so jQuery unobtrusive validation blocked the whole form client-side with no visible error. The Saving… spinner still ran, which made it look like a save that “didn’t persist” until a TX toggle key was set.
- Make `TxToggleKey` nullable, force `data-val="false"` on the input, and only show Saving… when validation actually allows the POST (scroll/open the first invalid field otherwise).
