### PR TITLE
Remote audio streaming (browser ↔ radio USB) + optional HTTPS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,16 +175,28 @@ jobs:
         run: |
           image="ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
           echo "image=${image}" >> "$GITHUB_OUTPUT"
+          # :latest only moves on full releases — never on pre-releases or smoke builds.
+          latest=false
           if [ "${{ github.event_name }}" = "release" ]; then
             echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
             echo "push=true" >> "$GITHUB_OUTPUT"
+            if [ "${{ github.event.release.prerelease }}" != "true" ]; then
+              latest=true
+            fi
           elif [ -n "${{ github.event.inputs.tag }}" ]; then
-            echo "version=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+            version="${{ github.event.inputs.tag }}"
+            echo "version=${version}" >> "$GITHUB_OUTPUT"
             echo "push=true" >> "$GITHUB_OUTPUT"
+            # SemVer pre-release (e.g. v2.4.3-pre6) has a hyphen after the numeric version.
+            ver="${version#v}"
+            if [[ "$ver" != *-* ]]; then
+              latest=true
+            fi
           else
             echo "version=smoke" >> "$GITHUB_OUTPUT"
             echo "push=false" >> "$GITHUB_OUTPUT"
           fi
+          echo "latest=${latest}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
         if: steps.prep.outputs.push == 'true'
@@ -202,7 +214,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}},value=${{ steps.prep.outputs.version }},enable=${{ steps.prep.outputs.push }}
             type=semver,pattern={{raw}},value=${{ steps.prep.outputs.version }},enable=${{ steps.prep.outputs.push }}
-            type=raw,value=latest,enable=${{ steps.prep.outputs.push }}
+            type=raw,value=latest,enable=${{ steps.prep.outputs.latest }}
             type=raw,value=smoke,enable=${{ steps.prep.outputs.push != 'true' }}
 
       - name: Build and push

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ appsettings.user.json
 .cursor
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
-
+.DS_Store
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ On macOS, set **Serial Port** to a `/dev/cu.*` device. On Linux, use `/dev/ttyUS
 | Serial validation | `COM*` | `/dev/…` |
 | AppData | `%APPDATA%\MM5AGM\Yaesu Web Control\` | `$XDG_CONFIG_HOME` or `~/.config/MM5AGM/Yaesu Web Control/` |
 | `AutoShutdownWhenNoBrowsers` | Default true | Default true; `HostRuntime.IsContainer` forces keep-alive |
-| Browser auto-open | Yes | Skipped when `HostRuntime.IsContainer` |
+| Browser auto-open | `OpenBrowserOnStartup` (default true) | Same setting; skipped when `HostRuntime.IsContainer` |
 | Operator-facing docs | `USER_MANUAL.md` §§1–4, 6.2–6.3, 15.10, 17 | Same |
 
 There are no automated tests. Verification is manual via the browser at `http://localhost:8080`.

--- a/Controllers/AudioController.cs
+++ b/Controllers/AudioController.cs
@@ -31,9 +31,27 @@ namespace Yaesu_Web_Control.Controllers
             try
             {
                 var inputs = AudioDeviceEnumerator.ListInputs()
-                    .Select(d => new { d.Index, d.Name, d.DefaultSampleRate });
+                    .Select(d => new
+                    {
+                        d.Index,
+                        d.Name,
+                        d.HostApiName,
+                        d.HostApiIndex,
+                        displayName = d.DisplayName,
+                        key = d.PersistenceKey,
+                        d.DefaultSampleRate
+                    });
                 var outputs = AudioDeviceEnumerator.ListOutputs()
-                    .Select(d => new { d.Index, d.Name, d.DefaultSampleRate });
+                    .Select(d => new
+                    {
+                        d.Index,
+                        d.Name,
+                        d.HostApiName,
+                        d.HostApiIndex,
+                        displayName = d.DisplayName,
+                        key = d.PersistenceKey,
+                        d.DefaultSampleRate
+                    });
                 return Ok(new { inputs, outputs });
             }
             catch (Exception ex)

--- a/Controllers/AudioController.cs
+++ b/Controllers/AudioController.cs
@@ -1,0 +1,94 @@
+using Microsoft.AspNetCore.Mvc;
+using Yaesu_Web_Control.Services;
+using Yaesu_Web_Control.Services.Audio;
+
+namespace Yaesu_Web_Control.Controllers
+{
+    [ApiController]
+    [Route("api/audio")]
+    public class AudioController : ControllerBase
+    {
+        private readonly ISettingsService _settings;
+        private readonly AudioSessionManager _sessions;
+        private readonly RadioAudioBridgeService _bridge;
+        private readonly ILogger<AudioController> _logger;
+
+        public AudioController(
+            ISettingsService settings,
+            AudioSessionManager sessions,
+            RadioAudioBridgeService bridge,
+            ILogger<AudioController> logger)
+        {
+            _settings = settings;
+            _sessions = sessions;
+            _bridge = bridge;
+            _logger = logger;
+        }
+
+        [HttpGet("devices")]
+        public IActionResult ListDevices()
+        {
+            try
+            {
+                var inputs = AudioDeviceEnumerator.ListInputs()
+                    .Select(d => new { d.Index, d.Name, d.DefaultSampleRate });
+                var outputs = AudioDeviceEnumerator.ListOutputs()
+                    .Select(d => new { d.Index, d.Name, d.DefaultSampleRate });
+                return Ok(new { inputs, outputs });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to enumerate audio devices");
+                return StatusCode(500, new { error = ex.Message });
+            }
+        }
+
+        [HttpGet("status")]
+        public async Task<IActionResult> Status()
+        {
+            var s = await _settings.GetSettingsAsync();
+            return Ok(new
+            {
+                enabled = s.AudioStreamingEnabled,
+                sessionActive = _sessions.HasActiveSession,
+                devicesOpen = _bridge.DevicesOpen,
+                codec = _bridge.ActiveCodec,
+                rxLevel = _bridge.RxLevel,
+                txLevel = _bridge.TxLevel,
+                httpsEnabled = s.HttpsEnabled,
+                httpsPort = s.HttpsPort,
+                certificatePresent = HttpsCertificateService.CertificateExists,
+                certificateInfo = HttpsCertificateService.DescribeCertificate()
+            });
+        }
+
+        public sealed class GenerateCertRequest
+        {
+            public string? SanHosts { get; set; }
+        }
+
+        [HttpPost("https/generate")]
+        public IActionResult GenerateCertificate([FromBody] GenerateCertRequest? body)
+        {
+            try
+            {
+                var hosts = (body?.SanHosts ?? "")
+                    .Split(new[] { '\n', '\r', ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                HttpsCertificateService.Generate(hosts);
+                _logger.LogInformation("Generated self-signed HTTPS certificate at {Path}", HttpsCertificateService.CertificatePath);
+                return Ok(new
+                {
+                    ok = true,
+                    path = HttpsCertificateService.CertificatePath,
+                    info = HttpsCertificateService.DescribeCertificate(),
+                    restartRequired = true
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "HTTPS certificate generation failed");
+                return StatusCode(500, new { error = ex.Message });
+            }
+        }
+    }
+}

--- a/Controllers/AudioController.cs
+++ b/Controllers/AudioController.cs
@@ -39,7 +39,8 @@ namespace Yaesu_Web_Control.Controllers
                         d.HostApiIndex,
                         displayName = d.DisplayName,
                         key = d.PersistenceKey,
-                        d.DefaultSampleRate
+                        d.DefaultSampleRate,
+                        likelyRadio = AudioDeviceEnumerator.LooksLikeRadioUsbCodec(d.Name)
                     });
                 var outputs = AudioDeviceEnumerator.ListOutputs()
                     .Select(d => new
@@ -50,7 +51,8 @@ namespace Yaesu_Web_Control.Controllers
                         d.HostApiIndex,
                         displayName = d.DisplayName,
                         key = d.PersistenceKey,
-                        d.DefaultSampleRate
+                        d.DefaultSampleRate,
+                        likelyRadio = AudioDeviceEnumerator.LooksLikeRadioUsbCodec(d.Name)
                     });
                 return Ok(new { inputs, outputs });
             }

--- a/Controllers/AudioController.cs
+++ b/Controllers/AudioController.cs
@@ -73,11 +73,31 @@ namespace Yaesu_Web_Control.Controllers
                 codec = _bridge.ActiveCodec,
                 rxLevel = _bridge.RxLevel,
                 txLevel = _bridge.TxLevel,
+                rxGain = s.AudioRxGain,
+                txGain = s.AudioTxGain,
                 httpsEnabled = s.HttpsEnabled,
                 httpsPort = s.HttpsPort,
                 certificatePresent = HttpsCertificateService.CertificateExists,
                 certificateInfo = HttpsCertificateService.DescribeCertificate()
             });
+        }
+
+        public sealed class GainRequest
+        {
+            public float? Rx { get; set; }
+            public float? Tx { get; set; }
+        }
+
+        /// <summary>Persist and apply RX/TX software gains (0.05–4).</summary>
+        [HttpPost("gain")]
+        public async Task<IActionResult> SetGain([FromBody] GainRequest? body)
+        {
+            var s = await _settings.GetSettingsAsync();
+            if (body?.Rx is float rx) s.AudioRxGain = Math.Clamp(rx, 0.05f, 4f);
+            if (body?.Tx is float tx) s.AudioTxGain = Math.Clamp(tx, 0.05f, 4f);
+            await _settings.SaveSettingsAsync(s);
+            _bridge.SetGains(s.AudioRxGain, s.AudioTxGain);
+            return Ok(new { rx = s.AudioRxGain, tx = s.AudioTxGain });
         }
 
         public sealed class GenerateCertRequest

--- a/Controllers/CatController.cs
+++ b/Controllers/CatController.cs
@@ -260,10 +260,27 @@ namespace Yaesu_Web_Control.Controllers
         [HttpGet("tx")]
         public IActionResult GetTxStatus()
         {
-            return Ok(new { 
+            return Ok(new {
                 transmitting = _radioStateService.IsTransmitting,
-                txVfo = _radioStateService.TxVfo
+                txVfo = EffectiveTxVfo(),
+                // Raw FT value — kept for diagnostics; UI should use txVfo (effective).
+                ftVfo = _radioStateService.TxVfo
             });
+        }
+
+        /// <summary>
+        /// Same TX-VFO positioning rules as the Index TX button
+        /// (single-receiver uses ActiveVfo / SplitMode; dual-receiver uses FT).
+        /// </summary>
+        private int EffectiveTxVfo()
+        {
+            if (_radioStateService.IsSingleReceiver)
+            {
+                if (_radioStateService.SplitMode > 0)
+                    return _radioStateService.ActiveVfo == 0 ? 1 : 0;
+                return _radioStateService.ActiveVfo;
+            }
+            return _radioStateService.TxVfo;
         }
 
         // Static band frequency mapping (apply this at the top of your class)

--- a/Models/ApplicationSettings.cs
+++ b/Models/ApplicationSettings.cs
@@ -268,10 +268,18 @@
         // mic audio into radio TX over the existing LAN/VPN path. Off by default.
         public bool AudioStreamingEnabled { get; set; } = false;
 
-        /// <summary>PortAudio capture device name for radio RX (USB recording). Empty = default input.</summary>
+        /// <summary>
+        /// PortAudio capture device for radio RX (USB recording). Empty = default input.
+        /// Stored as <c>{name} [{hostApi}]</c> (e.g. <c>Microphone (USB Audio CODEC) [Windows WASAPI]</c>)
+        /// so Windows duplicates across MME/WASAPI/DirectSound/WDM-KS stay distinct.
+        /// Legacy bare names still resolve.
+        /// </summary>
         public string? AudioRadioRxDevice { get; set; } = "";
 
-        /// <summary>PortAudio playback device name for radio TX (USB playback). Empty = default output.</summary>
+        /// <summary>
+        /// PortAudio playback device for radio TX (USB playback). Empty = default output.
+        /// Same <c>{name} [{hostApi}]</c> key format as <see cref="AudioRadioRxDevice"/>.
+        /// </summary>
         public string? AudioRadioTxDevice { get; set; } = "";
 
         public float AudioRxGain { get; set; } = 1.0f;

--- a/Models/ApplicationSettings.cs
+++ b/Models/ApplicationSettings.cs
@@ -20,6 +20,14 @@
         /// </summary>
         public bool AutoShutdownWhenNoBrowsers { get; set; } = true;
 
+        /// <summary>
+        /// When true (default), the host opens the default browser to the control
+        /// panel URL once after Kestrel starts. Set false to start quietly —
+        /// open the UI from the system tray / menu bar, or browse to the URL
+        /// yourself. Docker / containers always skip auto-open regardless.
+        /// </summary>
+        public bool OpenBrowserOnStartup { get; set; } = true;
+
         public string RadioModel { get; set; } = "FTdx101MP"; // MP = dual receiver, D = single receiver
 
 

--- a/Models/ApplicationSettings.cs
+++ b/Models/ApplicationSettings.cs
@@ -269,7 +269,8 @@
         public bool AudioStreamingEnabled { get; set; } = false;
 
         /// <summary>
-        /// PortAudio capture device for radio RX (USB recording). Empty = default input.
+        /// PortAudio capture device for radio RX (USB recording). Required when
+        /// <see cref="AudioStreamingEnabled"/> — no OS-default fallback (wrong mic).
         /// Stored as <c>{name} [{hostApi}]</c> (e.g. <c>Microphone (USB Audio CODEC) [Windows WASAPI]</c>)
         /// so Windows duplicates across MME/WASAPI/DirectSound/WDM-KS stay distinct.
         /// Legacy bare names still resolve.
@@ -277,8 +278,10 @@
         public string? AudioRadioRxDevice { get; set; } = "";
 
         /// <summary>
-        /// PortAudio playback device for radio TX (USB playback). Empty = default output.
-        /// Same <c>{name} [{hostApi}]</c> key format as <see cref="AudioRadioRxDevice"/>.
+        /// PortAudio playback device for radio TX (USB playback). Required when
+        /// <see cref="AudioStreamingEnabled"/> — blank must not fall back to PC
+        /// speakers (browser mic feedback). Same <c>{name} [{hostApi}]</c> key
+        /// format as <see cref="AudioRadioRxDevice"/>.
         /// </summary>
         public string? AudioRadioTxDevice { get; set; } = "";
 

--- a/Models/ApplicationSettings.cs
+++ b/Models/ApplicationSettings.cs
@@ -254,6 +254,31 @@
         // by name, so the chosen-device path renders the phrase to a WAV and
         // plays it via NAudio (see Services/Voice/AudioOutput.cs, VoiceTtsService).
         public string VoiceOutputDeviceName { get; set; } = "";
+
+        // ── Remote Audio (browser ↔ radio USB) ─────────────────────────────
+        // Opt-in Opus/PCM bridge so a remote browser can hear radio RX and send
+        // mic audio into radio TX over the existing LAN/VPN path. Off by default.
+        public bool AudioStreamingEnabled { get; set; } = false;
+
+        /// <summary>PortAudio capture device name for radio RX (USB recording). Empty = default input.</summary>
+        public string? AudioRadioRxDevice { get; set; } = "";
+
+        /// <summary>PortAudio playback device name for radio TX (USB playback). Empty = default output.</summary>
+        public string? AudioRadioTxDevice { get; set; } = "";
+
+        public float AudioRxGain { get; set; } = 1.0f;
+        public float AudioTxGain { get; set; } = 1.0f;
+
+        // ── Optional HTTPS (self-signed; restart to apply) ────────────────
+        // Required for getUserMedia from a remote browser (secure context).
+        public bool HttpsEnabled { get; set; } = false;
+        public int HttpsPort { get; set; } = 8443;
+
+        /// <summary>
+        /// Extra SAN hostnames/IPs (newline or comma separated) baked into the
+        /// self-signed cert — e.g. WireGuard IP or LAN hostname.
+        /// </summary>
+        public string? HttpsSanHosts { get; set; } = "";
     }
 
     public class RadioState

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -2216,14 +2216,14 @@
         import { FTdx101Meters }        from "/js/orchestrators/FTdx101Meters.js?v=1";
         import { SdrSpectrumPipeline }  from "/js/sdr/sdr-spectrum-pipeline.js?v=4";
         import { SpectrumPanel }        from "/js/sdr/spectrum-panel.js?v=5";
-        import { FilterScopePanel }    from "/js/ui/filter-scope-panel.js?v=2";
+        import { FilterScopePanel }    from "/js/ui/filter-scope-panel.js?v=3";
         import "/js/ui/if-width-tables.js?v=3";
         import { BAND_PLANS, BAND_EDGES, getSegments, segmentForHz, nearestBandForHz, loadBandPlanFromServer } from "/js/ui/band-plan.js?v=6";
         import { loadLabels }           from "/js/ui/a11y-labels.js?v=1";
         import { initFreqKeyboard }     from "/js/ui/freq-keyboard.js?v=14";
         import { initMemoriesPanel }   from "/js/ui/memories.js?v=10";
         import { DxSpotsPanel }         from "/js/ui/dx-spots-panel.js?v=1";
-        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=2";
+        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=3";
         window.bandPlanData = BAND_PLANS;
         window.getBandSegments = getSegments;
         window.getBandSegmentForHz = segmentForHz;

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -704,6 +704,13 @@
                             <i class="bi bi-headphones remote-audio-btn-icon" aria-hidden="true"></i>
                         </button>
                     </span>
+                    <label class="small text-muted mb-0" for="remoteAudioMicSelect">Mic</label>
+                    <select id="remoteAudioMicSelect" class="form-select form-select-sm"
+                            style="width:auto; max-width:16rem;"
+                            title="Browser microphone sent to the radio"
+                            aria-label="Browser microphone for remote audio TX">
+                        <option value="">Default microphone</option>
+                    </select>
                     <span class="small text-muted" id="remoteAudioStatus">Idle</span>
                     <div class="d-flex align-items-center gap-2 ms-auto" style="min-width:180px;">
                         <span class="small">RX</span>
@@ -2265,7 +2272,7 @@
         import { initFreqKeyboard }     from "/js/ui/freq-keyboard.js?v=14";
         import { initMemoriesPanel }   from "/js/ui/memories.js?v=10";
         import { DxSpotsPanel }         from "/js/ui/dx-spots-panel.js?v=1";
-        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=11";
+        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=12";
         window.bandPlanData = BAND_PLANS;
         window.getBandSegments = getSegments;
         window.getBandSegmentForHz = segmentForHz;

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -218,6 +218,20 @@
     #voiceHelpBody .vh-ex code { color: #ffd47a; background: #333; border-radius: 3px;
                                  padding: 1px 5px; margin-right: 4px; white-space: nowrap; }
 
+    #remoteAudioBar .remote-audio-icon-btn {
+        width: 2rem;
+        height: 2rem;
+        padding: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 1;
+    }
+    #remoteAudioBar .remote-audio-btn-icon {
+        font-size: 1rem;
+        line-height: 1;
+    }
+
     /* Voice PTT button — three visually distinct states so the operator can
        always tell whether it's listening:
          1. Rest / hover (armed, NOT listening) -> amber outline. Bootstrap
@@ -652,16 +666,44 @@
             <div class="card border-secondary">
                 <div class="card-body py-2 d-flex flex-wrap align-items-center gap-3">
                     <strong class="me-1"><i class="bi bi-soundwave" aria-hidden="true"></i> Remote Audio</strong>
-                    <button type="button" class="btn btn-sm btn-success" id="remoteAudioStartBtn">Start audio</button>
-                    <button type="button" class="btn btn-sm btn-outline-secondary" id="remoteAudioStopBtn" disabled>Stop</button>
-                    <div class="form-check form-switch mb-0">
-                        <input class="form-check-input" type="checkbox" id="remoteAudioMicMute" />
-                        <label class="form-check-label" for="remoteAudioMicMute">Mute mic</label>
-                    </div>
-                    <div class="form-check form-switch mb-0">
-                        <input class="form-check-input" type="checkbox" id="remoteAudioRxMute" />
-                        <label class="form-check-label" for="remoteAudioRxMute">Mute RX</label>
-                    </div>
+                    <span class="d-inline-block remote-audio-tip" data-bs-toggle="tooltip" data-bs-placement="top"
+                          data-bs-title="Connect to transceiver audio" aria-label="Connect to transceiver audio">
+                        <button type="button" class="btn btn-sm btn-success remote-audio-icon-btn" id="remoteAudioStartBtn"
+                                aria-label="Connect to transceiver audio">
+                            <i class="bi bi-telephone-fill remote-audio-btn-icon" aria-hidden="true"></i>
+                        </button>
+                    </span>
+                    <span class="d-inline-block remote-audio-tip" data-bs-toggle="tooltip" data-bs-placement="top"
+                          data-bs-title="Disconnect transceiver audio" aria-label="Disconnect transceiver audio">
+                        <button type="button" class="btn btn-sm btn-danger remote-audio-icon-btn" id="remoteAudioStopBtn" disabled
+                                aria-label="Disconnect transceiver audio">
+                            <i class="bi bi-telephone-x-fill remote-audio-btn-icon" aria-hidden="true"></i>
+                        </button>
+                    </span>
+                    <span class="d-inline-block remote-audio-tip" id="remoteAudioPopoutTip" data-bs-toggle="tooltip"
+                          data-bs-placement="top"
+                          data-bs-title="Popout audio, useful to navigate YWC without interrupting the audio stream"
+                          aria-label="Popout audio, useful to navigate YWC without interrupting the audio stream">
+                        <button type="button" class="btn btn-sm btn-outline-secondary remote-audio-icon-btn" id="remoteAudioPopoutBtn"
+                                aria-label="Popout audio, useful to navigate YWC without interrupting the audio stream">
+                            <i class="bi bi-window-plus remote-audio-btn-icon" aria-hidden="true"></i>
+                        </button>
+                    </span>
+                    <span class="d-inline-block remote-audio-tip" id="remoteAudioMicMuteTip" data-bs-toggle="tooltip"
+                          data-bs-placement="top" data-bs-title="Mute microphone" aria-label="Mute microphone">
+                        <button type="button" class="btn btn-sm btn-success remote-audio-icon-btn" id="remoteAudioMicMute"
+                                aria-pressed="false" aria-label="Mute microphone" disabled>
+                            <i class="bi bi-mic-fill remote-audio-btn-icon" aria-hidden="true"></i>
+                        </button>
+                    </span>
+                    <span class="d-inline-block remote-audio-tip" id="remoteAudioRxMuteTip" data-bs-toggle="tooltip"
+                          data-bs-placement="top" data-bs-title="Deafen — mute received audio"
+                          aria-label="Deafen — mute received audio">
+                        <button type="button" class="btn btn-sm btn-success remote-audio-icon-btn" id="remoteAudioRxMute"
+                                aria-pressed="false" aria-label="Deafen — mute received audio" disabled>
+                            <i class="bi bi-headphones remote-audio-btn-icon" aria-hidden="true"></i>
+                        </button>
+                    </span>
                     <span class="small text-muted" id="remoteAudioStatus">Idle</span>
                     <div class="d-flex align-items-center gap-2 ms-auto" style="min-width:180px;">
                         <span class="small">RX</span>
@@ -2223,7 +2265,7 @@
         import { initFreqKeyboard }     from "/js/ui/freq-keyboard.js?v=14";
         import { initMemoriesPanel }   from "/js/ui/memories.js?v=10";
         import { DxSpotsPanel }         from "/js/ui/dx-spots-panel.js?v=1";
-        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=3";
+        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=11";
         window.bandPlanData = BAND_PLANS;
         window.getBandSegments = getSegments;
         window.getBandSegmentForHz = segmentForHz;

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -2342,7 +2342,7 @@
         import { initFreqKeyboard }     from "/js/ui/freq-keyboard.js?v=14";
         import { initMemoriesPanel }   from "/js/ui/memories.js?v=10";
         import { DxSpotsPanel }         from "/js/ui/dx-spots-panel.js?v=1";
-        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=17";
+        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=21";
         window.bandPlanData = BAND_PLANS;
         window.getBandSegments = getSegments;
         window.getBandSegmentForHz = segmentForHz;

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -661,7 +661,7 @@
     </div>
 
     <!-- Remote Audio bar — visible when Settings → Remote Audio is enabled -->
-    <div id="remoteAudioBar" class="row mt-2" style="display:none;">
+    <div id="remoteAudioBar" class="row mt-2 mb-2" style="display:none;">
         <div class="col-12">
             <div class="card border-secondary">
                 <div class="card-body py-2 d-flex flex-wrap align-items-center gap-3">
@@ -704,20 +704,22 @@
                             <i class="bi bi-headphones remote-audio-btn-icon" aria-hidden="true"></i>
                         </button>
                     </span>
-                    <label class="small text-muted mb-0" for="remoteAudioMicSelect">Mic</label>
-                    <select id="remoteAudioMicSelect" class="form-select form-select-sm"
-                            style="width:auto; max-width:16rem;"
-                            title="Browser microphone sent to the radio"
-                            aria-label="Browser microphone for remote audio TX">
-                        <option value="">Default microphone</option>
-                    </select>
+                    <span class="d-inline-block remote-audio-tip" id="remoteAudioLevelsTip" data-bs-toggle="tooltip"
+                          data-bs-placement="top"
+                          data-bs-title="Browser microphone and software gain"
+                          aria-label="Browser microphone and software gain">
+                        <button type="button" class="btn btn-sm btn-outline-secondary" id="remoteAudioLevelsBtn"
+                                aria-label="Open mic and gain settings">
+                            <i class="bi bi-sliders remote-audio-btn-icon" aria-hidden="true"></i>&nbsp;Mic &amp; Gain
+                        </button>
+                    </span>
                     <span class="small text-muted" id="remoteAudioStatus">Idle</span>
                     <div class="d-flex align-items-center gap-2 ms-auto" style="min-width:180px;">
-                        <span class="small">RX</span>
+                        <span class="small" title="Radio → browser level">RX</span>
                         <div class="progress flex-grow-1" style="height:8px; width:80px;">
                             <div id="remoteAudioRxMeter" class="progress-bar bg-info" style="width:0%"></div>
                         </div>
-                        <span class="small">TX</span>
+                        <span class="small" title="Browser mic → radio level">TX</span>
                         <div class="progress flex-grow-1" style="height:8px; width:80px;">
                             <div id="remoteAudioTxMeter" class="progress-bar bg-warning" style="width:0%"></div>
                         </div>
@@ -2143,6 +2145,62 @@
     </div>
 </dialog>
 
+<!-- Remote Audio mic & gain — kept with other dialogs (late in DOM) and given a
+     high z-index so it is not painted under the spectrum / meter stacks. -->
+<dialog id="remoteAudioLevelsDialog"
+        style="border:1px solid #555; border-radius:8px; background:#222; color:#eee; padding:0; min-width:360px; max-width:460px;"
+        aria-labelledby="remoteAudioLevelsDialogTitle">
+    <div class="d-flex align-items-center justify-content-between px-3 py-2" style="border-bottom:1px solid #444;">
+        <strong id="remoteAudioLevelsDialogTitle">Mic &amp; Gain</strong>
+        <button type="button" class="btn btn-sm ywc-dialog-close"
+                onclick="document.getElementById('remoteAudioLevelsDialog').close()"
+                aria-label="Close mic and gain settings">✕</button>
+    </div>
+    <div class="p-3 d-flex flex-column gap-3">
+        <div>
+            <label class="mb-0 fw-semibold" for="remoteAudioMicSelect">Browser microphone</label>
+            <select id="remoteAudioMicSelect" class="form-select form-select-sm mt-1"
+                    title="Browser microphone sent to the radio (TX)"
+                    aria-label="Browser microphone for remote audio TX">
+                <option value="">Default microphone</option>
+            </select>
+            <div class="form-text text-muted mt-1 mb-0">
+                Which mic on <strong>this computer/browser</strong> is sent to the radio over remote audio.
+                Device names appear after the first time you grant microphone permission.
+            </div>
+        </div>
+        <div>
+            <div class="d-flex align-items-center justify-content-between gap-2 mb-1">
+                <label class="mb-0 fw-semibold" for="remoteAudioRxGain">Receive (RX) gain</label>
+                <span id="remoteAudioRxGainVal" class="fw-semibold text-info">1.00</span>
+            </div>
+            <input type="range" class="w-100" id="remoteAudioRxGain"
+                   min="0.05" max="4" step="0.05" value="1"
+                   style="height:18px;"
+                   aria-label="Receive gain — radio to browser"
+                   title="How loud the radio sounds in your browser">
+            <div class="form-text text-muted mt-1 mb-0">
+                How loud the <strong>radio</strong> sounds in your <strong>browser speakers/headphones</strong>.
+            </div>
+        </div>
+        <div>
+            <div class="d-flex align-items-center justify-content-between gap-2 mb-1">
+                <label class="mb-0 fw-semibold" for="remoteAudioTxGain">Mic (TX) gain</label>
+                <span id="remoteAudioTxGainVal" class="fw-semibold text-warning">1.00</span>
+            </div>
+            <input type="range" class="w-100" id="remoteAudioTxGain"
+                   min="0.05" max="4" step="0.05" value="1"
+                   style="height:18px;"
+                   aria-label="Mic gain — browser microphone to radio"
+                   title="How loud your browser mic is sent to the radio">
+            <div class="form-text text-muted mt-1 mb-0">
+                How loud your <strong>browser microphone</strong> is sent into the <strong>radio</strong> (USB TX).
+            </div>
+        </div>
+        <p class="small text-muted mb-0">Gain range 0.05–4.00 (1.00 = unity). Changes apply live while streaming and are saved automatically.</p>
+    </div>
+</dialog>
+
 <!-- UTC clock info popover — opened by clicking the top-bar clock.
      Explains the clock source, what depends on it, and how to verify
      the PC's time-sync state. -->
@@ -2272,7 +2330,7 @@
         import { initFreqKeyboard }     from "/js/ui/freq-keyboard.js?v=14";
         import { initMemoriesPanel }   from "/js/ui/memories.js?v=10";
         import { DxSpotsPanel }         from "/js/ui/dx-spots-panel.js?v=1";
-        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=12";
+        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=15";
         window.bandPlanData = BAND_PLANS;
         window.getBandSegments = getSegments;
         window.getBandSegmentForHz = segmentForHz;
@@ -3442,7 +3500,7 @@
             }, { passive: true });
         }
 
-        ['voxDialog', 'cwDialog', 'fmDialog', 'dxWatchDialog', 'voiceDialog', 'voiceHelpDialog', 'audioFilterDialogA', 'audioFilterDialogB', 'utcClockInfoDialog'].forEach(id => {
+        ['voxDialog', 'cwDialog', 'fmDialog', 'dxWatchDialog', 'voiceDialog', 'voiceHelpDialog', 'audioFilterDialogA', 'audioFilterDialogB', 'utcClockInfoDialog', 'remoteAudioLevelsDialog'].forEach(id => {
             const dlg = document.getElementById(id);
             if (!dlg) return;
             makeDraggable(dlg, dlg.querySelector('div'));

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -646,6 +646,38 @@
         </div>
     </div>
 
+    <!-- Remote Audio bar — visible when Settings → Remote Audio is enabled -->
+    <div id="remoteAudioBar" class="row mt-2" style="display:none;">
+        <div class="col-12">
+            <div class="card border-secondary">
+                <div class="card-body py-2 d-flex flex-wrap align-items-center gap-3">
+                    <strong class="me-1"><i class="bi bi-soundwave" aria-hidden="true"></i> Remote Audio</strong>
+                    <button type="button" class="btn btn-sm btn-success" id="remoteAudioStartBtn">Start audio</button>
+                    <button type="button" class="btn btn-sm btn-outline-secondary" id="remoteAudioStopBtn" disabled>Stop</button>
+                    <div class="form-check form-switch mb-0">
+                        <input class="form-check-input" type="checkbox" id="remoteAudioMicMute" />
+                        <label class="form-check-label" for="remoteAudioMicMute">Mute mic</label>
+                    </div>
+                    <div class="form-check form-switch mb-0">
+                        <input class="form-check-input" type="checkbox" id="remoteAudioRxMute" />
+                        <label class="form-check-label" for="remoteAudioRxMute">Mute RX</label>
+                    </div>
+                    <span class="small text-muted" id="remoteAudioStatus">Idle</span>
+                    <div class="d-flex align-items-center gap-2 ms-auto" style="min-width:180px;">
+                        <span class="small">RX</span>
+                        <div class="progress flex-grow-1" style="height:8px; width:80px;">
+                            <div id="remoteAudioRxMeter" class="progress-bar bg-info" style="width:0%"></div>
+                        </div>
+                        <span class="small">TX</span>
+                        <div class="progress flex-grow-1" style="height:8px; width:80px;">
+                            <div id="remoteAudioTxMeter" class="progress-bar bg-warning" style="width:0%"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Spectrum Display — dual-VFO layout (v2.3.0+).
          Each panel has its own canvas. Mono A / Mono B / Multi toggle below
          hides/shows individual panels. Outer container hides itself when no
@@ -2191,6 +2223,7 @@
         import { initFreqKeyboard }     from "/js/ui/freq-keyboard.js?v=14";
         import { initMemoriesPanel }   from "/js/ui/memories.js?v=10";
         import { DxSpotsPanel }         from "/js/ui/dx-spots-panel.js?v=1";
+        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=1";
         window.bandPlanData = BAND_PLANS;
         window.getBandSegments = getSegments;
         window.getBandSegmentForHz = segmentForHz;
@@ -2215,6 +2248,7 @@
         });
 
         loadLabels();
+        initRemoteAudioUi();
         // loadLabels() rewrites every title from labels.json on each focus,
         // wiping the "out of band" title suffix; restore it once that has run.
         window.addEventListener('focus', async () => {

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -2223,7 +2223,7 @@
         import { initFreqKeyboard }     from "/js/ui/freq-keyboard.js?v=14";
         import { initMemoriesPanel }   from "/js/ui/memories.js?v=10";
         import { DxSpotsPanel }         from "/js/ui/dx-spots-panel.js?v=1";
-        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=1";
+        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=2";
         window.bandPlanData = BAND_PLANS;
         window.getBandSegments = getSegments;
         window.getBandSegmentForHz = segmentForHz;

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -2172,13 +2172,13 @@
         <div>
             <label class="mb-0 fw-semibold" for="remoteAudioCodecSelect">Audio codec</label>
             <select id="remoteAudioCodecSelect" class="form-select form-select-sm mt-1"
-                    title="Compression used for remote audio (applies on next Start)"
+                    title="Compression used for remote audio (stop and reconnect to apply)"
                     aria-label="Remote audio codec">
                 <option value="opus">Opus (~32 kb/s) — recommended</option>
                 <option value="pcm16">PCM16 (~768 kb/s) — uncompressed</option>
             </select>
             <div class="form-text text-muted mt-1 mb-0" id="remoteAudioCodecHint">
-                Opus uses far less bandwidth than PCM16. Takes effect on the next Start.
+                Opus uses far less bandwidth than PCM16. Stop and reconnect remote audio for a codec change to apply.
             </div>
         </div>
         <div>

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -2342,7 +2342,7 @@
         import { initFreqKeyboard }     from "/js/ui/freq-keyboard.js?v=14";
         import { initMemoriesPanel }   from "/js/ui/memories.js?v=10";
         import { DxSpotsPanel }         from "/js/ui/dx-spots-panel.js?v=1";
-        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=21";
+        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=22";
         window.bandPlanData = BAND_PLANS;
         window.getBandSegments = getSegments;
         window.getBandSegmentForHz = segmentForHz;

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -2170,6 +2170,18 @@
             </div>
         </div>
         <div>
+            <label class="mb-0 fw-semibold" for="remoteAudioCodecSelect">Audio codec</label>
+            <select id="remoteAudioCodecSelect" class="form-select form-select-sm mt-1"
+                    title="Compression used for remote audio (applies on next Start)"
+                    aria-label="Remote audio codec">
+                <option value="opus">Opus (~32 kb/s) — recommended</option>
+                <option value="pcm16">PCM16 (~768 kb/s) — uncompressed</option>
+            </select>
+            <div class="form-text text-muted mt-1 mb-0" id="remoteAudioCodecHint">
+                Opus uses far less bandwidth than PCM16. Takes effect on the next Start.
+            </div>
+        </div>
+        <div>
             <div class="d-flex align-items-center justify-content-between gap-2 mb-1">
                 <label class="mb-0 fw-semibold" for="remoteAudioRxGain">Receive (RX) gain</label>
                 <span id="remoteAudioRxGainVal" class="fw-semibold text-info">1.00</span>
@@ -2330,7 +2342,7 @@
         import { initFreqKeyboard }     from "/js/ui/freq-keyboard.js?v=14";
         import { initMemoriesPanel }   from "/js/ui/memories.js?v=10";
         import { DxSpotsPanel }         from "/js/ui/dx-spots-panel.js?v=1";
-        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=15";
+        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=17";
         window.bandPlanData = BAND_PLANS;
         window.getBandSegments = getSegments;
         window.getBandSegmentForHz = segmentForHz;

--- a/Pages/RemoteAudio.cshtml
+++ b/Pages/RemoteAudio.cshtml
@@ -74,6 +74,16 @@
                             <i class="bi bi-headphones remote-audio-btn-icon" aria-hidden="true"></i>
                         </button>
                     </span>
+                    <span class="d-inline-block remote-audio-tip" id="remoteAudioTxTip" data-bs-toggle="tooltip"
+                          data-bs-placement="top" data-bs-title="Toggle transmit (PTT)"
+                          aria-label="Toggle transmit (PTT)">
+                        <button type="button" class="btn btn-sm btn-warning" id="remoteAudioTxBtn"
+                                aria-pressed="false" aria-label="Toggle transmit">
+                            <i class="bi bi-broadcast" aria-hidden="true"></i> TX
+                        </button>
+                    </span>
+                    <span class="badge text-bg-secondary" id="remoteAudioTxVfo"
+                          title="VFO that will transmit" aria-live="polite">VFO A</span>
                     <span class="small text-muted" id="remoteAudioStatus">Idle</span>
                     <div class="d-flex align-items-center gap-2 ms-auto" style="min-width:180px;">
                         <span class="small" title="Radio → browser level">RX</span>
@@ -139,8 +149,11 @@
         </div>
     </div>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.js"></script>
+    <script>
+        window.ywcTxToggleKey = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.TxToggleKey));
+    </script>
     <script type="module">
-        import { initRemoteAudioPopout } from "/js/audio/remote-audio-ui.js?v=17";
+        import { initRemoteAudioPopout } from "/js/audio/remote-audio-ui.js?v=21";
         initRemoteAudioPopout();
     </script>
 </body>

--- a/Pages/RemoteAudio.cshtml
+++ b/Pages/RemoteAudio.cshtml
@@ -101,14 +101,14 @@
                         <label class="mb-0 text-nowrap" for="remoteAudioCodecSelect" style="min-width:11rem;">Audio codec</label>
                         <select id="remoteAudioCodecSelect" class="form-select form-select-sm flex-grow-1"
                                 style="min-width:12rem; max-width:24rem;"
-                                title="Compression used for remote audio (applies on next Start)"
+                                title="Compression used for remote audio (stop and reconnect to apply)"
                                 aria-label="Remote audio codec">
                             <option value="opus">Opus (~32 kb/s) — recommended</option>
                             <option value="pcm16">PCM16 (~768 kb/s) — uncompressed</option>
                         </select>
                     </div>
                     <div class="small text-muted" id="remoteAudioCodecHint">
-                        Opus uses far less bandwidth than PCM16. Takes effect on the next Start.
+                        Opus uses far less bandwidth than PCM16. Stop and reconnect remote audio for a codec change to apply.
                     </div>
                     <div class="d-flex align-items-center gap-2 flex-wrap">
                         <label class="mb-0 text-nowrap" for="remoteAudioRxGain" style="min-width:11rem;">

--- a/Pages/RemoteAudio.cshtml
+++ b/Pages/RemoteAudio.cshtml
@@ -159,7 +159,7 @@
         window.ywcTxToggleKey = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.TxToggleKey));
     </script>
     <script type="module">
-        import { initRemoteAudioPopout } from "/js/audio/remote-audio-ui.js?v=21";
+        import { initRemoteAudioPopout } from "/js/audio/remote-audio-ui.js?v=22";
         initRemoteAudioPopout();
     </script>
 </body>

--- a/Pages/RemoteAudio.cshtml
+++ b/Pages/RemoteAudio.cshtml
@@ -36,67 +36,98 @@
             font-size: 1rem;
             line-height: 1;
         }
+        .remote-audio-gain-row label { color: #ddd; }
     </style>
 </head>
 <body>
     <div class="remote-audio-popout" id="remoteAudioBar">
         <div class="card border-secondary">
-            <div class="card-body py-2 d-flex flex-wrap align-items-center gap-3">
-                <strong class="me-1"><i class="bi bi-soundwave" aria-hidden="true"></i> Remote Audio</strong>
-                <span class="d-inline-block remote-audio-tip" data-bs-toggle="tooltip" data-bs-placement="top"
-                      data-bs-title="Connect to transceiver audio" aria-label="Connect to transceiver audio">
-                    <button type="button" class="btn btn-sm btn-success remote-audio-icon-btn" id="remoteAudioStartBtn"
-                            aria-label="Connect to transceiver audio">
-                        <i class="bi bi-telephone-fill remote-audio-btn-icon" aria-hidden="true"></i>
-                    </button>
-                </span>
-                <span class="d-inline-block remote-audio-tip" data-bs-toggle="tooltip" data-bs-placement="top"
-                      data-bs-title="Disconnect transceiver audio" aria-label="Disconnect transceiver audio">
-                    <button type="button" class="btn btn-sm btn-danger remote-audio-icon-btn" id="remoteAudioStopBtn" disabled
-                            aria-label="Disconnect transceiver audio">
-                        <i class="bi bi-telephone-x-fill remote-audio-btn-icon" aria-hidden="true"></i>
-                    </button>
-                </span>
-                <span class="d-inline-block remote-audio-tip" id="remoteAudioMicMuteTip" data-bs-toggle="tooltip"
-                      data-bs-placement="top" data-bs-title="Mute microphone" aria-label="Mute microphone">
-                    <button type="button" class="btn btn-sm btn-success remote-audio-icon-btn" id="remoteAudioMicMute"
-                            aria-pressed="false" aria-label="Mute microphone" disabled>
-                        <i class="bi bi-mic-fill remote-audio-btn-icon" aria-hidden="true"></i>
-                    </button>
-                </span>
-                <span class="d-inline-block remote-audio-tip" id="remoteAudioRxMuteTip" data-bs-toggle="tooltip"
-                      data-bs-placement="top" data-bs-title="Deafen — mute received audio"
-                      aria-label="Deafen — mute received audio">
-                    <button type="button" class="btn btn-sm btn-success remote-audio-icon-btn" id="remoteAudioRxMute"
-                            aria-pressed="false" aria-label="Deafen — mute received audio" disabled>
-                        <i class="bi bi-headphones remote-audio-btn-icon" aria-hidden="true"></i>
-                    </button>
-                </span>
-                <label class="small text-muted mb-0" for="remoteAudioMicSelect">Mic</label>
-                <select id="remoteAudioMicSelect" class="form-select form-select-sm"
-                        style="width:auto; max-width:14rem;"
-                        title="Browser microphone sent to the radio"
-                        aria-label="Browser microphone for remote audio TX">
-                    <option value="">Default microphone</option>
-                </select>
-                <span class="small text-muted" id="remoteAudioStatus">Idle</span>
-                <div class="d-flex align-items-center gap-2 ms-auto" style="min-width:180px;">
-                    <span class="small">RX</span>
-                    <div class="progress flex-grow-1" style="height:8px; width:80px;">
-                        <div id="remoteAudioRxMeter" class="progress-bar bg-info" style="width:0%"></div>
+            <div class="card-body py-2 d-flex flex-column gap-2">
+                <div class="d-flex flex-wrap align-items-center gap-3">
+                    <strong class="me-1"><i class="bi bi-soundwave" aria-hidden="true"></i> Remote Audio</strong>
+                    <span class="d-inline-block remote-audio-tip" data-bs-toggle="tooltip" data-bs-placement="top"
+                          data-bs-title="Connect to transceiver audio" aria-label="Connect to transceiver audio">
+                        <button type="button" class="btn btn-sm btn-success remote-audio-icon-btn" id="remoteAudioStartBtn"
+                                aria-label="Connect to transceiver audio">
+                            <i class="bi bi-telephone-fill remote-audio-btn-icon" aria-hidden="true"></i>
+                        </button>
+                    </span>
+                    <span class="d-inline-block remote-audio-tip" data-bs-toggle="tooltip" data-bs-placement="top"
+                          data-bs-title="Disconnect transceiver audio" aria-label="Disconnect transceiver audio">
+                        <button type="button" class="btn btn-sm btn-danger remote-audio-icon-btn" id="remoteAudioStopBtn" disabled
+                                aria-label="Disconnect transceiver audio">
+                            <i class="bi bi-telephone-x-fill remote-audio-btn-icon" aria-hidden="true"></i>
+                        </button>
+                    </span>
+                    <span class="d-inline-block remote-audio-tip" id="remoteAudioMicMuteTip" data-bs-toggle="tooltip"
+                          data-bs-placement="top" data-bs-title="Mute microphone" aria-label="Mute microphone">
+                        <button type="button" class="btn btn-sm btn-success remote-audio-icon-btn" id="remoteAudioMicMute"
+                                aria-pressed="false" aria-label="Mute microphone" disabled>
+                            <i class="bi bi-mic-fill remote-audio-btn-icon" aria-hidden="true"></i>
+                        </button>
+                    </span>
+                    <span class="d-inline-block remote-audio-tip" id="remoteAudioRxMuteTip" data-bs-toggle="tooltip"
+                          data-bs-placement="top" data-bs-title="Deafen — mute received audio"
+                          aria-label="Deafen — mute received audio">
+                        <button type="button" class="btn btn-sm btn-success remote-audio-icon-btn" id="remoteAudioRxMute"
+                                aria-pressed="false" aria-label="Deafen — mute received audio" disabled>
+                            <i class="bi bi-headphones remote-audio-btn-icon" aria-hidden="true"></i>
+                        </button>
+                    </span>
+                    <span class="small text-muted" id="remoteAudioStatus">Idle</span>
+                    <div class="d-flex align-items-center gap-2 ms-auto" style="min-width:180px;">
+                        <span class="small" title="Radio → browser level">RX</span>
+                        <div class="progress flex-grow-1" style="height:8px; width:80px;">
+                            <div id="remoteAudioRxMeter" class="progress-bar bg-info" style="width:0%"></div>
+                        </div>
+                        <span class="small" title="Browser mic → radio level">TX</span>
+                        <div class="progress flex-grow-1" style="height:8px; width:80px;">
+                            <div id="remoteAudioTxMeter" class="progress-bar bg-warning" style="width:0%"></div>
+                        </div>
                     </div>
-                    <span class="small">TX</span>
-                    <div class="progress flex-grow-1" style="height:8px; width:80px;">
-                        <div id="remoteAudioTxMeter" class="progress-bar bg-warning" style="width:0%"></div>
+                    <button type="button" class="btn btn-sm btn-outline-light" id="remoteAudioCloseBtn" title="Close this window">Close</button>
+                </div>
+                <div class="remote-audio-gain-row d-flex flex-column gap-2 pt-1 border-top border-secondary">
+                    <div class="d-flex align-items-center gap-2 flex-wrap">
+                        <label class="mb-0 text-nowrap" for="remoteAudioMicSelect" style="min-width:11rem;">Browser microphone</label>
+                        <select id="remoteAudioMicSelect" class="form-select form-select-sm flex-grow-1"
+                                style="min-width:12rem; max-width:24rem;"
+                                title="Browser microphone sent to the radio (TX)"
+                                aria-label="Browser microphone for remote audio TX">
+                            <option value="">Default microphone</option>
+                        </select>
+                    </div>
+                    <div class="d-flex align-items-center gap-2 flex-wrap">
+                        <label class="mb-0 text-nowrap" for="remoteAudioRxGain" style="min-width:11rem;">
+                            Receive (RX) gain
+                            <span id="remoteAudioRxGainVal" class="fw-semibold text-info">1.00</span>
+                        </label>
+                        <input type="range" class="flex-grow-1" id="remoteAudioRxGain"
+                               min="0.05" max="4" step="0.05" value="1"
+                               style="min-width:120px; height:18px;"
+                               aria-label="Receive gain — radio to browser"
+                               title="How loud the radio sounds in your browser">
+                        <span class="small text-muted">Radio → browser</span>
+                    </div>
+                    <div class="d-flex align-items-center gap-2 flex-wrap">
+                        <label class="mb-0 text-nowrap" for="remoteAudioTxGain" style="min-width:11rem;">
+                            Mic (TX) gain
+                            <span id="remoteAudioTxGainVal" class="fw-semibold text-warning">1.00</span>
+                        </label>
+                        <input type="range" class="flex-grow-1" id="remoteAudioTxGain"
+                               min="0.05" max="4" step="0.05" value="1"
+                               style="min-width:120px; height:18px;"
+                               aria-label="Mic gain — browser microphone to radio"
+                               title="How loud your browser mic is sent to the radio">
+                        <span class="small text-muted">Browser mic → radio</span>
                     </div>
                 </div>
-                <button type="button" class="btn btn-sm btn-outline-light" id="remoteAudioCloseBtn" title="Close this window">Close</button>
             </div>
         </div>
     </div>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.js"></script>
     <script type="module">
-        import { initRemoteAudioPopout } from "/js/audio/remote-audio-ui.js?v=12";
+        import { initRemoteAudioPopout } from "/js/audio/remote-audio-ui.js?v=15";
         initRemoteAudioPopout();
     </script>
 </body>

--- a/Pages/RemoteAudio.cshtml
+++ b/Pages/RemoteAudio.cshtml
@@ -20,9 +20,15 @@
         .remote-audio-popout .card {
             background: #22262b;
             border-color: #444;
+            color: #e8e8e8;
         }
         .remote-audio-popout .form-check-label { color: #ddd; }
         .remote-audio-popout .text-muted { color: #9aa0a6 !important; }
+        .remote-audio-popout .remote-audio-meter-label {
+            color: #9aa0a6;
+            font-size: 0.7rem;
+            line-height: 1;
+        }
         #remoteAudioBar .remote-audio-icon-btn {
             width: 2rem;
             height: 2rem;
@@ -86,11 +92,11 @@
                           title="VFO that will transmit" aria-live="polite">VFO A</span>
                     <span class="small text-muted" id="remoteAudioStatus">Idle</span>
                     <div class="d-flex align-items-center gap-2 ms-auto" style="min-width:180px;">
-                        <span class="small" title="Radio → browser level">RX</span>
+                        <span class="remote-audio-meter-label" title="Radio → browser level">RX</span>
                         <div class="progress flex-grow-1" style="height:8px; width:80px;">
                             <div id="remoteAudioRxMeter" class="progress-bar bg-info" style="width:0%"></div>
                         </div>
-                        <span class="small" title="Browser mic → radio level">TX</span>
+                        <span class="remote-audio-meter-label" title="Browser mic → radio level">TX</span>
                         <div class="progress flex-grow-1" style="height:8px; width:80px;">
                             <div id="remoteAudioTxMeter" class="progress-bar bg-warning" style="width:0%"></div>
                         </div>

--- a/Pages/RemoteAudio.cshtml
+++ b/Pages/RemoteAudio.cshtml
@@ -72,6 +72,13 @@
                         <i class="bi bi-headphones remote-audio-btn-icon" aria-hidden="true"></i>
                     </button>
                 </span>
+                <label class="small text-muted mb-0" for="remoteAudioMicSelect">Mic</label>
+                <select id="remoteAudioMicSelect" class="form-select form-select-sm"
+                        style="width:auto; max-width:14rem;"
+                        title="Browser microphone sent to the radio"
+                        aria-label="Browser microphone for remote audio TX">
+                    <option value="">Default microphone</option>
+                </select>
                 <span class="small text-muted" id="remoteAudioStatus">Idle</span>
                 <div class="d-flex align-items-center gap-2 ms-auto" style="min-width:180px;">
                     <span class="small">RX</span>
@@ -89,7 +96,7 @@
     </div>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.js"></script>
     <script type="module">
-        import { initRemoteAudioPopout } from "/js/audio/remote-audio-ui.js?v=11";
+        import { initRemoteAudioPopout } from "/js/audio/remote-audio-ui.js?v=12";
         initRemoteAudioPopout();
     </script>
 </body>

--- a/Pages/RemoteAudio.cshtml
+++ b/Pages/RemoteAudio.cshtml
@@ -1,0 +1,96 @@
+@page
+@model Yaesu_Web_Control.Pages.RemoteAudioModel
+@{
+    Layout = null;
+    ViewData["Title"] = "Remote Audio";
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="x-app-version" content="@Yaesu_Web_Control.AppVersion.Current">
+    <title>Remote Audio - Yaesu Web Control</title>
+    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/lib/bootstrap-icons/font/bootstrap-icons.min.css" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <style>
+        body { margin: 0; background: #1a1d21; color: #e8e8e8; }
+        .remote-audio-popout { padding: 12px 14px; }
+        .remote-audio-popout .card {
+            background: #22262b;
+            border-color: #444;
+        }
+        .remote-audio-popout .form-check-label { color: #ddd; }
+        .remote-audio-popout .text-muted { color: #9aa0a6 !important; }
+        #remoteAudioBar .remote-audio-icon-btn {
+            width: 2rem;
+            height: 2rem;
+            padding: 0;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            line-height: 1;
+        }
+        #remoteAudioBar .remote-audio-btn-icon {
+            font-size: 1rem;
+            line-height: 1;
+        }
+    </style>
+</head>
+<body>
+    <div class="remote-audio-popout" id="remoteAudioBar">
+        <div class="card border-secondary">
+            <div class="card-body py-2 d-flex flex-wrap align-items-center gap-3">
+                <strong class="me-1"><i class="bi bi-soundwave" aria-hidden="true"></i> Remote Audio</strong>
+                <span class="d-inline-block remote-audio-tip" data-bs-toggle="tooltip" data-bs-placement="top"
+                      data-bs-title="Connect to transceiver audio" aria-label="Connect to transceiver audio">
+                    <button type="button" class="btn btn-sm btn-success remote-audio-icon-btn" id="remoteAudioStartBtn"
+                            aria-label="Connect to transceiver audio">
+                        <i class="bi bi-telephone-fill remote-audio-btn-icon" aria-hidden="true"></i>
+                    </button>
+                </span>
+                <span class="d-inline-block remote-audio-tip" data-bs-toggle="tooltip" data-bs-placement="top"
+                      data-bs-title="Disconnect transceiver audio" aria-label="Disconnect transceiver audio">
+                    <button type="button" class="btn btn-sm btn-danger remote-audio-icon-btn" id="remoteAudioStopBtn" disabled
+                            aria-label="Disconnect transceiver audio">
+                        <i class="bi bi-telephone-x-fill remote-audio-btn-icon" aria-hidden="true"></i>
+                    </button>
+                </span>
+                <span class="d-inline-block remote-audio-tip" id="remoteAudioMicMuteTip" data-bs-toggle="tooltip"
+                      data-bs-placement="top" data-bs-title="Mute microphone" aria-label="Mute microphone">
+                    <button type="button" class="btn btn-sm btn-success remote-audio-icon-btn" id="remoteAudioMicMute"
+                            aria-pressed="false" aria-label="Mute microphone" disabled>
+                        <i class="bi bi-mic-fill remote-audio-btn-icon" aria-hidden="true"></i>
+                    </button>
+                </span>
+                <span class="d-inline-block remote-audio-tip" id="remoteAudioRxMuteTip" data-bs-toggle="tooltip"
+                      data-bs-placement="top" data-bs-title="Deafen — mute received audio"
+                      aria-label="Deafen — mute received audio">
+                    <button type="button" class="btn btn-sm btn-success remote-audio-icon-btn" id="remoteAudioRxMute"
+                            aria-pressed="false" aria-label="Deafen — mute received audio" disabled>
+                        <i class="bi bi-headphones remote-audio-btn-icon" aria-hidden="true"></i>
+                    </button>
+                </span>
+                <span class="small text-muted" id="remoteAudioStatus">Idle</span>
+                <div class="d-flex align-items-center gap-2 ms-auto" style="min-width:180px;">
+                    <span class="small">RX</span>
+                    <div class="progress flex-grow-1" style="height:8px; width:80px;">
+                        <div id="remoteAudioRxMeter" class="progress-bar bg-info" style="width:0%"></div>
+                    </div>
+                    <span class="small">TX</span>
+                    <div class="progress flex-grow-1" style="height:8px; width:80px;">
+                        <div id="remoteAudioTxMeter" class="progress-bar bg-warning" style="width:0%"></div>
+                    </div>
+                </div>
+                <button type="button" class="btn btn-sm btn-outline-light" id="remoteAudioCloseBtn" title="Close this window">Close</button>
+            </div>
+        </div>
+    </div>
+    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.js"></script>
+    <script type="module">
+        import { initRemoteAudioPopout } from "/js/audio/remote-audio-ui.js?v=11";
+        initRemoteAudioPopout();
+    </script>
+</body>
+</html>

--- a/Pages/RemoteAudio.cshtml
+++ b/Pages/RemoteAudio.cshtml
@@ -98,6 +98,19 @@
                         </select>
                     </div>
                     <div class="d-flex align-items-center gap-2 flex-wrap">
+                        <label class="mb-0 text-nowrap" for="remoteAudioCodecSelect" style="min-width:11rem;">Audio codec</label>
+                        <select id="remoteAudioCodecSelect" class="form-select form-select-sm flex-grow-1"
+                                style="min-width:12rem; max-width:24rem;"
+                                title="Compression used for remote audio (applies on next Start)"
+                                aria-label="Remote audio codec">
+                            <option value="opus">Opus (~32 kb/s) — recommended</option>
+                            <option value="pcm16">PCM16 (~768 kb/s) — uncompressed</option>
+                        </select>
+                    </div>
+                    <div class="small text-muted" id="remoteAudioCodecHint">
+                        Opus uses far less bandwidth than PCM16. Takes effect on the next Start.
+                    </div>
+                    <div class="d-flex align-items-center gap-2 flex-wrap">
                         <label class="mb-0 text-nowrap" for="remoteAudioRxGain" style="min-width:11rem;">
                             Receive (RX) gain
                             <span id="remoteAudioRxGainVal" class="fw-semibold text-info">1.00</span>
@@ -127,7 +140,7 @@
     </div>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.js"></script>
     <script type="module">
-        import { initRemoteAudioPopout } from "/js/audio/remote-audio-ui.js?v=15";
+        import { initRemoteAudioPopout } from "/js/audio/remote-audio-ui.js?v=17";
         initRemoteAudioPopout();
     </script>
 </body>

--- a/Pages/RemoteAudio.cshtml.cs
+++ b/Pages/RemoteAudio.cshtml.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Yaesu_Web_Control.Pages
+{
+    /// <summary>
+    /// Compact pop-out host for the Remote Audio WebSocket session so Index
+    /// navigation (e.g. Settings) does not tear down RX/TX audio.
+    /// </summary>
+    public class RemoteAudioModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Pages/RemoteAudio.cshtml.cs
+++ b/Pages/RemoteAudio.cshtml.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Yaesu_Web_Control.Services;
 
 namespace Yaesu_Web_Control.Pages
 {
@@ -8,8 +9,21 @@ namespace Yaesu_Web_Control.Pages
     /// </summary>
     public class RemoteAudioModel : PageModel
     {
-        public void OnGet()
+        private readonly ISettingsService _settingsService;
+
+        public RemoteAudioModel(ISettingsService settingsService)
         {
+            _settingsService = settingsService;
+        }
+
+        /// <summary>Same TX shortcut as Home (<c>window.ywcTxToggleKey</c>). Empty = disabled.</summary>
+        public string TxToggleKey { get; set; } = string.Empty;
+
+        public async Task OnGetAsync()
+        {
+            var settings = await _settingsService.GetSettingsAsync();
+            // Match Index: HTML cannot round-trip a lone space — Settings stores Space as "Space".
+            TxToggleKey = settings.TxToggleKey == " " ? "Space" : (settings.TxToggleKey ?? string.Empty);
         }
     }
 }

--- a/Pages/Settings.cshtml
+++ b/Pages/Settings.cshtml
@@ -1842,21 +1842,36 @@
                         </div>
                         <div class="mb-3">
                             <label asp-for="Settings.SerialPort" class="form-label">Serial Port</label>
+                            <div class="input-group">
+                                <select asp-for="Settings.SerialPort" class="form-select" id="Settings_SerialPort"
+                                        data-selected="@Model.Settings.SerialPort" required>
+                                    @if (!string.IsNullOrWhiteSpace(Model.Settings.SerialPort))
+                                    {
+                                        <option value="@Model.Settings.SerialPort" selected>@Model.Settings.SerialPort</option>
+                                    }
+                                    else
+                                    {
+                                        <option value="">Loading ports…</option>
+                                    }
+                                </select>
+                                <button type="button" class="btn btn-outline-secondary" id="btnRefreshSerialPorts"
+                                        title="Refresh port list">
+                                    <i class="bi bi-arrow-clockwise" aria-hidden="true"></i>
+                                    <span class="visually-hidden">Refresh</span>
+                                </button>
+                            </div>
                             @if (Model.IsWindowsHost)
                             {
-                                <input asp-for="Settings.SerialPort" class="form-control" placeholder="COM3" required />
                                 <div class="form-text">
-                                    Enter the COM port where your radio is connected (e.g., COM3, COM4).
-                                    <br /><strong>Tip:</strong> Check Device Manager to find the correct port.
+                                    Choose the radio's <strong>Enhanced</strong> (CAT) COM port — not Standard / TX-control if two appear.
+                                    Use Refresh if you just plugged the radio in.
                                 </div>
                             }
                             else
                             {
-                                <input asp-for="Settings.SerialPort" class="form-control" placeholder="/dev/cu.usbserial-…" required />
                                 <div class="form-text">
-                                    Enter the serial device path (e.g. <code>/dev/cu.usbserial-XXXX</code> or <code>/dev/cu.usbmodem…</code>).
-                                    Prefer <code>cu.*</code> over <code>tty.*</code> on macOS.
-                                    <br /><strong>Tip:</strong> Run <code>ls /dev/cu.*</code> in Terminal, or check Diagnostics → Ports.
+                                    Choose the radio's CAT serial device. Prefer <code>cu.*</code> over <code>tty.*</code> on macOS.
+                                    Use Refresh if you just plugged the radio in.
                                 </div>
                             }
                             <span asp-validation-for="Settings.SerialPort" class="text-danger"></span>
@@ -2661,6 +2676,72 @@
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
+    <script>
+        // Serial port dropdown — same /api/ports source as Diagnostics
+        (function () {
+            async function loadSerialPorts() {
+                const sel = document.getElementById('Settings_SerialPort');
+                if (!sel) return;
+                const selected = sel.getAttribute('data-selected') || sel.value || '';
+                const selectedKey = selected.toLowerCase();
+                try {
+                    const res = await fetch('/api/ports');
+                    if (!res.ok) throw new Error('HTTP ' + res.status);
+                    const data = await res.json();
+                    const ports = Array.isArray(data.ports) ? data.ports.slice() : [];
+                    ports.sort(function (a, b) {
+                        return String(a).localeCompare(String(b), undefined, { numeric: true, sensitivity: 'base' });
+                    });
+
+                    const found = ports.some(function (p) { return String(p).toLowerCase() === selectedKey; });
+
+                    sel.innerHTML = '';
+                    if (selected && !found) {
+                        const missing = document.createElement('option');
+                        missing.value = selected;
+                        missing.textContent = selected + ' (not currently detected)';
+                        missing.selected = true;
+                        sel.appendChild(missing);
+                    }
+
+                    if (ports.length === 0 && !selected) {
+                        const empty = document.createElement('option');
+                        empty.value = '';
+                        empty.textContent = 'No serial ports detected';
+                        sel.appendChild(empty);
+                    } else {
+                        ports.forEach(function (p) {
+                            const opt = document.createElement('option');
+                            opt.value = p;
+                            opt.textContent = p;
+                            if (String(p).toLowerCase() === selectedKey) opt.selected = true;
+                            sel.appendChild(opt);
+                        });
+                    }
+
+                    if (sel.value) sel.setAttribute('data-selected', sel.value);
+                } catch (e) {
+                    console.warn('Serial port list failed', e);
+                    if (!sel.options.length) {
+                        const err = document.createElement('option');
+                        err.value = selected || '';
+                        err.textContent = selected
+                            ? selected + ' (list unavailable)'
+                            : 'Could not load ports';
+                        err.selected = true;
+                        sel.appendChild(err);
+                    }
+                }
+            }
+
+            document.getElementById('btnRefreshSerialPorts')?.addEventListener('click', function () {
+                const sel = document.getElementById('Settings_SerialPort');
+                if (sel?.value) sel.setAttribute('data-selected', sel.value);
+                loadSerialPorts();
+            });
+            loadSerialPorts();
+        })();
+    </script>
     <script>
         // Remote audio device list + HTTPS certificate generation
         (function () {

--- a/Pages/Settings.cshtml
+++ b/Pages/Settings.cshtml
@@ -2055,7 +2055,7 @@
                             data-selected="@Model.Settings.AudioRadioRxDevice">
                         <option value="">(Default input)</option>
                     </select>
-                    <div class="form-text">Usually the Yaesu USB <em>recording</em> endpoint — what you hear in the browser.</div>
+                    <div class="form-text">Usually the Yaesu USB <em>recording</em> endpoint — what you hear in the browser. On Windows the same device may appear once per audio API (prefer <strong>Windows WASAPI</strong>).</div>
                 </div>
                 <div class="col-md-6">
                     <label class="form-label" for="audioRadioTxDevice">Radio TX device (playback)</label>
@@ -2063,7 +2063,7 @@
                             data-selected="@Model.Settings.AudioRadioTxDevice">
                         <option value="">(Default output)</option>
                     </select>
-                    <div class="form-text">Usually the Yaesu USB <em>playback</em> endpoint — where browser mic audio is sent.</div>
+                    <div class="form-text">Usually the Yaesu USB <em>playback</em> endpoint — where browser mic audio is sent. Labels include the PortAudio host API so duplicates are distinguishable.</div>
                 </div>
             </div>
             <div class="row g-3 mt-1">
@@ -2766,22 +2766,49 @@
                     const data = await res.json();
                     const rxSelected = rxSel.getAttribute('data-selected') || '';
                     const txSelected = txSel.getAttribute('data-selected') || '';
-                    rxSel.innerHTML = '<option value="">(Default input)</option>';
-                    (data.inputs || []).forEach(function (d) {
-                        const opt = document.createElement('option');
-                        opt.value = d.name;
-                        opt.textContent = d.name;
-                        if (d.name === rxSelected) opt.selected = true;
-                        rxSel.appendChild(opt);
-                    });
-                    txSel.innerHTML = '<option value="">(Default output)</option>';
-                    (data.outputs || []).forEach(function (d) {
-                        const opt = document.createElement('option');
-                        opt.value = d.name;
-                        opt.textContent = d.name;
-                        if (d.name === txSelected) opt.selected = true;
-                        txSel.appendChild(opt);
-                    });
+                    // Keys are "{name} [{hostApi}]" so Windows MME/WASAPI/DS/WDM-KS
+                    // duplicates stay distinct. Legacy bare-name settings still match.
+                    function pickSelectedKey(devices, selected) {
+                        if (!selected) return '';
+                        const list = devices || [];
+                        const exact = list.find(function (d) {
+                            return (d.key || d.displayName || d.name) === selected;
+                        });
+                        if (exact) return exact.key || exact.displayName || exact.name;
+                        // Legacy bare name — prefer WASAPI / Core Audio when several match.
+                        const byName = list.filter(function (d) { return d.name === selected; });
+                        const prefer = byName.find(function (d) { return /WASAPI/i.test(d.hostApiName || ''); })
+                            || byName.find(function (d) { return /Core Audio/i.test(d.hostApiName || ''); })
+                            || byName[0];
+                        return prefer ? (prefer.key || prefer.displayName || prefer.name) : '';
+                    }
+                    function fillAudioSelect(sel, devices, selected, defaultLabel) {
+                        const matchKey = pickSelectedKey(devices, selected);
+                        sel.innerHTML = '';
+                        const def = document.createElement('option');
+                        def.value = '';
+                        def.textContent = defaultLabel;
+                        if (!selected) def.selected = true;
+                        sel.appendChild(def);
+                        (devices || []).forEach(function (d) {
+                            const key = d.key || d.displayName || d.name;
+                            const opt = document.createElement('option');
+                            opt.value = key;
+                            opt.textContent = d.displayName || key;
+                            if (key === matchKey) opt.selected = true;
+                            sel.appendChild(opt);
+                        });
+                        // Saved key not in the live list — keep it visible so Save doesn't wipe it.
+                        if (selected && !matchKey) {
+                            const orphan = document.createElement('option');
+                            orphan.value = selected;
+                            orphan.textContent = selected + ' (not present)';
+                            orphan.selected = true;
+                            sel.appendChild(orphan);
+                        }
+                    }
+                    fillAudioSelect(rxSel, data.inputs, rxSelected, '(Default input)');
+                    fillAudioSelect(txSel, data.outputs, txSelected, '(Default output)');
                 } catch (e) {
                     console.warn('Audio device list failed', e);
                 }

--- a/Pages/Settings.cshtml
+++ b/Pages/Settings.cshtml
@@ -2032,7 +2032,7 @@
     </details>
 
     <!-- Remote Audio (browser ↔ radio USB) -->
-    <details class="settings-section" id="remoteAudioSection">
+    <details class="settings-section" id="remoteAudioSection" @(ViewContext.ModelState.IsValid ? "" : "open")>
         <summary><i class="bi bi-soundwave" aria-hidden="true"></i>&nbsp;Remote Audio</summary>
         <div class="section-body">
             <p class="text-muted">
@@ -2045,6 +2045,7 @@
             <div class="alert alert-info" role="alert">
                 On the radio, set <strong>MOD SOURCE</strong> to USB / REAR (USB) so TX audio from the PC reaches the transmitter.
                 For remote mic access, enable <strong>HTTPS</strong> under Web / HTTP and open the HTTPS URL.
+                When enabled, you must pick <strong>both</strong> radio USB devices — leaving TX blank used to open the PC speakers and loop the browser mic into the room.
             </div>
             <div class="mb-3 form-check form-switch">
                 <input class="form-check-input" type="checkbox" asp-for="Settings.AudioStreamingEnabled" id="audioStreamingEnabled" />
@@ -2055,17 +2056,27 @@
                     <label class="form-label" for="audioRadioRxDevice">Radio RX device (capture)</label>
                     <select class="form-select" id="audioRadioRxDevice" name="Settings.AudioRadioRxDevice"
                             data-selected="@Model.Settings.AudioRadioRxDevice">
-                        <option value="">(Default input)</option>
+                        <option value="">(Select radio USB recording…)</option>
                     </select>
-                    <div class="form-text">Usually the Yaesu USB <em>recording</em> endpoint — what you hear in the browser. On Windows only <strong>WASAPI</strong> devices are listed.</div>
+                    <span asp-validation-for="Settings.AudioRadioRxDevice" class="text-danger"></span>
+                    <div class="form-text">
+                        Radio USB <em>recording</em> endpoint — what you hear in the browser.
+                        Factory names are often <strong>Microphone (USB Audio CODEC)</strong> or <strong>Line (USB Audio CODEC)</strong>;
+                        if you renamed it in the OS (e.g. “FTDX101”), pick that. On Windows only <strong>WASAPI</strong> devices are listed.
+                    </div>
                 </div>
                 <div class="col-md-6">
                     <label class="form-label" for="audioRadioTxDevice">Radio TX device (playback)</label>
                     <select class="form-select" id="audioRadioTxDevice" name="Settings.AudioRadioTxDevice"
                             data-selected="@Model.Settings.AudioRadioTxDevice">
-                        <option value="">(Default output)</option>
+                        <option value="">(Select radio USB playback…)</option>
                     </select>
-                    <div class="form-text">Usually the Yaesu USB <em>playback</em> endpoint — where browser mic audio is sent. On Windows only <strong>WASAPI</strong> devices are listed.</div>
+                    <span asp-validation-for="Settings.AudioRadioTxDevice" class="text-danger"></span>
+                    <div class="form-text">
+                        Radio USB <em>playback</em> / Speakers endpoint — where browser mic audio is sent.
+                        Often <strong>Speakers (USB Audio CODEC)</strong>. Do <strong>not</strong> pick your PC speakers / headphones
+                        (that causes mic feedback). On Windows only <strong>WASAPI</strong> devices are listed.
+                    </div>
                 </div>
             </div>
             <div class="row g-3 mt-1">
@@ -2798,7 +2809,9 @@
                             const key = d.key || d.displayName || d.name;
                             const opt = document.createElement('option');
                             opt.value = key;
-                            opt.textContent = d.displayName || key;
+                            // Server already sorts likely USB codec names first; mark them in the label.
+                            const base = d.displayName || key;
+                            opt.textContent = d.likelyRadio ? ('★ ' + base) : base;
                             if (key === matchKey) opt.selected = true;
                             sel.appendChild(opt);
                         });
@@ -2811,8 +2824,8 @@
                             sel.appendChild(orphan);
                         }
                     }
-                    fillAudioSelect(rxSel, data.inputs, rxSelected, '(Default input)');
-                    fillAudioSelect(txSel, data.outputs, txSelected, '(Default output)');
+                    fillAudioSelect(rxSel, data.inputs, rxSelected, '(Select radio USB recording…)');
+                    fillAudioSelect(txSel, data.outputs, txSelected, '(Select radio USB playback…)');
                 } catch (e) {
                     console.warn('Audio device list failed', e);
                 }

--- a/Pages/Settings.cshtml
+++ b/Pages/Settings.cshtml
@@ -2079,20 +2079,11 @@
                     </div>
                 </div>
             </div>
-            <div class="row g-3 mt-1">
-                <div class="col-md-6">
-                    <label asp-for="Settings.AudioRxGain" class="form-label">RX gain</label>
-                    <input asp-for="Settings.AudioRxGain" type="number" step="0.05" min="0.05" max="4" class="form-control" style="max-width: 8em;" />
-                    <div class="form-text">Also adjustable live via <strong>Mic &amp; Gain</strong> on the Index Remote Audio bar (or inline on the pop-out).</div>
-                </div>
-                <div class="col-md-6">
-                    <label asp-for="Settings.AudioTxGain" class="form-label">TX (mic) gain</label>
-                    <input asp-for="Settings.AudioTxGain" type="number" step="0.05" min="0.05" max="4" class="form-control" style="max-width: 8em;" />
-                    <div class="form-text">Also adjustable live via <strong>Mic &amp; Gain</strong> on the Index Remote Audio bar (or inline on the pop-out).</div>
-                </div>
-            </div>
             <div class="mt-3">
                 <button type="button" class="btn btn-outline-secondary btn-sm" id="btnRefreshAudioDevices">Refresh device list</button>
+                <div class="form-text mt-2">
+                    RX / TX software gain is adjusted live via <strong>Mic &amp; Gain</strong> on the Index Remote Audio bar (or inline on the pop-out), not here.
+                </div>
             </div>
             <div class="mt-2 pt-3 border-top">
                 <button type="submit" class="btn btn-primary">
@@ -2811,7 +2802,7 @@
                             opt.value = key;
                             // Server already sorts likely USB codec names first; mark them in the label.
                             const base = d.displayName || key;
-                            opt.textContent = d.likelyRadio ? ('★ ' + base) : base;
+                            opt.textContent = d.likelyRadio ? ('📻 ' + base) : base;
                             if (key === matchKey) opt.selected = true;
                             sel.appendChild(opt);
                         });

--- a/Pages/Settings.cshtml
+++ b/Pages/Settings.cshtml
@@ -1949,6 +1949,43 @@
                                 (quit via the system tray on Windows, or Ctrl+C in the console on macOS).
                             </div>
                         </div>
+
+                        <hr class="my-4" />
+                        <h5 class="mb-3">Optional HTTPS (for remote microphone)</h5>
+                        <p class="text-muted small">
+                            Browsers only allow microphone access on a <strong>secure context</strong> (HTTPS or localhost).
+                            Over WireGuard/LAN, enable HTTPS here, generate a self-signed certificate, save, and <strong>restart YWC</strong>.
+                            Then open the HTTPS URL (default port 8443) and accept the certificate warning once.
+                        </p>
+                        <div class="mb-3 form-check form-switch">
+                            <input class="form-check-input" type="checkbox" asp-for="Settings.HttpsEnabled" id="httpsEnabled" />
+                            <label class="form-check-label" asp-for="Settings.HttpsEnabled">Enable HTTPS</label>
+                        </div>
+                        <div class="mb-3">
+                            <label asp-for="Settings.HttpsPort" class="form-label">HTTPS Port</label>
+                            <input asp-for="Settings.HttpsPort" type="number" min="1" max="65535" class="form-control" style="max-width: 12em;" />
+                            <div class="form-text">Default <strong>8443</strong>. HTTP continues on the HTTP port above (dual-listen).</div>
+                        </div>
+                        <div class="mb-3">
+                            <label asp-for="Settings.HttpsSanHosts" class="form-label">Certificate SAN hostnames / IPs</label>
+                            <textarea asp-for="Settings.HttpsSanHosts" class="form-control" rows="2"
+                                      placeholder="e.g. 10.0.0.2&#10;ywc.local"></textarea>
+                            <div class="form-text">
+                                Extra names/IPs embedded in the certificate (one per line). Always includes localhost.
+                                Use your WireGuard or LAN address so the browser warning matches the URL you type.
+                            </div>
+                        </div>
+                        <div class="mb-3 d-flex flex-wrap gap-2 align-items-center">
+                            <button type="button" class="btn btn-outline-secondary" id="btnGenerateHttpsCert">
+                                Generate self-signed certificate
+                            </button>
+                            <span class="form-text" id="httpsCertInfo">Checking…</span>
+                        </div>
+                        <div class="alert alert-warning" role="alert">
+                            <i class="bi bi-exclamation-triangle-fill"></i>
+                            <strong>Restart required</strong> after enabling HTTPS or regenerating the certificate.
+                        </div>
+
                         <div class="alert alert-warning" role="alert">
                             <i class="bi bi-exclamation-triangle-fill"></i>
                             <strong>Important:</strong> Save Settings and Restart the application after changing web server settings.
@@ -1959,6 +1996,63 @@
                             <a asp-page="/ApplicationSetup" class="alert-link">Application Setup</a> page.
                         </div>
             <!-- Inline Save Settings so this section can be saved in place. -->
+            <div class="mt-2 pt-3 border-top">
+                <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-save" aria-hidden="true"></i>&nbsp;Save Settings
+                </button>
+                <span class="form-text ms-2">Saves everything on this page.</span>
+            </div>
+        </div>
+    </details>
+
+    <!-- Remote Audio (browser ↔ radio USB) -->
+    <details class="settings-section" id="remoteAudioSection">
+        <summary><i class="bi bi-soundwave" aria-hidden="true"></i>&nbsp;Remote Audio</summary>
+        <div class="section-body">
+            <p class="text-muted">
+                Stream radio receive audio to the browser and send the browser microphone into the radio’s USB audio
+                (SCU-LAN10-style remote SSB without Mumble). PTT stays on the existing TX button / shortcut.
+                Designed for LAN or VPN (e.g. WireGuard). Off by default.
+            </p>
+            <div class="alert alert-info" role="alert">
+                On the radio, set <strong>MOD SOURCE</strong> to USB / REAR (USB) so TX audio from the PC reaches the transmitter.
+                For remote mic access, enable <strong>HTTPS</strong> under Web / HTTP and open the HTTPS URL.
+            </div>
+            <div class="mb-3 form-check form-switch">
+                <input class="form-check-input" type="checkbox" asp-for="Settings.AudioStreamingEnabled" id="audioStreamingEnabled" />
+                <label class="form-check-label" asp-for="Settings.AudioStreamingEnabled">Enable remote audio</label>
+            </div>
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <label class="form-label" for="audioRadioRxDevice">Radio RX device (capture)</label>
+                    <select class="form-select" id="audioRadioRxDevice" name="Settings.AudioRadioRxDevice"
+                            data-selected="@Model.Settings.AudioRadioRxDevice">
+                        <option value="">(Default input)</option>
+                    </select>
+                    <div class="form-text">Usually the Yaesu USB <em>recording</em> endpoint — what you hear in the browser.</div>
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label" for="audioRadioTxDevice">Radio TX device (playback)</label>
+                    <select class="form-select" id="audioRadioTxDevice" name="Settings.AudioRadioTxDevice"
+                            data-selected="@Model.Settings.AudioRadioTxDevice">
+                        <option value="">(Default output)</option>
+                    </select>
+                    <div class="form-text">Usually the Yaesu USB <em>playback</em> endpoint — where browser mic audio is sent.</div>
+                </div>
+            </div>
+            <div class="row g-3 mt-1">
+                <div class="col-md-6">
+                    <label asp-for="Settings.AudioRxGain" class="form-label">RX gain</label>
+                    <input asp-for="Settings.AudioRxGain" type="number" step="0.05" min="0.05" max="4" class="form-control" style="max-width: 8em;" />
+                </div>
+                <div class="col-md-6">
+                    <label asp-for="Settings.AudioTxGain" class="form-label">TX gain</label>
+                    <input asp-for="Settings.AudioTxGain" type="number" step="0.05" min="0.05" max="4" class="form-control" style="max-width: 8em;" />
+                </div>
+            </div>
+            <div class="mt-3">
+                <button type="button" class="btn btn-outline-secondary btn-sm" id="btnRefreshAudioDevices">Refresh device list</button>
+            </div>
             <div class="mt-2 pt-3 border-top">
                 <button type="submit" class="btn btn-primary">
                     <i class="bi bi-save" aria-hidden="true"></i>&nbsp;Save Settings
@@ -2567,6 +2661,80 @@
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
+    <script>
+        // Remote audio device list + HTTPS certificate generation
+        (function () {
+            async function loadAudioDevices() {
+                const rxSel = document.getElementById('audioRadioRxDevice');
+                const txSel = document.getElementById('audioRadioTxDevice');
+                if (!rxSel || !txSel) return;
+                try {
+                    const res = await fetch('/api/audio/devices');
+                    if (!res.ok) throw new Error('HTTP ' + res.status);
+                    const data = await res.json();
+                    const rxSelected = rxSel.getAttribute('data-selected') || '';
+                    const txSelected = txSel.getAttribute('data-selected') || '';
+                    rxSel.innerHTML = '<option value="">(Default input)</option>';
+                    (data.inputs || []).forEach(function (d) {
+                        const opt = document.createElement('option');
+                        opt.value = d.name;
+                        opt.textContent = d.name;
+                        if (d.name === rxSelected) opt.selected = true;
+                        rxSel.appendChild(opt);
+                    });
+                    txSel.innerHTML = '<option value="">(Default output)</option>';
+                    (data.outputs || []).forEach(function (d) {
+                        const opt = document.createElement('option');
+                        opt.value = d.name;
+                        opt.textContent = d.name;
+                        if (d.name === txSelected) opt.selected = true;
+                        txSel.appendChild(opt);
+                    });
+                } catch (e) {
+                    console.warn('Audio device list failed', e);
+                }
+            }
+
+            async function refreshHttpsInfo() {
+                const el = document.getElementById('httpsCertInfo');
+                if (!el) return;
+                try {
+                    const res = await fetch('/api/audio/status');
+                    const data = await res.json();
+                    el.textContent = data.certificatePresent
+                        ? data.certificateInfo
+                        : 'No certificate generated yet.';
+                } catch (e) {
+                    el.textContent = 'Could not read certificate status.';
+                }
+            }
+
+            document.getElementById('btnRefreshAudioDevices')?.addEventListener('click', loadAudioDevices);
+            document.getElementById('btnGenerateHttpsCert')?.addEventListener('click', async function () {
+                if (!confirm('Generate a new self-signed certificate? This overwrites any existing one. Restart YWC afterwards if HTTPS is enabled.'))
+                    return;
+                const san = document.getElementById('Settings_HttpsSanHosts')?.value
+                    || document.querySelector('[name="Settings.HttpsSanHosts"]')?.value
+                    || '';
+                try {
+                    const res = await fetch('/api/audio/https/generate', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ sanHosts: san })
+                    });
+                    const data = await res.json();
+                    if (!res.ok) throw new Error(data.error || 'Generate failed');
+                    alert('Certificate generated.\n\n' + (data.info || '') + '\n\nSave Settings if you changed HTTPS options, then restart YWC.');
+                    refreshHttpsInfo();
+                } catch (e) {
+                    alert('Certificate generation failed: ' + e.message);
+                }
+            });
+
+            loadAudioDevices();
+            refreshHttpsInfo();
+        })();
+    </script>
     <script>
         // Must run AFTER _ValidationScriptsPartial so jQuery Validate is present.
         // "Saving…" only when the form will actually POST. Previously the spinner

--- a/Pages/Settings.cshtml
+++ b/Pages/Settings.cshtml
@@ -2070,10 +2070,12 @@
                 <div class="col-md-6">
                     <label asp-for="Settings.AudioRxGain" class="form-label">RX gain</label>
                     <input asp-for="Settings.AudioRxGain" type="number" step="0.05" min="0.05" max="4" class="form-control" style="max-width: 8em;" />
+                    <div class="form-text">Also adjustable live via <strong>Mic &amp; Gain</strong> on the Index Remote Audio bar (or inline on the pop-out).</div>
                 </div>
                 <div class="col-md-6">
-                    <label asp-for="Settings.AudioTxGain" class="form-label">TX gain</label>
+                    <label asp-for="Settings.AudioTxGain" class="form-label">TX (mic) gain</label>
                     <input asp-for="Settings.AudioTxGain" type="number" step="0.05" min="0.05" max="4" class="form-control" style="max-width: 8em;" />
+                    <div class="form-text">Also adjustable live via <strong>Mic &amp; Gain</strong> on the Index Remote Audio bar (or inline on the pop-out).</div>
                 </div>
             </div>
             <div class="mt-3">

--- a/Pages/Settings.cshtml
+++ b/Pages/Settings.cshtml
@@ -2055,7 +2055,7 @@
                             data-selected="@Model.Settings.AudioRadioRxDevice">
                         <option value="">(Default input)</option>
                     </select>
-                    <div class="form-text">Usually the Yaesu USB <em>recording</em> endpoint — what you hear in the browser. On Windows the same device may appear once per audio API (prefer <strong>Windows WASAPI</strong>).</div>
+                    <div class="form-text">Usually the Yaesu USB <em>recording</em> endpoint — what you hear in the browser. On Windows only <strong>WASAPI</strong> devices are listed.</div>
                 </div>
                 <div class="col-md-6">
                     <label class="form-label" for="audioRadioTxDevice">Radio TX device (playback)</label>
@@ -2063,7 +2063,7 @@
                             data-selected="@Model.Settings.AudioRadioTxDevice">
                         <option value="">(Default output)</option>
                     </select>
-                    <div class="form-text">Usually the Yaesu USB <em>playback</em> endpoint — where browser mic audio is sent. Labels include the PortAudio host API so duplicates are distinguishable.</div>
+                    <div class="form-text">Usually the Yaesu USB <em>playback</em> endpoint — where browser mic audio is sent. On Windows only <strong>WASAPI</strong> devices are listed.</div>
                 </div>
             </div>
             <div class="row g-3 mt-1">

--- a/Pages/Settings.cshtml
+++ b/Pages/Settings.cshtml
@@ -1954,6 +1954,17 @@
                             <span asp-validation-for="Settings.HttpPort" class="text-danger"></span>
                         </div>
                         <div class="mb-3 form-check form-switch">
+                            <input class="form-check-input" type="checkbox" asp-for="Settings.OpenBrowserOnStartup" />
+                            <label class="form-check-label" asp-for="Settings.OpenBrowserOnStartup">
+                                Open browser automatically on startup
+                            </label>
+                            <div class="form-text">
+                                When enabled (default), YWC opens your default browser to the control panel after
+                                the web server starts. Turn this off to start quietly — open the UI from the
+                                system tray / menu bar, or browse to the URL yourself. Docker never auto-opens.
+                            </div>
+                        </div>
+                        <div class="mb-3 form-check form-switch">
                             <input class="form-check-input" type="checkbox" asp-for="Settings.AutoShutdownWhenNoBrowsers" />
                             <label class="form-check-label" asp-for="Settings.AutoShutdownWhenNoBrowsers">
                                 Automatically exit when no browser is connected

--- a/Pages/Settings.cshtml
+++ b/Pages/Settings.cshtml
@@ -2039,6 +2039,8 @@
                 Stream radio receive audio to the browser and send the browser microphone into the radio’s USB audio
                 (SCU-LAN10-style remote SSB without Mumble). PTT stays on the existing TX button / shortcut.
                 Designed for LAN or VPN (e.g. WireGuard). Off by default.
+                On the Index Remote Audio bar (or pop-out), choose <strong>Opus</strong> (default, low bandwidth)
+                or <strong>PCM16</strong> (uncompressed) — see the user manual §18.6.
             </p>
             <div class="alert alert-info" role="alert">
                 On the radio, set <strong>MOD SOURCE</strong> to USB / REAR (USB) so TX audio from the PC reaches the transmitter.

--- a/Pages/Settings.cshtml.cs
+++ b/Pages/Settings.cshtml.cs
@@ -208,6 +208,7 @@ namespace Yaesu_Web_Control.Pages
                     ? Settings.HttpPort
                     : 8080;
                 current.AutoShutdownWhenNoBrowsers = Settings.AutoShutdownWhenNoBrowsers;
+                current.OpenBrowserOnStartup = Settings.OpenBrowserOnStartup;
                 current.SerialPort        = Settings.SerialPort;
                 current.BaudRate          = Settings.BaudRate;
                 current.WebAddress        = Settings.WebAddress;

--- a/Pages/Settings.cshtml.cs
+++ b/Pages/Settings.cshtml.cs
@@ -132,6 +132,10 @@ namespace Yaesu_Web_Control.Pages
             ModelState.Remove("Settings.DxClusterPostLoginCommands");
             // Accessibility TX shortcut is optional — empty = disabled.
             ModelState.Remove("Settings.TxToggleKey");
+            // Remote audio device names may be empty (use PortAudio defaults).
+            ModelState.Remove("Settings.AudioRadioRxDevice");
+            ModelState.Remove("Settings.AudioRadioTxDevice");
+            ModelState.Remove("Settings.HttpsSanHosts");
 
             if (!ModelState.IsValid)
             {
@@ -174,6 +178,8 @@ namespace Yaesu_Web_Control.Pages
                 var oldRadioModel = current.RadioModel;
                 var oldWebAddress = current.WebAddress;
                 var oldHttpPort   = current.HttpPort;
+                var oldHttpsEnabled = current.HttpsEnabled;
+                var oldHttpsPort    = current.HttpsPort;
 
                 // Capture pre-change CAT connection values so the radio reconnect
                 // below only fires when something that actually affects the CAT
@@ -276,6 +282,18 @@ namespace Yaesu_Web_Control.Pages
                 current.VoiceControlEnabled = Settings.VoiceControlEnabled;
                 current.VoiceSpokenConfirmationEnabled = Settings.VoiceSpokenConfirmationEnabled;
 
+                // Remote audio + optional HTTPS
+                current.AudioStreamingEnabled = Settings.AudioStreamingEnabled;
+                current.AudioRadioRxDevice = Settings.AudioRadioRxDevice ?? "";
+                current.AudioRadioTxDevice = Settings.AudioRadioTxDevice ?? "";
+                current.AudioRxGain = Math.Clamp(Settings.AudioRxGain, 0.05f, 4f);
+                current.AudioTxGain = Math.Clamp(Settings.AudioTxGain, 0.05f, 4f);
+                current.HttpsEnabled = Settings.HttpsEnabled;
+                current.HttpsPort = (Settings.HttpsPort >= 1 && Settings.HttpsPort <= 65535)
+                    ? Settings.HttpsPort
+                    : 8443;
+                current.HttpsSanHosts = Settings.HttpsSanHosts ?? "";
+
                 await _settingsService.SaveSettingsAsync(current);
 
                 // Only reconnect the radio if something that actually affects the
@@ -342,6 +360,8 @@ namespace Yaesu_Web_Control.Pages
                     reasons.Add($"web server address ({oldWebAddress} → {current.WebAddress})");
                 if (oldHttpPort != current.HttpPort)
                     reasons.Add($"HTTP port ({oldHttpPort} → {current.HttpPort})");
+                if (oldHttpsEnabled != current.HttpsEnabled || oldHttpsPort != current.HttpsPort)
+                    reasons.Add("HTTPS settings");
                 if (reasons.Count > 0)
                 {
                     RestartRequiredReason = string.Join(" and ", reasons);

--- a/Pages/Settings.cshtml.cs
+++ b/Pages/Settings.cshtml.cs
@@ -132,7 +132,8 @@ namespace Yaesu_Web_Control.Pages
             ModelState.Remove("Settings.DxClusterPostLoginCommands");
             // Accessibility TX shortcut is optional — empty = disabled.
             ModelState.Remove("Settings.TxToggleKey");
-            // Remote audio device names may be empty (use PortAudio defaults).
+            // Remote audio device names may be empty when the feature is off.
+            // When enabled we require explicit RX/TX picks (see check below).
             ModelState.Remove("Settings.AudioRadioRxDevice");
             ModelState.Remove("Settings.AudioRadioTxDevice");
             ModelState.Remove("Settings.HttpsSanHosts");
@@ -164,6 +165,28 @@ namespace Yaesu_Web_Control.Pages
                         : "Serial port must be a device path (e.g. /dev/cu.usbserial-…).");
                 NetworkAddresses = GetLocalIPAddresses();
                 return Page();
+            }
+
+            // Remote Audio: refuse blank devices when enabled. Empty TX used to
+            // open the PC speakers → browser-mic feedback into the room.
+            if (Settings.AudioStreamingEnabled)
+            {
+                if (string.IsNullOrWhiteSpace(Settings.AudioRadioRxDevice))
+                {
+                    ModelState.AddModelError("Settings.AudioRadioRxDevice",
+                        "Pick the radio’s USB recording / capture device (often “Microphone (USB Audio CODEC)” or a name you gave it).");
+                }
+                if (string.IsNullOrWhiteSpace(Settings.AudioRadioTxDevice))
+                {
+                    ModelState.AddModelError("Settings.AudioRadioTxDevice",
+                        "Pick the radio’s USB Speakers / playback device — not your PC speakers. Blank TX causes mic feedback.");
+                }
+                if (!ModelState.IsValid)
+                {
+                    StatusMessage = "❌ Settings not saved — Remote Audio needs explicit radio RX and TX devices.";
+                    NetworkAddresses = GetLocalIPAddresses();
+                    return Page();
+                }
             }
 
             try

--- a/Pages/Settings.cshtml.cs
+++ b/Pages/Settings.cshtml.cs
@@ -310,8 +310,8 @@ namespace Yaesu_Web_Control.Pages
                 current.AudioStreamingEnabled = Settings.AudioStreamingEnabled;
                 current.AudioRadioRxDevice = Settings.AudioRadioRxDevice ?? "";
                 current.AudioRadioTxDevice = Settings.AudioRadioTxDevice ?? "";
-                current.AudioRxGain = Math.Clamp(Settings.AudioRxGain, 0.05f, 4f);
-                current.AudioTxGain = Math.Clamp(Settings.AudioTxGain, 0.05f, 4f);
+                // AudioRxGain / AudioTxGain are live-only (Mic & Gain / pop-out → /api/audio/gain).
+                // Do not overwrite them from this form — the inputs were removed from Settings.
                 current.HttpsEnabled = Settings.HttpsEnabled;
                 current.HttpsPort = (Settings.HttpsPort >= 1 && Settings.HttpsPort <= 65535)
                     ? Settings.HttpsPort

--- a/Program.cs
+++ b/Program.cs
@@ -193,6 +193,25 @@ static int LoadConfiguredHttpPort()
     return 8080;
 }
 
+static (bool enabled, int port) LoadConfiguredHttps()
+{
+    try
+    {
+        var path = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "MM5AGM", "Yaesu Web Control", "appsettings.user.json");
+        if (!File.Exists(path)) return (false, 8443);
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        bool enabled = doc.RootElement.TryGetProperty("HttpsEnabled", out var e) && e.ValueKind == JsonValueKind.True;
+        int port = 8443;
+        if (doc.RootElement.TryGetProperty("HttpsPort", out var p) && p.TryGetInt32(out int hp) && hp >= 1 && hp <= 65535)
+            port = hp;
+        return (enabled, port);
+    }
+    catch { }
+    return (false, 8443);
+}
+
 #if WINDOWS
 // ── Suppress Windows critical-error dialogs during DLL load ─────────────────
 // When SoapySDR enumerates plugins (HackRF, RTL-SDR, Airspy, etc.), Windows
@@ -369,6 +388,11 @@ builder.Services.AddHostedService<RigctldServer>();
 // Register your settings service
 builder.Services.AddSingleton<ISettingsService, SettingsService>();
 
+// Remote radio audio (browser ↔ USB) — opt-in; devices open only while a client is connected.
+builder.Services.AddSingleton<Yaesu_Web_Control.Services.Audio.AudioSessionManager>();
+builder.Services.AddSingleton<Yaesu_Web_Control.Services.Audio.RadioAudioBridgeService>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<Yaesu_Web_Control.Services.Audio.RadioAudioBridgeService>());
+
 // Audio filter EX address map — loaded once at startup from
 // wwwroot/data/audio-filter-ex-map.json; used by the Audio Filter popout
 // controller endpoints to translate per-radio menu addresses.
@@ -446,10 +470,48 @@ if (chosenPort < 0)
 }
 
 // Force the web host to use the chosen port on all interfaces.
-builder.WebHost.UseUrls($"http://0.0.0.0:{chosenPort}");
+// Optional HTTPS (self-signed) dual-binds when enabled and a cert exists.
+var (httpsWanted, httpsPortCfg) = LoadConfiguredHttps();
+bool httpsActive = false;
+int? httpsListenPort = null;
+if (httpsWanted)
+{
+    if (Yaesu_Web_Control.Services.Audio.HttpsCertificateService.CertificateExists)
+    {
+        if (IsPortFree(httpsPortCfg) || httpsPortCfg == chosenPort)
+        {
+            httpsActive = true;
+            httpsListenPort = httpsPortCfg;
+        }
+        else
+        {
+            Log.Warning("HTTPS enabled but port {Port} is in use ({Owner}); staying HTTP-only",
+                httpsPortCfg, GetPortOwner(httpsPortCfg) ?? "unknown");
+        }
+    }
+    else
+    {
+        Log.Warning("HTTPS enabled but no certificate at {Path}; generate one in Settings and restart",
+            Yaesu_Web_Control.Services.Audio.HttpsCertificateService.CertificatePath);
+    }
+}
+
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.ListenAnyIP(chosenPort);
+    if (httpsActive && httpsListenPort is int hp)
+    {
+        options.ListenAnyIP(hp, listen =>
+        {
+            listen.UseHttps(Yaesu_Web_Control.Services.Audio.HttpsCertificateService.CertificatePath,
+                Yaesu_Web_Control.Services.Audio.HttpsCertificateService.PfxPassword);
+        });
+        Log.Information("HTTPS listening on 0.0.0.0:{Port}", hp);
+    }
+});
 
 // Publish the chosen port so every consumer reads from one source of truth.
-builder.Services.AddSingleton(new HttpPortInfo(chosenPort));
+builder.Services.AddSingleton(new HttpPortInfo(chosenPort, httpsListenPort, httpsActive));
 
 builder.Services.AddSingleton<BrowserLauncher>();
 #if WINDOWS
@@ -538,6 +600,7 @@ try
             RequestPath = "/pictures"
         });
     }
+    app.UseWebSockets();
     app.UseRouting();
     app.UseAuthorization();
     //app.MapGet("/", () => "ROOT ROUTE HIT");
@@ -547,6 +610,12 @@ try
 
     // MAP SIGNALR HUB:
     app.MapHub<Yaesu_Web_Control.Hubs.RadioHub>("/radioHub");
+
+    // Remote audio WebSocket (binary Opus/PCM frames) — not SignalR.
+    app.Map("/audio", async (HttpContext ctx, Yaesu_Web_Control.Services.Audio.RadioAudioBridgeService bridge) =>
+    {
+        await bridge.HandleWebSocketAsync(ctx);
+    });
 
     app.MapGet("/api/status/init", () => new { status = Yaesu_Web_Control.Services.AppStatus.InitializationStatus });
 

--- a/Services/Audio/AudioConstants.cs
+++ b/Services/Audio/AudioConstants.cs
@@ -5,9 +5,12 @@ namespace Yaesu_Web_Control.Services.Audio
     {
         public const int SampleRate = 48_000;
         public const int Channels = 1;
-        /// <summary>20 ms at 48 kHz.</summary>
-        public const int FrameSamples = 960;
+        /// <summary>10 ms at 48 kHz — lower packetization delay than 20 ms.</summary>
+        public const int FrameSamples = 480;
         public const int OpusBitrate = 32_000;
+
+        /// <summary>Max host TX ring depth (~40 ms) before dropping oldest samples.</summary>
+        public const int PlaybackRingMaxSamples = FrameSamples * 4;
 
         public const byte MsgOpusRx = 0x01;
         public const byte MsgOpusTx = 0x02;

--- a/Services/Audio/AudioConstants.cs
+++ b/Services/Audio/AudioConstants.cs
@@ -5,12 +5,17 @@ namespace Yaesu_Web_Control.Services.Audio
     {
         public const int SampleRate = 48_000;
         public const int Channels = 1;
-        /// <summary>10 ms at 48 kHz — lower packetization delay than 20 ms.</summary>
+        /// <summary>10 ms at 48 kHz — PCM packetization / Opus encode frame.</summary>
         public const int FrameSamples = 480;
+        /// <summary>
+        /// WebCodecs Opus defaults to 20 ms; Concentus decode buffer must be at least
+        /// this large or Decode throws and the audio WebSocket dies.
+        /// </summary>
+        public const int OpusDecodeMaxSamples = 5760; // 120 ms @ 48 kHz (Opus max)
         public const int OpusBitrate = 32_000;
 
-        /// <summary>Max host TX ring depth (~40 ms) before dropping oldest samples.</summary>
-        public const int PlaybackRingMaxSamples = FrameSamples * 4;
+        /// <summary>Max host TX ring depth (~80 ms) before dropping oldest samples.</summary>
+        public const int PlaybackRingMaxSamples = FrameSamples * 8;
 
         public const byte MsgOpusRx = 0x01;
         public const byte MsgOpusTx = 0x02;

--- a/Services/Audio/AudioConstants.cs
+++ b/Services/Audio/AudioConstants.cs
@@ -1,0 +1,21 @@
+namespace Yaesu_Web_Control.Services.Audio
+{
+    /// <summary>Shared constants for the remote radio audio bridge.</summary>
+    public static class AudioConstants
+    {
+        public const int SampleRate = 48_000;
+        public const int Channels = 1;
+        /// <summary>20 ms at 48 kHz.</summary>
+        public const int FrameSamples = 960;
+        public const int OpusBitrate = 32_000;
+
+        public const byte MsgOpusRx = 0x01;
+        public const byte MsgOpusTx = 0x02;
+        public const byte MsgPcmRx = 0x03;
+        public const byte MsgPcmTx = 0x04;
+        public const byte MsgControl = 0x10;
+
+        public const string CodecOpus = "opus";
+        public const string CodecPcm16 = "pcm16";
+    }
+}

--- a/Services/Audio/AudioDeviceEnumerator.cs
+++ b/Services/Audio/AudioDeviceEnumerator.cs
@@ -1,0 +1,69 @@
+using PortAudioSharp;
+
+namespace Yaesu_Web_Control.Services.Audio
+{
+    /// <summary>
+    /// Enumerates PortAudio devices. Names are the stable persistence key
+    /// (same approach as Voice Control's MME product names).
+    /// </summary>
+    public static class AudioDeviceEnumerator
+    {
+        private static readonly object Sync = new();
+        private static bool _initialized;
+
+        public static void EnsureInitialized()
+        {
+            lock (Sync)
+            {
+                if (_initialized) return;
+                PortAudio.Initialize();
+                _initialized = true;
+            }
+        }
+
+        public static IReadOnlyList<AudioDeviceInfo> ListDevices()
+        {
+            EnsureInitialized();
+            var list = new List<AudioDeviceInfo>();
+            int count = PortAudio.DeviceCount;
+            for (int i = 0; i < count; i++)
+            {
+                try
+                {
+                    DeviceInfo info = PortAudio.GetDeviceInfo(i);
+                    if (string.IsNullOrWhiteSpace(info.name)) continue;
+                    list.Add(new AudioDeviceInfo(
+                        i,
+                        info.name.Trim(),
+                        info.maxInputChannels,
+                        info.maxOutputChannels,
+                        info.defaultSampleRate));
+                }
+                catch
+                {
+                    // Skip devices that won't describe themselves.
+                }
+            }
+            return list;
+        }
+
+        public static IReadOnlyList<AudioDeviceInfo> ListInputs() =>
+            ListDevices().Where(d => d.IsInput).ToList();
+
+        public static IReadOnlyList<AudioDeviceInfo> ListOutputs() =>
+            ListDevices().Where(d => d.IsOutput).ToList();
+
+        /// <summary>Resolve a saved device name to a PortAudio index, or -1.</summary>
+        public static int FindDeviceIndex(string? name, bool requireInput, bool requireOutput)
+        {
+            if (string.IsNullOrWhiteSpace(name)) return -1;
+            EnsureInitialized();
+            var devices = ListDevices();
+            var match = devices.FirstOrDefault(d =>
+                string.Equals(d.Name, name.Trim(), StringComparison.OrdinalIgnoreCase)
+                && (!requireInput || d.IsInput)
+                && (!requireOutput || d.IsOutput));
+            return match?.Index ?? -1;
+        }
+    }
+}

--- a/Services/Audio/AudioDeviceEnumerator.cs
+++ b/Services/Audio/AudioDeviceEnumerator.cs
@@ -1,15 +1,30 @@
+using System.Runtime.InteropServices;
+using System.Text;
 using PortAudioSharp;
 
 namespace Yaesu_Web_Control.Services.Audio
 {
     /// <summary>
-    /// Enumerates PortAudio devices. Names are the stable persistence key
-    /// (same approach as Voice Control's MME product names).
+    /// Enumerates PortAudio devices. Persistence keys are
+    /// <c>{name} [{hostApi}]</c> so Windows duplicates across MME / WASAPI /
+    /// DirectSound / WDM-KS stay distinct. Legacy name-only settings still match.
     /// </summary>
     public static class AudioDeviceEnumerator
     {
         private static readonly object Sync = new();
         private static bool _initialized;
+
+        // Prefer shared-mode / modern APIs when a legacy name matches several entries.
+        private static readonly string[] PreferredHostApiSubstrings =
+        {
+            "WASAPI",
+            "Core Audio",
+            "ALSA",
+            "JACK",
+            "ASIO",
+            "DirectSound",
+            "MME",
+        };
 
         public static void EnsureInitialized()
         {
@@ -24,6 +39,7 @@ namespace Yaesu_Web_Control.Services.Audio
         public static IReadOnlyList<AudioDeviceInfo> ListDevices()
         {
             EnsureInitialized();
+            var hostApiNames = LoadHostApiNames();
             var list = new List<AudioDeviceInfo>();
             int count = PortAudio.DeviceCount;
             for (int i = 0; i < count; i++)
@@ -32,9 +48,14 @@ namespace Yaesu_Web_Control.Services.Audio
                 {
                     DeviceInfo info = PortAudio.GetDeviceInfo(i);
                     if (string.IsNullOrWhiteSpace(info.name)) continue;
+                    string hostApiName = hostApiNames.TryGetValue(info.hostApi, out var n) && !string.IsNullOrEmpty(n)
+                        ? n
+                        : $"HostApi {info.hostApi}";
                     list.Add(new AudioDeviceInfo(
                         i,
                         info.name.Trim(),
+                        hostApiName,
+                        info.hostApi,
                         info.maxInputChannels,
                         info.maxOutputChannels,
                         info.defaultSampleRate));
@@ -53,17 +74,101 @@ namespace Yaesu_Web_Control.Services.Audio
         public static IReadOnlyList<AudioDeviceInfo> ListOutputs() =>
             ListDevices().Where(d => d.IsOutput).ToList();
 
-        /// <summary>Resolve a saved device name to a PortAudio index, or -1.</summary>
-        public static int FindDeviceIndex(string? name, bool requireInput, bool requireOutput)
+        /// <summary>
+        /// Resolve a saved device key to a PortAudio index, or -1.
+        /// Accepts <c>{name} [{hostApi}]</c> or a legacy bare name.
+        /// </summary>
+        public static int FindDeviceIndex(string? savedKey, bool requireInput, bool requireOutput)
         {
-            if (string.IsNullOrWhiteSpace(name)) return -1;
+            if (string.IsNullOrWhiteSpace(savedKey)) return -1;
             EnsureInitialized();
-            var devices = ListDevices();
-            var match = devices.FirstOrDefault(d =>
-                string.Equals(d.Name, name.Trim(), StringComparison.OrdinalIgnoreCase)
-                && (!requireInput || d.IsInput)
-                && (!requireOutput || d.IsOutput));
-            return match?.Index ?? -1;
+            AudioDeviceKey.Parse(savedKey, out var hostApi, out var name);
+            if (string.IsNullOrEmpty(name)) return -1;
+
+            var candidates = ListDevices()
+                .Where(d =>
+                    string.Equals(d.Name, name, StringComparison.OrdinalIgnoreCase)
+                    && (!requireInput || d.IsInput)
+                    && (!requireOutput || d.IsOutput))
+                .ToList();
+
+            if (candidates.Count == 0) return -1;
+
+            if (!string.IsNullOrEmpty(hostApi))
+            {
+                var exact = candidates.FirstOrDefault(d =>
+                    string.Equals(d.HostApiName, hostApi, StringComparison.OrdinalIgnoreCase));
+                if (exact != null) return exact.Index;
+                // Host API from settings no longer present — fall through to name match.
+            }
+
+            if (candidates.Count == 1) return candidates[0].Index;
+            return PreferHostApi(candidates).Index;
+        }
+
+        private static AudioDeviceInfo PreferHostApi(IReadOnlyList<AudioDeviceInfo> matches)
+        {
+            foreach (var prefer in PreferredHostApiSubstrings)
+            {
+                var hit = matches.FirstOrDefault(d =>
+                    d.HostApiName.Contains(prefer, StringComparison.OrdinalIgnoreCase));
+                if (hit != null) return hit;
+            }
+            return matches[0];
+        }
+
+        private static Dictionary<int, string> LoadHostApiNames()
+        {
+            var map = new Dictionary<int, string>();
+            int count = Pa_GetHostApiCount();
+            if (count <= 0) return map;
+            for (int i = 0; i < count; i++)
+            {
+                IntPtr ptr = Pa_GetHostApiInfo(i);
+                if (ptr == IntPtr.Zero) continue;
+                try
+                {
+                    var info = Marshal.PtrToStructure<PaHostApiInfoNative>(ptr);
+                    string name = ReadUtf8(info.name);
+                    if (!string.IsNullOrWhiteSpace(name))
+                        map[i] = name.Trim();
+                }
+                catch
+                {
+                    // Leave unnamed; caller falls back to "HostApi N".
+                }
+            }
+            return map;
+        }
+
+        private static string ReadUtf8(IntPtr p)
+        {
+            if (p == IntPtr.Zero) return "";
+            int length = 0;
+            while (Marshal.ReadByte(p, length) != 0) length++;
+            if (length == 0) return "";
+            var buf = new byte[length];
+            Marshal.Copy(p, buf, 0, length);
+            return Encoding.UTF8.GetString(buf);
+        }
+
+        // PortAudioSharp2 does not wrap Pa_GetHostApiInfo; P/Invoke the same
+        // portaudio.dll it already loads (DLL name matches PortAudioSharp.Native).
+        [DllImport("portaudio")]
+        private static extern int Pa_GetHostApiCount();
+
+        [DllImport("portaudio")]
+        private static extern IntPtr Pa_GetHostApiInfo(int hostApi);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct PaHostApiInfoNative
+        {
+            public int structVersion;
+            public int type;
+            public IntPtr name;
+            public int deviceCount;
+            public int defaultInputDevice;
+            public int defaultOutputDevice;
         }
     }
 }

--- a/Services/Audio/AudioDeviceEnumerator.cs
+++ b/Services/Audio/AudioDeviceEnumerator.cs
@@ -72,10 +72,28 @@ namespace Yaesu_Web_Control.Services.Audio
         }
 
         public static IReadOnlyList<AudioDeviceInfo> ListInputs() =>
-            ListDevices().Where(d => d.IsInput).ToList();
+            PreferLikelyRadioUsb(ListDevices().Where(d => d.IsInput));
 
         public static IReadOnlyList<AudioDeviceInfo> ListOutputs() =>
-            ListDevices().Where(d => d.IsOutput).ToList();
+            PreferLikelyRadioUsb(ListDevices().Where(d => d.IsOutput));
+
+        /// <summary>
+        /// Soft hint only: put names that look like a Yaesu USB codec first.
+        /// Does <strong>not</strong> hide other devices — operators often rename
+        /// the endpoint (e.g. to "FTDX101"), and OS strings vary.
+        /// </summary>
+        public static bool LooksLikeRadioUsbCodec(string? deviceName)
+        {
+            if (string.IsNullOrWhiteSpace(deviceName)) return false;
+            return deviceName.Contains("USB Audio", StringComparison.OrdinalIgnoreCase)
+                || deviceName.Contains("Yaesu", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static IReadOnlyList<AudioDeviceInfo> PreferLikelyRadioUsb(IEnumerable<AudioDeviceInfo> devices) =>
+            devices
+                .OrderByDescending(d => LooksLikeRadioUsbCodec(d.Name))
+                .ThenBy(d => d.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
         /// <summary>
         /// Resolve a saved device key to a PortAudio index, or -1.

--- a/Services/Audio/AudioDeviceEnumerator.cs
+++ b/Services/Audio/AudioDeviceEnumerator.cs
@@ -6,15 +6,17 @@ namespace Yaesu_Web_Control.Services.Audio
 {
     /// <summary>
     /// Enumerates PortAudio devices. Persistence keys are
-    /// <c>{name} [{hostApi}]</c> so Windows duplicates across MME / WASAPI /
-    /// DirectSound / WDM-KS stay distinct. Legacy name-only settings still match.
+    /// <c>{name} [{hostApi}]</c>. On Windows only <strong>WASAPI</strong>
+    /// endpoints are listed (MME / DirectSound / WDM-KS duplicates are hidden).
+    /// Legacy name-only settings still resolve.
     /// </summary>
     public static class AudioDeviceEnumerator
     {
         private static readonly object Sync = new();
         private static bool _initialized;
 
-        // Prefer shared-mode / modern APIs when a legacy name matches several entries.
+        // Prefer shared-mode / modern APIs when a legacy name matches several entries
+        // (mainly relevant on non-Windows, or if the WASAPI filter is relaxed later).
         private static readonly string[] PreferredHostApiSubstrings =
         {
             "WASAPI",
@@ -65,7 +67,8 @@ namespace Yaesu_Web_Control.Services.Audio
                     // Skip devices that won't describe themselves.
                 }
             }
-            return list;
+
+            return FilterForHost(list);
         }
 
         public static IReadOnlyList<AudioDeviceInfo> ListInputs() =>
@@ -99,11 +102,27 @@ namespace Yaesu_Web_Control.Services.Audio
                 var exact = candidates.FirstOrDefault(d =>
                     string.Equals(d.HostApiName, hostApi, StringComparison.OrdinalIgnoreCase));
                 if (exact != null) return exact.Index;
-                // Host API from settings no longer present — fall through to name match.
+                // Saved host API filtered out (e.g. old DirectSound key) — use name match.
             }
 
             if (candidates.Count == 1) return candidates[0].Index;
             return PreferHostApi(candidates).Index;
+        }
+
+        /// <summary>
+        /// On Windows, keep only WASAPI endpoints so USB CODECs are not listed
+        /// four times. If WASAPI yields nothing, fall back to the full list.
+        /// Other OSes are unchanged (Core Audio / ALSA / etc.).
+        /// </summary>
+        private static IReadOnlyList<AudioDeviceInfo> FilterForHost(List<AudioDeviceInfo> all)
+        {
+            if (!OperatingSystem.IsWindows() || all.Count == 0)
+                return all;
+
+            var wasapi = all
+                .Where(d => d.HostApiName.Contains("WASAPI", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            return wasapi.Count > 0 ? wasapi : all;
         }
 
         private static AudioDeviceInfo PreferHostApi(IReadOnlyList<AudioDeviceInfo> matches)

--- a/Services/Audio/AudioDeviceInfo.cs
+++ b/Services/Audio/AudioDeviceInfo.cs
@@ -1,0 +1,8 @@
+namespace Yaesu_Web_Control.Services.Audio
+{
+    public sealed record AudioDeviceInfo(int Index, string Name, int MaxInputChannels, int MaxOutputChannels, double DefaultSampleRate)
+    {
+        public bool IsInput => MaxInputChannels > 0;
+        public bool IsOutput => MaxOutputChannels > 0;
+    }
+}

--- a/Services/Audio/AudioDeviceInfo.cs
+++ b/Services/Audio/AudioDeviceInfo.cs
@@ -1,8 +1,22 @@
 namespace Yaesu_Web_Control.Services.Audio
 {
-    public sealed record AudioDeviceInfo(int Index, string Name, int MaxInputChannels, int MaxOutputChannels, double DefaultSampleRate)
+    public sealed record AudioDeviceInfo(
+        int Index,
+        string Name,
+        string HostApiName,
+        int HostApiIndex,
+        int MaxInputChannels,
+        int MaxOutputChannels,
+        double DefaultSampleRate)
     {
         public bool IsInput => MaxInputChannels > 0;
         public bool IsOutput => MaxOutputChannels > 0;
+
+        /// <summary>Human-readable label and persistence value (name + host API).</summary>
+        public string DisplayName =>
+            string.IsNullOrEmpty(HostApiName) ? Name : AudioDeviceKey.Format(Name, HostApiName);
+
+        /// <summary>Same as <see cref="DisplayName"/> — the string written to settings.</summary>
+        public string PersistenceKey => DisplayName;
     }
 }

--- a/Services/Audio/AudioDeviceKey.cs
+++ b/Services/Audio/AudioDeviceKey.cs
@@ -1,0 +1,46 @@
+namespace Yaesu_Web_Control.Services.Audio
+{
+    /// <summary>
+    /// Persistence / display key for a PortAudio device.
+    /// On Windows the same USB CODEC is enumerated once per host API
+    /// (MME, DirectSound, WASAPI, WDM-KS), so the key is
+    /// <c>{name} [{hostApi}]</c>. Legacy settings that stored only the
+    /// device name still resolve via name-only fallback.
+    /// </summary>
+    public static class AudioDeviceKey
+    {
+        public static string Format(string deviceName, string hostApiName) =>
+            $"{deviceName.Trim()} [{hostApiName.Trim()}]";
+
+        /// <summary>
+        /// Parses a saved key. When the host-API suffix is present,
+        /// <paramref name="hostApiName"/> is set; otherwise it is null
+        /// (legacy name-only settings).
+        /// </summary>
+        public static void Parse(string? key, out string? hostApiName, out string deviceName)
+        {
+            hostApiName = null;
+            deviceName = "";
+            if (string.IsNullOrWhiteSpace(key)) return;
+
+            var s = key.Trim();
+            if (s.EndsWith(']'))
+            {
+                int open = s.LastIndexOf(" [", StringComparison.Ordinal);
+                if (open > 0)
+                {
+                    var host = s[(open + 2)..^1].Trim();
+                    var name = s[..open].Trim();
+                    if (host.Length > 0 && name.Length > 0)
+                    {
+                        hostApiName = host;
+                        deviceName = name;
+                        return;
+                    }
+                }
+            }
+
+            deviceName = s;
+        }
+    }
+}

--- a/Services/Audio/AudioSessionManager.cs
+++ b/Services/Audio/AudioSessionManager.cs
@@ -1,0 +1,56 @@
+using System.Net.WebSockets;
+
+namespace Yaesu_Web_Control.Services.Audio
+{
+    /// <summary>
+    /// Single active remote-audio session. A second connect is rejected busy.
+    /// </summary>
+    public sealed class AudioSessionManager
+    {
+        private readonly object _lock = new();
+        private string? _connectionId;
+        private WebSocket? _socket;
+
+        public bool HasActiveSession
+        {
+            get { lock (_lock) return _socket is { State: WebSocketState.Open }; }
+        }
+
+        public string? ActiveConnectionId
+        {
+            get { lock (_lock) return _connectionId; }
+        }
+
+        /// <summary>
+        /// Try to claim the single audio session. Returns false if busy.
+        /// </summary>
+        public bool TryAcquire(string connectionId, WebSocket socket)
+        {
+            lock (_lock)
+            {
+                if (_socket is { State: WebSocketState.Open })
+                    return false;
+                _connectionId = connectionId;
+                _socket = socket;
+                return true;
+            }
+        }
+
+        public void Release(string connectionId)
+        {
+            lock (_lock)
+            {
+                if (_connectionId == connectionId)
+                {
+                    _connectionId = null;
+                    _socket = null;
+                }
+            }
+        }
+
+        public WebSocket? CurrentSocket
+        {
+            get { lock (_lock) return _socket; }
+        }
+    }
+}

--- a/Services/Audio/AudioWireProtocol.cs
+++ b/Services/Audio/AudioWireProtocol.cs
@@ -1,0 +1,47 @@
+using System.Buffers.Binary;
+using System.Text;
+using System.Text.Json;
+
+namespace Yaesu_Web_Control.Services.Audio
+{
+    /// <summary>
+    /// Length-prefixed binary framing for the /audio WebSocket.
+    /// Layout: length(u32 BE) | type(u8) | seq(u32 BE) | payload
+    /// </summary>
+    public static class AudioWireProtocol
+    {
+        public const int HeaderSize = 1 + 4; // type + seq (length is outside)
+
+        public static byte[] Frame(byte type, uint seq, ReadOnlySpan<byte> payload)
+        {
+            int bodyLen = HeaderSize + payload.Length;
+            var buf = new byte[4 + bodyLen];
+            BinaryPrimitives.WriteUInt32BigEndian(buf.AsSpan(0, 4), (uint)bodyLen);
+            buf[4] = type;
+            BinaryPrimitives.WriteUInt32BigEndian(buf.AsSpan(5, 4), seq);
+            payload.CopyTo(buf.AsSpan(9));
+            return buf;
+        }
+
+        public static byte[] FrameControl(uint seq, object payload)
+        {
+            var json = JsonSerializer.SerializeToUtf8Bytes(payload);
+            return Frame(AudioConstants.MsgControl, seq, json);
+        }
+
+        public static bool TryParse(ReadOnlySpan<byte> body, out byte type, out uint seq, out ReadOnlySpan<byte> payload)
+        {
+            type = 0;
+            seq = 0;
+            payload = default;
+            if (body.Length < HeaderSize) return false;
+            type = body[0];
+            seq = BinaryPrimitives.ReadUInt32BigEndian(body.Slice(1, 4));
+            payload = body.Slice(HeaderSize);
+            return true;
+        }
+
+        public static string ControlJson(ReadOnlySpan<byte> payload) =>
+            Encoding.UTF8.GetString(payload);
+    }
+}

--- a/Services/Audio/HttpsCertificateService.cs
+++ b/Services/Audio/HttpsCertificateService.cs
@@ -1,0 +1,99 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace Yaesu_Web_Control.Services.Audio
+{
+    /// <summary>
+    /// Generates and locates the optional self-signed HTTPS certificate in AppData.
+    /// </summary>
+    public static class HttpsCertificateService
+    {
+        public const string CertFileName = "https.pfx";
+        public const string PfxPassword = "ywc-https"; // local-only; enables cross-platform Kestrel load
+
+        public static string AppDataDirectory => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "MM5AGM", "Yaesu Web Control");
+
+        public static string CertificatePath => Path.Combine(AppDataDirectory, CertFileName);
+
+        public static bool CertificateExists => File.Exists(CertificatePath);
+
+        /// <summary>
+        /// Create a self-signed cert with localhost + optional SAN hostnames/IPs.
+        /// Overwrites any existing certificate.
+        /// </summary>
+        public static void Generate(IEnumerable<string> sanHosts, int validityYears = 2)
+        {
+            Directory.CreateDirectory(AppDataDirectory);
+
+            using var rsa = RSA.Create(2048);
+            var request = new CertificateRequest(
+                "CN=Yaesu Web Control",
+                rsa,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+
+            request.CertificateExtensions.Add(
+                new X509BasicConstraintsExtension(false, false, 0, false));
+            request.CertificateExtensions.Add(
+                new X509KeyUsageExtension(
+                    X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment,
+                    true));
+            request.CertificateExtensions.Add(
+                new X509EnhancedKeyUsageExtension(
+                    new OidCollection { new Oid("1.3.6.1.5.5.7.3.1") }, // serverAuth
+                    false));
+
+            var san = new SubjectAlternativeNameBuilder();
+            san.AddDnsName("localhost");
+            san.AddIpAddress(System.Net.IPAddress.Loopback);
+            san.AddIpAddress(System.Net.IPAddress.IPv6Loopback);
+
+            foreach (var raw in sanHosts)
+            {
+                var host = raw.Trim();
+                if (string.IsNullOrEmpty(host)) continue;
+                if (System.Net.IPAddress.TryParse(host, out var ip))
+                    san.AddIpAddress(ip);
+                else
+                    san.AddDnsName(host);
+            }
+
+            request.CertificateExtensions.Add(san.Build());
+
+            using var cert = request.CreateSelfSigned(
+                DateTimeOffset.UtcNow.AddDays(-1),
+                DateTimeOffset.UtcNow.AddYears(validityYears));
+
+            var pfxBytes = cert.Export(X509ContentType.Pfx, PfxPassword);
+            File.WriteAllBytes(CertificatePath, pfxBytes);
+        }
+
+        public static X509Certificate2? Load()
+        {
+            if (!CertificateExists) return null;
+            return X509CertificateLoader.LoadPkcs12FromFile(CertificatePath, PfxPassword);
+        }
+
+        public static string DescribeCertificate()
+        {
+            if (!CertificateExists) return "No certificate generated yet.";
+            try
+            {
+                using var cert = Load();
+                if (cert == null) return "Certificate file unreadable.";
+                var sb = new StringBuilder();
+                sb.Append($"Subject: {cert.Subject}; ");
+                sb.Append($"NotAfter: {cert.NotAfter:u}; ");
+                sb.Append($"Thumbprint: {cert.Thumbprint}");
+                return sb.ToString();
+            }
+            catch (Exception ex)
+            {
+                return $"Certificate error: {ex.Message}";
+            }
+        }
+    }
+}

--- a/Services/Audio/OpusCodec.cs
+++ b/Services/Audio/OpusCodec.cs
@@ -3,7 +3,11 @@ using Concentus.Enums;
 
 namespace Yaesu_Web_Control.Services.Audio
 {
-    /// <summary>Thin Concentus wrapper fixed at 48 kHz mono / 20 ms frames.</summary>
+    /// <summary>
+    /// Thin Concentus wrapper at 48 kHz mono.
+    /// Encodes 10 ms frames; decode accepts up to Opus max packet duration
+    /// (WebCodecs defaults to 20 ms unless configured otherwise).
+    /// </summary>
     public sealed class OpusCodec : IDisposable
     {
         private readonly IOpusEncoder _encoder;
@@ -28,7 +32,7 @@ namespace Yaesu_Web_Control.Services.Audio
         public int Encode(ReadOnlySpan<float> pcm, Span<byte> output)
         {
             if (pcm.Length < AudioConstants.FrameSamples)
-                throw new ArgumentException("Need a full 20 ms frame.", nameof(pcm));
+                throw new ArgumentException("Need a full 10 ms frame.", nameof(pcm));
             return _encoder.Encode(pcm[..AudioConstants.FrameSamples], AudioConstants.FrameSamples, output, output.Length);
         }
 
@@ -40,9 +44,20 @@ namespace Yaesu_Web_Control.Services.Audio
             return packet;
         }
 
+        /// <summary>
+        /// Decodes one Opus packet. <paramref name="pcmOut"/> must hold at least 960
+        /// samples (20 ms); prefer <see cref="AudioConstants.OpusDecodeMaxSamples"/>.
+        /// Returns samples written.
+        /// </summary>
         public int Decode(ReadOnlySpan<byte> packet, Span<float> pcmOut, bool decodeFec = false)
         {
-            return _decoder.Decode(packet, pcmOut, AudioConstants.FrameSamples, decodeFec);
+            if (pcmOut.Length < 960)
+                throw new ArgumentException("Decode buffer must hold at least 20 ms (960 samples).", nameof(pcmOut));
+
+            // frame_size is available space — must cover the packet duration (WebCodecs Opus
+            // defaults to 20 ms / 960 samples). Using the Opus maximum keeps us safe.
+            int frameSize = Math.Min(pcmOut.Length, AudioConstants.OpusDecodeMaxSamples);
+            return _decoder.Decode(packet, pcmOut[..frameSize], frameSize, decodeFec);
         }
 
         public void Dispose()

--- a/Services/Audio/OpusCodec.cs
+++ b/Services/Audio/OpusCodec.cs
@@ -1,0 +1,56 @@
+using Concentus;
+using Concentus.Enums;
+
+namespace Yaesu_Web_Control.Services.Audio
+{
+    /// <summary>Thin Concentus wrapper fixed at 48 kHz mono / 20 ms frames.</summary>
+    public sealed class OpusCodec : IDisposable
+    {
+        private readonly IOpusEncoder _encoder;
+        private readonly IOpusDecoder _decoder;
+        private readonly byte[] _encodeBuf = new byte[4000];
+        private bool _disposed;
+
+        public OpusCodec()
+        {
+            _encoder = OpusCodecFactory.CreateEncoder(
+                AudioConstants.SampleRate,
+                AudioConstants.Channels,
+                OpusApplication.OPUS_APPLICATION_VOIP);
+            _encoder.Bitrate = AudioConstants.OpusBitrate;
+            _encoder.Complexity = 5;
+
+            _decoder = OpusCodecFactory.CreateDecoder(
+                AudioConstants.SampleRate,
+                AudioConstants.Channels);
+        }
+
+        public int Encode(ReadOnlySpan<float> pcm, Span<byte> output)
+        {
+            if (pcm.Length < AudioConstants.FrameSamples)
+                throw new ArgumentException("Need a full 20 ms frame.", nameof(pcm));
+            return _encoder.Encode(pcm[..AudioConstants.FrameSamples], AudioConstants.FrameSamples, output, output.Length);
+        }
+
+        public byte[] Encode(ReadOnlySpan<float> pcm)
+        {
+            int n = Encode(pcm, _encodeBuf);
+            var packet = new byte[n];
+            _encodeBuf.AsSpan(0, n).CopyTo(packet);
+            return packet;
+        }
+
+        public int Decode(ReadOnlySpan<byte> packet, Span<float> pcmOut, bool decodeFec = false)
+        {
+            return _decoder.Decode(packet, pcmOut, AudioConstants.FrameSamples, decodeFec);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            (_encoder as IDisposable)?.Dispose();
+            (_decoder as IDisposable)?.Dispose();
+        }
+    }
+}

--- a/Services/Audio/RadioAudioBridgeService.cs
+++ b/Services/Audio/RadioAudioBridgeService.cs
@@ -59,6 +59,15 @@ namespace Yaesu_Web_Control.Services.Audio
         public float TxLevel => _txLevel;
         public bool DevicesOpen => _devicesOpen;
         public string ActiveCodec => _codecName;
+        public float RxGain => _rxGain;
+        public float TxGain => _txGain;
+
+        /// <summary>Update live gains (session or idle). Values are clamped.</summary>
+        public void SetGains(float? rx = null, float? tx = null)
+        {
+            if (rx.HasValue) _rxGain = Math.Clamp(rx.Value, 0.05f, 4f);
+            if (tx.HasValue) _txGain = Math.Clamp(tx.Value, 0.05f, 4f);
+        }
 
         public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 

--- a/Services/Audio/RadioAudioBridgeService.cs
+++ b/Services/Audio/RadioAudioBridgeService.cs
@@ -1,8 +1,8 @@
 using System.Buffers.Binary;
-using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using System.Threading.Channels;
 using Microsoft.Extensions.Hosting;
 using PortAudioSharp;
 using Yaesu_Web_Control.Models;
@@ -11,7 +11,8 @@ namespace Yaesu_Web_Control.Services.Audio
 {
     /// <summary>
     /// Bridges radio USB audio (PortAudio) to a single browser WebSocket client
-    /// using Opus (preferred) or PCM16 frames.
+    /// using Opus or PCM16 frames. RX packets are sent as soon as a frame is
+    /// ready (not on a timer) to keep LAN latency low.
     /// </summary>
     public sealed class RadioAudioBridgeService : IHostedService, IDisposable
     {
@@ -19,7 +20,6 @@ namespace Yaesu_Web_Control.Services.Audio
         private readonly ISettingsService _settings;
         private readonly AudioSessionManager _sessions;
 
-        private readonly ConcurrentQueue<byte[]> _txQueue = new();
         private readonly object _deviceLock = new();
 
         private PortAudioSharp.Stream? _captureStream;
@@ -30,11 +30,13 @@ namespace Yaesu_Web_Control.Services.Audio
         private float _txGain = 1f;
         private int _rxSeq;
         private CancellationTokenSource? _pumpCts;
-        private Task? _pumpTask;
+        private Task? _sendTask;
+        private Task? _levelsTask;
         private WebSocket? _activeSocket;
+        private Channel<byte[]>? _outChannel;
         private readonly float[] _captureAccum = new float[AudioConstants.FrameSamples * 4];
         private int _captureAccumLen;
-        private readonly float[] _playbackRing = new float[AudioConstants.SampleRate]; // 1s
+        private readonly float[] _playbackRing = new float[AudioConstants.PlaybackRingMaxSamples];
         private int _playbackWrite;
         private int _playbackRead;
         private int _playbackCount;
@@ -125,7 +127,6 @@ namespace Yaesu_Web_Control.Services.Audio
             _codecName = AudioConstants.CodecOpus;
             _codec = new OpusCodec();
 
-            // Wait for client hello (control) before opening devices, so we can pick codec.
             using var helloCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             helloCts.CancelAfter(TimeSpan.FromSeconds(10));
             var hello = await ReceiveOneMessageAsync(socket, helloCts.Token);
@@ -160,9 +161,6 @@ namespace Yaesu_Web_Control.Services.Audio
                     if (s == AudioConstants.CodecOpus) wantsOpus = true;
                     if (s == AudioConstants.CodecPcm16) wantsPcm = true;
                 }
-                // Prefer PCM16 when offered — reliable across browsers without
-                // depending on WebCodecs↔Concentus Opus packet interop. Opus
-                // remains available when the client only advertises opus.
                 if (wantsPcm) _codecName = AudioConstants.CodecPcm16;
                 else if (wantsOpus) _codecName = AudioConstants.CodecOpus;
             }
@@ -182,8 +180,16 @@ namespace Yaesu_Web_Control.Services.Audio
                 frameSamples = AudioConstants.FrameSamples
             });
 
+            _outChannel = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(48)
+            {
+                FullMode = BoundedChannelFullMode.DropOldest,
+                SingleReader = true,
+                SingleWriter = false
+            });
+
             _pumpCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            _pumpTask = Task.Run(() => LevelPumpAsync(_pumpCts.Token), _pumpCts.Token);
+            _sendTask = Task.Run(() => SendPumpAsync(socket, _pumpCts.Token), _pumpCts.Token);
+            _levelsTask = Task.Run(() => LevelsPumpAsync(socket, _pumpCts.Token), _pumpCts.Token);
 
             var buffer = new byte[64 * 1024];
             while (socket.State == WebSocketState.Open && !ct.IsCancellationRequested)
@@ -205,13 +211,9 @@ namespace Yaesu_Web_Control.Services.Audio
                 if (!AudioWireProtocol.TryParse(body, out var msgType, out _, out var msgPayload)) continue;
 
                 if (msgType == AudioConstants.MsgOpusTx || msgType == AudioConstants.MsgPcmTx)
-                {
                     HandleTxAudio(msgType, msgPayload);
-                }
                 else if (msgType == AudioConstants.MsgControl)
-                {
                     HandleControl(msgPayload);
-                }
             }
         }
 
@@ -275,7 +277,6 @@ namespace Yaesu_Web_Control.Services.Audio
                 {
                     if (_playbackCount >= _playbackRing.Length)
                     {
-                        // Drop oldest sample on overrun
                         _playbackRead = (_playbackRead + 1) % _playbackRing.Length;
                         _playbackCount--;
                     }
@@ -326,12 +327,18 @@ namespace Yaesu_Web_Control.Services.Audio
                     var rxInfo = PortAudio.GetDeviceInfo(rxIndex);
                     var txInfo = PortAudio.GetDeviceInfo(txIndex);
 
+                    const double targetLatency = 0.01;
+                    double inLat = Math.Min(rxInfo.defaultLowInputLatency > 0 ? rxInfo.defaultLowInputLatency : targetLatency, 0.02);
+                    double outLat = Math.Min(txInfo.defaultLowOutputLatency > 0 ? txInfo.defaultLowOutputLatency : targetLatency, 0.02);
+                    inLat = Math.Max(inLat, 0.005);
+                    outLat = Math.Max(outLat, 0.005);
+
                     var inParams = new StreamParameters
                     {
                         device = rxIndex,
                         channelCount = 1,
                         sampleFormat = SampleFormat.Float32,
-                        suggestedLatency = rxInfo.defaultLowInputLatency,
+                        suggestedLatency = inLat,
                         hostApiSpecificStreamInfo = IntPtr.Zero
                     };
 
@@ -340,7 +347,7 @@ namespace Yaesu_Web_Control.Services.Audio
                         device = txIndex,
                         channelCount = 1,
                         sampleFormat = SampleFormat.Float32,
-                        suggestedLatency = txInfo.defaultLowOutputLatency,
+                        suggestedLatency = outLat,
                         hostApiSpecificStreamInfo = IntPtr.Zero
                     };
 
@@ -386,8 +393,8 @@ namespace Yaesu_Web_Control.Services.Audio
                     _playbackStream.Start();
                     _devicesOpen = true;
                     _logger.LogInformation(
-                        "Audio devices open — RX '{Rx}' (#{RxI}), TX '{Tx}' (#{TxI}), codec={Codec}",
-                        rxInfo.name, rxIndex, txInfo.name, txIndex, _codecName);
+                        "Audio devices open — RX '{Rx}' (#{RxI}), TX '{Tx}' (#{TxI}), codec={Codec}, frame={Frame} samples",
+                        rxInfo.name, rxIndex, txInfo.name, txIndex, _codecName, AudioConstants.FrameSamples);
                     return null;
                 }
                 catch (Exception ex)
@@ -401,7 +408,6 @@ namespace Yaesu_Web_Control.Services.Audio
 
         private void OnCaptureSamples(float[] samples)
         {
-            // Accumulate to 20 ms frames, encode, queue for send.
             Span<float> frame = stackalloc float[AudioConstants.FrameSamples];
             int offset = 0;
             while (offset < samples.Length)
@@ -444,7 +450,8 @@ namespace Yaesu_Web_Control.Services.Audio
                     }
 
                     uint seq = (uint)Interlocked.Increment(ref _rxSeq);
-                    _txQueue.Enqueue(AudioWireProtocol.Frame(msgType, seq, packet));
+                    var framed = AudioWireProtocol.Frame(msgType, seq, packet);
+                    _outChannel?.Writer.TryWrite(framed);
 
                     int remain = _captureAccumLen - AudioConstants.FrameSamples;
                     if (remain > 0)
@@ -454,54 +461,69 @@ namespace Yaesu_Web_Control.Services.Audio
             }
         }
 
-        private async Task LevelPumpAsync(CancellationToken ct)
+        private async Task SendPumpAsync(WebSocket socket, CancellationToken ct)
+        {
+            var channel = _outChannel;
+            if (channel == null) return;
+
+            try
+            {
+                await foreach (var frame in channel.Reader.ReadAllAsync(ct))
+                {
+                    if (socket.State != WebSocketState.Open) break;
+                    await socket.SendAsync(frame, WebSocketMessageType.Binary, true, ct);
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Audio send pump failed");
+            }
+        }
+
+        private async Task LevelsPumpAsync(WebSocket socket, CancellationToken ct)
         {
             while (!ct.IsCancellationRequested)
             {
                 try
                 {
-                    var socket = _activeSocket;
-                    if (socket is { State: WebSocketState.Open })
-                    {
-                        while (_txQueue.TryDequeue(out var frame))
-                        {
-                            await socket.SendAsync(frame, WebSocketMessageType.Binary, true, ct);
-                        }
-
-                        // Periodic levels (~5 Hz)
-                        var levels = AudioWireProtocol.FrameControl(
-                            (uint)Interlocked.Increment(ref _rxSeq),
-                            new { cmd = "levels", rx = _rxLevel, tx = _txLevel });
-                        await socket.SendAsync(levels, WebSocketMessageType.Binary, true, ct);
-                    }
+                    await Task.Delay(100, ct);
+                    if (socket.State != WebSocketState.Open) break;
+                    var levels = AudioWireProtocol.FrameControl(
+                        (uint)Interlocked.Increment(ref _rxSeq),
+                        new { cmd = "levels", rx = _rxLevel, tx = _txLevel });
+                    await socket.SendAsync(levels, WebSocketMessageType.Binary, true, ct);
                 }
                 catch (OperationCanceledException) { break; }
                 catch (Exception ex)
                 {
-                    _logger.LogDebug(ex, "Audio pump send failed");
+                    _logger.LogDebug(ex, "Audio levels pump failed");
                     break;
                 }
-
-                try { await Task.Delay(50, ct); }
-                catch (OperationCanceledException) { break; }
             }
         }
 
         private async Task StopSessionAsync()
         {
+            try { _outChannel?.Writer.TryComplete(); } catch { /* ignore */ }
             try { _pumpCts?.Cancel(); } catch { /* ignore */ }
-            if (_pumpTask != null)
+            if (_sendTask != null)
             {
-                try { await _pumpTask; } catch { /* ignore */ }
-                _pumpTask = null;
+                try { await _sendTask; } catch { /* ignore */ }
+                _sendTask = null;
+            }
+            if (_levelsTask != null)
+            {
+                try { await _levelsTask; } catch { /* ignore */ }
+                _levelsTask = null;
             }
             _pumpCts?.Dispose();
             _pumpCts = null;
+            _outChannel = null;
             CloseDevices();
             _codec?.Dispose();
             _codec = null;
             _activeSocket = null;
-            while (_txQueue.TryDequeue(out _)) { }
             lock (_playbackLock)
             {
                 _playbackCount = 0;

--- a/Services/Audio/RadioAudioBridgeService.cs
+++ b/Services/Audio/RadioAudioBridgeService.cs
@@ -327,6 +327,20 @@ namespace Yaesu_Web_Control.Services.Audio
                     var rxInfo = PortAudio.GetDeviceInfo(rxIndex);
                     var txInfo = PortAudio.GetDeviceInfo(txIndex);
 
+                    // WASAPI shared mode usually requires the device mix format
+                    // (typically stereo). Opening mono against a 2-ch USB CODEC
+                    // fails with InvalidChannelCount — open stereo and mix to mono.
+                    int inCh = rxInfo.maxInputChannels >= 2 ? 2 : Math.Max(1, rxInfo.maxInputChannels);
+                    int outCh = txInfo.maxOutputChannels >= 2 ? 2 : Math.Max(1, txInfo.maxOutputChannels);
+
+                    // Same for sample rate: WASAPI rejects a rate that isn't the
+                    // shared-mode mix format. Open at each device's default and
+                    // resample to/from the 48 kHz bridge.
+                    int rxRate = PickDeviceSampleRate(rxInfo.defaultSampleRate);
+                    int txRate = PickDeviceSampleRate(txInfo.defaultSampleRate);
+                    uint rxFrames = DeviceFramesPerBuffer(rxRate);
+                    uint txFrames = DeviceFramesPerBuffer(txRate);
+
                     const double targetLatency = 0.01;
                     double inLat = Math.Min(rxInfo.defaultLowInputLatency > 0 ? rxInfo.defaultLowInputLatency : targetLatency, 0.02);
                     double outLat = Math.Min(txInfo.defaultLowOutputLatency > 0 ? txInfo.defaultLowOutputLatency : targetLatency, 0.02);
@@ -336,7 +350,7 @@ namespace Yaesu_Web_Control.Services.Audio
                     var inParams = new StreamParameters
                     {
                         device = rxIndex,
-                        channelCount = 1,
+                        channelCount = inCh,
                         sampleFormat = SampleFormat.Float32,
                         suggestedLatency = inLat,
                         hostApiSpecificStreamInfo = IntPtr.Zero
@@ -345,7 +359,7 @@ namespace Yaesu_Web_Control.Services.Audio
                     var outParams = new StreamParameters
                     {
                         device = txIndex,
-                        channelCount = 1,
+                        channelCount = outCh,
                         sampleFormat = SampleFormat.Float32,
                         suggestedLatency = outLat,
                         hostApiSpecificStreamInfo = IntPtr.Zero
@@ -355,9 +369,20 @@ namespace Yaesu_Web_Control.Services.Audio
                         ref StreamCallbackTimeInfo timeInfo, StreamCallbackFlags statusFlags, IntPtr userData) =>
                     {
                         if (input == IntPtr.Zero) return StreamCallbackResult.Continue;
-                        var samples = new float[frameCount];
-                        Marshal.Copy(input, samples, 0, (int)frameCount);
-                        OnCaptureSamples(samples);
+                        int interleaved = (int)frameCount * inCh;
+                        var raw = new float[interleaved];
+                        Marshal.Copy(input, raw, 0, interleaved);
+                        var mono = new float[frameCount];
+                        if (inCh == 1)
+                        {
+                            Array.Copy(raw, mono, (int)frameCount);
+                        }
+                        else
+                        {
+                            for (int i = 0; i < (int)frameCount; i++)
+                                mono[i] = 0.5f * (raw[i * inCh] + raw[i * inCh + 1]);
+                        }
+                        OnCaptureSamples(Resample(mono, rxRate, AudioConstants.SampleRate));
                         return StreamCallbackResult.Continue;
                     };
 
@@ -365,17 +390,41 @@ namespace Yaesu_Web_Control.Services.Audio
                         ref StreamCallbackTimeInfo timeInfo, StreamCallbackFlags statusFlags, IntPtr userData) =>
                     {
                         if (output == IntPtr.Zero) return StreamCallbackResult.Continue;
-                        var samples = new float[frameCount];
-                        PullPlayback(samples);
-                        Marshal.Copy(samples, 0, output, (int)frameCount);
+                        int bridgeCount = Math.Max(1,
+                            (int)Math.Round(frameCount * (double)AudioConstants.SampleRate / txRate));
+                        var bridge = new float[bridgeCount];
+                        PullPlayback(bridge);
+                        var mono = Resample(bridge, AudioConstants.SampleRate, txRate);
+                        // Callback asked for frameCount samples; pad/truncate if rounding drifted.
+                        if (mono.Length != frameCount)
+                        {
+                            var adjusted = new float[frameCount];
+                            Array.Copy(mono, adjusted, Math.Min(mono.Length, (int)frameCount));
+                            mono = adjusted;
+                        }
+                        if (outCh == 1)
+                        {
+                            Marshal.Copy(mono, 0, output, (int)frameCount);
+                        }
+                        else
+                        {
+                            var interleaved = new float[frameCount * outCh];
+                            for (int i = 0; i < (int)frameCount; i++)
+                            {
+                                float s = mono[i];
+                                interleaved[i * outCh] = s;
+                                interleaved[i * outCh + 1] = s;
+                            }
+                            Marshal.Copy(interleaved, 0, output, interleaved.Length);
+                        }
                         return StreamCallbackResult.Continue;
                     };
 
                     _captureStream = new PortAudioSharp.Stream(
                         inParams: inParams,
                         outParams: null,
-                        sampleRate: AudioConstants.SampleRate,
-                        framesPerBuffer: (uint)AudioConstants.FrameSamples,
+                        sampleRate: rxRate,
+                        framesPerBuffer: rxFrames,
                         streamFlags: StreamFlags.ClipOff,
                         callback: captureCb,
                         userData: IntPtr.Zero);
@@ -383,8 +432,8 @@ namespace Yaesu_Web_Control.Services.Audio
                     _playbackStream = new PortAudioSharp.Stream(
                         inParams: null,
                         outParams: outParams,
-                        sampleRate: AudioConstants.SampleRate,
-                        framesPerBuffer: (uint)AudioConstants.FrameSamples,
+                        sampleRate: txRate,
+                        framesPerBuffer: txFrames,
                         streamFlags: StreamFlags.ClipOff,
                         callback: playbackCb,
                         userData: IntPtr.Zero);
@@ -393,9 +442,16 @@ namespace Yaesu_Web_Control.Services.Audio
                     _playbackStream.Start();
                     _devicesOpen = true;
                     _logger.LogInformation(
-                        "Audio devices open — RX '{Rx}' (#{RxI}), TX '{Tx}' (#{TxI}), codec={Codec}, frame={Frame} samples",
-                        rxInfo.name, rxIndex, txInfo.name, txIndex, _codecName, AudioConstants.FrameSamples);
+                        "Audio devices open — RX '{Rx}' (#{RxI}, {InCh}ch @{RxRate} Hz), TX '{Tx}' (#{TxI}, {OutCh}ch @{TxRate} Hz), codec={Codec}, bridge={Bridge} Hz",
+                        rxInfo.name, rxIndex, inCh, rxRate, txInfo.name, txIndex, outCh, txRate, _codecName, AudioConstants.SampleRate);
                     return null;
+                }
+                catch (PortAudioException ex)
+                {
+                    string detail = PortAudio.GetErrorText(ex.ErrorCode);
+                    _logger.LogError(ex, "Failed to open audio devices ({Code}: {Detail})", ex.ErrorCode, detail);
+                    CloseDevices();
+                    return $"Failed to open audio devices: {ex.ErrorCode} — {detail}";
                 }
                 catch (Exception ex)
                 {
@@ -404,6 +460,41 @@ namespace Yaesu_Web_Control.Services.Audio
                     return $"Failed to open audio devices: {ex.Message}";
                 }
             }
+        }
+
+        private static int PickDeviceSampleRate(double defaultRate)
+        {
+            int rate = (int)Math.Round(defaultRate);
+            if (rate >= 8_000 && rate <= 192_000) return rate;
+            return AudioConstants.SampleRate;
+        }
+
+        /// <summary>~10 ms worth of frames at the device rate (matches bridge frame duration).</summary>
+        private static uint DeviceFramesPerBuffer(int deviceRate) =>
+            (uint)Math.Max(64, (int)Math.Round(deviceRate * AudioConstants.FrameSamples / (double)AudioConstants.SampleRate));
+
+        private static float[] Resample(ReadOnlySpan<float> input, int inRate, int outRate)
+        {
+            if (inRate == outRate || input.Length == 0)
+                return input.ToArray();
+
+            int outLen = Math.Max(1, (int)Math.Round(input.Length * (double)outRate / inRate));
+            var output = new float[outLen];
+            double ratio = (double)inRate / outRate;
+            int last = input.Length - 1;
+            for (int i = 0; i < outLen; i++)
+            {
+                double src = i * ratio;
+                int i0 = (int)src;
+                if (i0 >= last)
+                {
+                    output[i] = input[last];
+                    continue;
+                }
+                double frac = src - i0;
+                output[i] = (float)(input[i0] + (input[i0 + 1] - input[i0]) * frac);
+            }
+            return output;
         }
 
         private void OnCaptureSamples(float[] samples)

--- a/Services/Audio/RadioAudioBridgeService.cs
+++ b/Services/Audio/RadioAudioBridgeService.cs
@@ -442,8 +442,8 @@ namespace Yaesu_Web_Control.Services.Audio
                     _playbackStream.Start();
                     _devicesOpen = true;
                     _logger.LogInformation(
-                        "Audio devices open — RX '{Rx}' (#{RxI}, {InCh}ch @{RxRate} Hz), TX '{Tx}' (#{TxI}, {OutCh}ch @{TxRate} Hz), codec={Codec}, bridge={Bridge} Hz",
-                        rxInfo.name, rxIndex, inCh, rxRate, txInfo.name, txIndex, outCh, txRate, _codecName, AudioConstants.SampleRate);
+                        "Audio devices open — RX '{Rx}' (#{RxI}, {InCh}ch @{RxRate} Hz), TX '{Tx}' (#{TxI}, {OutCh}ch @{TxRate} Hz), codec={Codec}, bridge={Bridge} Hz, frame={Frame} samples",
+                        rxInfo.name, rxIndex, inCh, rxRate, txInfo.name, txIndex, outCh, txRate, _codecName, AudioConstants.SampleRate, AudioConstants.FrameSamples);
                     return null;
                 }
                 catch (PortAudioException ex)

--- a/Services/Audio/RadioAudioBridgeService.cs
+++ b/Services/Audio/RadioAudioBridgeService.cs
@@ -1,0 +1,560 @@
+using System.Buffers.Binary;
+using System.Collections.Concurrent;
+using System.Net.WebSockets;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using Microsoft.Extensions.Hosting;
+using PortAudioSharp;
+using Yaesu_Web_Control.Models;
+
+namespace Yaesu_Web_Control.Services.Audio
+{
+    /// <summary>
+    /// Bridges radio USB audio (PortAudio) to a single browser WebSocket client
+    /// using Opus (preferred) or PCM16 frames.
+    /// </summary>
+    public sealed class RadioAudioBridgeService : IHostedService, IDisposable
+    {
+        private readonly ILogger<RadioAudioBridgeService> _logger;
+        private readonly ISettingsService _settings;
+        private readonly AudioSessionManager _sessions;
+
+        private readonly ConcurrentQueue<byte[]> _txQueue = new();
+        private readonly object _deviceLock = new();
+
+        private PortAudioSharp.Stream? _captureStream;
+        private PortAudioSharp.Stream? _playbackStream;
+        private OpusCodec? _codec;
+        private string _codecName = AudioConstants.CodecOpus;
+        private float _rxGain = 1f;
+        private float _txGain = 1f;
+        private int _rxSeq;
+        private CancellationTokenSource? _pumpCts;
+        private Task? _pumpTask;
+        private WebSocket? _activeSocket;
+        private readonly float[] _captureAccum = new float[AudioConstants.FrameSamples * 4];
+        private int _captureAccumLen;
+        private readonly float[] _playbackRing = new float[AudioConstants.SampleRate]; // 1s
+        private int _playbackWrite;
+        private int _playbackRead;
+        private int _playbackCount;
+        private readonly object _playbackLock = new();
+        private bool _devicesOpen;
+        private float _rxLevel;
+        private float _txLevel;
+
+        public RadioAudioBridgeService(
+            ILogger<RadioAudioBridgeService> logger,
+            ISettingsService settings,
+            AudioSessionManager sessions)
+        {
+            _logger = logger;
+            _settings = settings;
+            _sessions = sessions;
+        }
+
+        public float RxLevel => _rxLevel;
+        public float TxLevel => _txLevel;
+        public bool DevicesOpen => _devicesOpen;
+        public string ActiveCodec => _codecName;
+
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            await StopSessionAsync();
+        }
+
+        public async Task HandleWebSocketAsync(HttpContext context)
+        {
+            if (!context.WebSockets.IsWebSocketRequest)
+            {
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                return;
+            }
+
+            var settings = await _settings.GetSettingsAsync();
+            if (!settings.AudioStreamingEnabled)
+            {
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                await context.Response.WriteAsync("Remote audio is disabled in Settings.");
+                return;
+            }
+
+            var socket = await context.WebSockets.AcceptWebSocketAsync();
+            var connectionId = context.Connection.Id;
+
+            if (!_sessions.TryAcquire(connectionId, socket))
+            {
+                var busy = AudioWireProtocol.FrameControl(0, new { cmd = "busy", message = "Another audio session is already active." });
+                await socket.SendAsync(busy, WebSocketMessageType.Binary, true, CancellationToken.None);
+                await socket.CloseAsync(WebSocketCloseStatus.PolicyViolation, "busy", CancellationToken.None);
+                return;
+            }
+
+            _activeSocket = socket;
+            _logger.LogInformation("Audio WebSocket connected ({Id})", connectionId);
+
+            try
+            {
+                await RunSessionAsync(socket, settings, context.RequestAborted);
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Audio session failed");
+            }
+            finally
+            {
+                await StopSessionAsync();
+                _sessions.Release(connectionId);
+                if (socket.State == WebSocketState.Open)
+                {
+                    try { await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None); }
+                    catch { /* ignore */ }
+                }
+                socket.Dispose();
+                _logger.LogInformation("Audio WebSocket disconnected ({Id})", connectionId);
+            }
+        }
+
+        private async Task RunSessionAsync(WebSocket socket, ApplicationSettings settings, CancellationToken ct)
+        {
+            _rxGain = Math.Clamp(settings.AudioRxGain, 0.05f, 4f);
+            _txGain = Math.Clamp(settings.AudioTxGain, 0.05f, 4f);
+            _codecName = AudioConstants.CodecOpus;
+            _codec = new OpusCodec();
+
+            // Wait for client hello (control) before opening devices, so we can pick codec.
+            using var helloCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            helloCts.CancelAfter(TimeSpan.FromSeconds(10));
+            var hello = await ReceiveOneMessageAsync(socket, helloCts.Token);
+            if (hello == null)
+            {
+                await SendControlAsync(socket, new { cmd = "error", message = "Expected hello control message." });
+                return;
+            }
+
+            if (!AudioWireProtocol.TryParse(hello, out var type, out _, out var payload) || type != AudioConstants.MsgControl)
+            {
+                await SendControlAsync(socket, new { cmd = "error", message = "First message must be control hello." });
+                return;
+            }
+
+            using var doc = JsonDocument.Parse(payload.ToArray());
+            var root = doc.RootElement;
+            var cmd = root.TryGetProperty("cmd", out var c) ? c.GetString() : null;
+            if (!string.Equals(cmd, "hello", StringComparison.OrdinalIgnoreCase))
+            {
+                await SendControlAsync(socket, new { cmd = "error", message = "Expected cmd=hello." });
+                return;
+            }
+
+            _codecName = AudioConstants.CodecPcm16;
+            if (root.TryGetProperty("codecs", out var codecs) && codecs.ValueKind == JsonValueKind.Array)
+            {
+                bool wantsOpus = false, wantsPcm = false;
+                foreach (var el in codecs.EnumerateArray())
+                {
+                    var s = el.GetString();
+                    if (s == AudioConstants.CodecOpus) wantsOpus = true;
+                    if (s == AudioConstants.CodecPcm16) wantsPcm = true;
+                }
+                // Prefer PCM16 when offered — reliable across browsers without
+                // depending on WebCodecs↔Concentus Opus packet interop. Opus
+                // remains available when the client only advertises opus.
+                if (wantsPcm) _codecName = AudioConstants.CodecPcm16;
+                else if (wantsOpus) _codecName = AudioConstants.CodecOpus;
+            }
+
+            string? openError = OpenDevices(settings);
+            if (openError != null)
+            {
+                await SendControlAsync(socket, new { cmd = "error", message = openError });
+                return;
+            }
+
+            await SendControlAsync(socket, new
+            {
+                cmd = "ready",
+                codec = _codecName,
+                sampleRate = AudioConstants.SampleRate,
+                frameSamples = AudioConstants.FrameSamples
+            });
+
+            _pumpCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            _pumpTask = Task.Run(() => LevelPumpAsync(_pumpCts.Token), _pumpCts.Token);
+
+            var buffer = new byte[64 * 1024];
+            while (socket.State == WebSocketState.Open && !ct.IsCancellationRequested)
+            {
+                using var ms = new MemoryStream();
+                WebSocketReceiveResult result;
+                do
+                {
+                    result = await socket.ReceiveAsync(buffer, ct);
+                    if (result.MessageType == WebSocketMessageType.Close) return;
+                    ms.Write(buffer, 0, result.Count);
+                } while (!result.EndOfMessage);
+
+                var msg = ms.ToArray();
+                if (msg.Length < 4) continue;
+                uint bodyLen = BinaryPrimitives.ReadUInt32BigEndian(msg.AsSpan(0, 4));
+                if (msg.Length < 4 + bodyLen) continue;
+                var body = msg.AsSpan(4, (int)bodyLen);
+                if (!AudioWireProtocol.TryParse(body, out var msgType, out _, out var msgPayload)) continue;
+
+                if (msgType == AudioConstants.MsgOpusTx || msgType == AudioConstants.MsgPcmTx)
+                {
+                    HandleTxAudio(msgType, msgPayload);
+                }
+                else if (msgType == AudioConstants.MsgControl)
+                {
+                    HandleControl(msgPayload);
+                }
+            }
+        }
+
+        private void HandleControl(ReadOnlySpan<byte> payload)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(payload.ToArray());
+                var root = doc.RootElement;
+                var cmd = root.TryGetProperty("cmd", out var c) ? c.GetString() : null;
+                if (cmd == "setGain")
+                {
+                    if (root.TryGetProperty("rx", out var rx) && rx.TryGetSingle(out var rxf))
+                        _rxGain = Math.Clamp(rxf, 0.05f, 4f);
+                    if (root.TryGetProperty("tx", out var tx) && tx.TryGetSingle(out var txf))
+                        _txGain = Math.Clamp(txf, 0.05f, 4f);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Ignoring bad audio control message");
+            }
+        }
+
+        private void HandleTxAudio(byte msgType, ReadOnlySpan<byte> payload)
+        {
+            Span<float> pcm = stackalloc float[AudioConstants.FrameSamples];
+            int n;
+            if (msgType == AudioConstants.MsgOpusTx)
+            {
+                if (_codec == null) return;
+                n = _codec.Decode(payload, pcm);
+            }
+            else
+            {
+                n = Math.Min(AudioConstants.FrameSamples, payload.Length / 2);
+                for (int i = 0; i < n; i++)
+                {
+                    short s = BinaryPrimitives.ReadInt16LittleEndian(payload.Slice(i * 2, 2));
+                    pcm[i] = s / 32768f;
+                }
+            }
+
+            float peak = 0;
+            for (int i = 0; i < n; i++)
+            {
+                float v = pcm[i] * _txGain;
+                pcm[i] = Math.Clamp(v, -1f, 1f);
+                float a = Math.Abs(pcm[i]);
+                if (a > peak) peak = a;
+            }
+            _txLevel = peak;
+            PushPlayback(pcm[..n]);
+        }
+
+        private void PushPlayback(ReadOnlySpan<float> samples)
+        {
+            lock (_playbackLock)
+            {
+                foreach (var s in samples)
+                {
+                    if (_playbackCount >= _playbackRing.Length)
+                    {
+                        // Drop oldest sample on overrun
+                        _playbackRead = (_playbackRead + 1) % _playbackRing.Length;
+                        _playbackCount--;
+                    }
+                    _playbackRing[_playbackWrite] = s;
+                    _playbackWrite = (_playbackWrite + 1) % _playbackRing.Length;
+                    _playbackCount++;
+                }
+            }
+        }
+
+        private int PullPlayback(Span<float> dest)
+        {
+            lock (_playbackLock)
+            {
+                int n = Math.Min(dest.Length, _playbackCount);
+                for (int i = 0; i < n; i++)
+                {
+                    dest[i] = _playbackRing[_playbackRead];
+                    _playbackRead = (_playbackRead + 1) % _playbackRing.Length;
+                }
+                for (int i = n; i < dest.Length; i++) dest[i] = 0;
+                _playbackCount -= n;
+                return n;
+            }
+        }
+
+        private string? OpenDevices(ApplicationSettings settings)
+        {
+            lock (_deviceLock)
+            {
+                try
+                {
+                    AudioDeviceEnumerator.EnsureInitialized();
+
+                    int rxIndex = AudioDeviceEnumerator.FindDeviceIndex(settings.AudioRadioRxDevice, requireInput: true, requireOutput: false);
+                    int txIndex = AudioDeviceEnumerator.FindDeviceIndex(settings.AudioRadioTxDevice, requireInput: false, requireOutput: true);
+
+                    if (rxIndex < 0 && string.IsNullOrWhiteSpace(settings.AudioRadioRxDevice))
+                        rxIndex = PortAudio.DefaultInputDevice;
+                    if (txIndex < 0 && string.IsNullOrWhiteSpace(settings.AudioRadioTxDevice))
+                        txIndex = PortAudio.DefaultOutputDevice;
+
+                    if (rxIndex < 0)
+                        return "Radio RX (capture) device not found. Pick it in Settings → Remote Audio.";
+                    if (txIndex < 0)
+                        return "Radio TX (playback) device not found. Pick it in Settings → Remote Audio.";
+
+                    var rxInfo = PortAudio.GetDeviceInfo(rxIndex);
+                    var txInfo = PortAudio.GetDeviceInfo(txIndex);
+
+                    var inParams = new StreamParameters
+                    {
+                        device = rxIndex,
+                        channelCount = 1,
+                        sampleFormat = SampleFormat.Float32,
+                        suggestedLatency = rxInfo.defaultLowInputLatency,
+                        hostApiSpecificStreamInfo = IntPtr.Zero
+                    };
+
+                    var outParams = new StreamParameters
+                    {
+                        device = txIndex,
+                        channelCount = 1,
+                        sampleFormat = SampleFormat.Float32,
+                        suggestedLatency = txInfo.defaultLowOutputLatency,
+                        hostApiSpecificStreamInfo = IntPtr.Zero
+                    };
+
+                    PortAudioSharp.Stream.Callback captureCb = (IntPtr input, IntPtr output, uint frameCount,
+                        ref StreamCallbackTimeInfo timeInfo, StreamCallbackFlags statusFlags, IntPtr userData) =>
+                    {
+                        if (input == IntPtr.Zero) return StreamCallbackResult.Continue;
+                        var samples = new float[frameCount];
+                        Marshal.Copy(input, samples, 0, (int)frameCount);
+                        OnCaptureSamples(samples);
+                        return StreamCallbackResult.Continue;
+                    };
+
+                    PortAudioSharp.Stream.Callback playbackCb = (IntPtr input, IntPtr output, uint frameCount,
+                        ref StreamCallbackTimeInfo timeInfo, StreamCallbackFlags statusFlags, IntPtr userData) =>
+                    {
+                        if (output == IntPtr.Zero) return StreamCallbackResult.Continue;
+                        var samples = new float[frameCount];
+                        PullPlayback(samples);
+                        Marshal.Copy(samples, 0, output, (int)frameCount);
+                        return StreamCallbackResult.Continue;
+                    };
+
+                    _captureStream = new PortAudioSharp.Stream(
+                        inParams: inParams,
+                        outParams: null,
+                        sampleRate: AudioConstants.SampleRate,
+                        framesPerBuffer: (uint)AudioConstants.FrameSamples,
+                        streamFlags: StreamFlags.ClipOff,
+                        callback: captureCb,
+                        userData: IntPtr.Zero);
+
+                    _playbackStream = new PortAudioSharp.Stream(
+                        inParams: null,
+                        outParams: outParams,
+                        sampleRate: AudioConstants.SampleRate,
+                        framesPerBuffer: (uint)AudioConstants.FrameSamples,
+                        streamFlags: StreamFlags.ClipOff,
+                        callback: playbackCb,
+                        userData: IntPtr.Zero);
+
+                    _captureStream.Start();
+                    _playbackStream.Start();
+                    _devicesOpen = true;
+                    _logger.LogInformation(
+                        "Audio devices open — RX '{Rx}' (#{RxI}), TX '{Tx}' (#{TxI}), codec={Codec}",
+                        rxInfo.name, rxIndex, txInfo.name, txIndex, _codecName);
+                    return null;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to open audio devices");
+                    CloseDevices();
+                    return $"Failed to open audio devices: {ex.Message}";
+                }
+            }
+        }
+
+        private void OnCaptureSamples(float[] samples)
+        {
+            // Accumulate to 20 ms frames, encode, queue for send.
+            Span<float> frame = stackalloc float[AudioConstants.FrameSamples];
+            int offset = 0;
+            while (offset < samples.Length)
+            {
+                int space = _captureAccum.Length - _captureAccumLen;
+                int take = Math.Min(space, samples.Length - offset);
+                Array.Copy(samples, offset, _captureAccum, _captureAccumLen, take);
+                _captureAccumLen += take;
+                offset += take;
+
+                while (_captureAccumLen >= AudioConstants.FrameSamples)
+                {
+                    _captureAccum.AsSpan(0, AudioConstants.FrameSamples).CopyTo(frame);
+                    float peak = 0;
+                    for (int i = 0; i < frame.Length; i++)
+                    {
+                        float v = Math.Clamp(frame[i] * _rxGain, -1f, 1f);
+                        frame[i] = v;
+                        float a = Math.Abs(v);
+                        if (a > peak) peak = a;
+                    }
+                    _rxLevel = peak;
+
+                    byte[] packet;
+                    byte msgType;
+                    if (_codecName == AudioConstants.CodecOpus && _codec != null)
+                    {
+                        packet = _codec.Encode(frame);
+                        msgType = AudioConstants.MsgOpusRx;
+                    }
+                    else
+                    {
+                        packet = new byte[AudioConstants.FrameSamples * 2];
+                        for (int i = 0; i < AudioConstants.FrameSamples; i++)
+                        {
+                            short s = (short)Math.Clamp((int)(frame[i] * 32767f), short.MinValue, short.MaxValue);
+                            BinaryPrimitives.WriteInt16LittleEndian(packet.AsSpan(i * 2, 2), s);
+                        }
+                        msgType = AudioConstants.MsgPcmRx;
+                    }
+
+                    uint seq = (uint)Interlocked.Increment(ref _rxSeq);
+                    _txQueue.Enqueue(AudioWireProtocol.Frame(msgType, seq, packet));
+
+                    int remain = _captureAccumLen - AudioConstants.FrameSamples;
+                    if (remain > 0)
+                        Array.Copy(_captureAccum, AudioConstants.FrameSamples, _captureAccum, 0, remain);
+                    _captureAccumLen = remain;
+                }
+            }
+        }
+
+        private async Task LevelPumpAsync(CancellationToken ct)
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                try
+                {
+                    var socket = _activeSocket;
+                    if (socket is { State: WebSocketState.Open })
+                    {
+                        while (_txQueue.TryDequeue(out var frame))
+                        {
+                            await socket.SendAsync(frame, WebSocketMessageType.Binary, true, ct);
+                        }
+
+                        // Periodic levels (~5 Hz)
+                        var levels = AudioWireProtocol.FrameControl(
+                            (uint)Interlocked.Increment(ref _rxSeq),
+                            new { cmd = "levels", rx = _rxLevel, tx = _txLevel });
+                        await socket.SendAsync(levels, WebSocketMessageType.Binary, true, ct);
+                    }
+                }
+                catch (OperationCanceledException) { break; }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Audio pump send failed");
+                    break;
+                }
+
+                try { await Task.Delay(50, ct); }
+                catch (OperationCanceledException) { break; }
+            }
+        }
+
+        private async Task StopSessionAsync()
+        {
+            try { _pumpCts?.Cancel(); } catch { /* ignore */ }
+            if (_pumpTask != null)
+            {
+                try { await _pumpTask; } catch { /* ignore */ }
+                _pumpTask = null;
+            }
+            _pumpCts?.Dispose();
+            _pumpCts = null;
+            CloseDevices();
+            _codec?.Dispose();
+            _codec = null;
+            _activeSocket = null;
+            while (_txQueue.TryDequeue(out _)) { }
+            lock (_playbackLock)
+            {
+                _playbackCount = 0;
+                _playbackRead = 0;
+                _playbackWrite = 0;
+            }
+            _captureAccumLen = 0;
+            _rxLevel = 0;
+            _txLevel = 0;
+        }
+
+        private void CloseDevices()
+        {
+            lock (_deviceLock)
+            {
+                try { _captureStream?.Stop(); } catch { /* ignore */ }
+                try { _captureStream?.Dispose(); } catch { /* ignore */ }
+                _captureStream = null;
+                try { _playbackStream?.Stop(); } catch { /* ignore */ }
+                try { _playbackStream?.Dispose(); } catch { /* ignore */ }
+                _playbackStream = null;
+                _devicesOpen = false;
+            }
+        }
+
+        private static async Task SendControlAsync(WebSocket socket, object payload)
+        {
+            var frame = AudioWireProtocol.FrameControl(0, payload);
+            await socket.SendAsync(frame, WebSocketMessageType.Binary, true, CancellationToken.None);
+        }
+
+        private static async Task<byte[]?> ReceiveOneMessageAsync(WebSocket socket, CancellationToken ct)
+        {
+            var buffer = new byte[16 * 1024];
+            using var ms = new MemoryStream();
+            WebSocketReceiveResult result;
+            do
+            {
+                result = await socket.ReceiveAsync(buffer, ct);
+                if (result.MessageType == WebSocketMessageType.Close) return null;
+                ms.Write(buffer, 0, result.Count);
+            } while (!result.EndOfMessage);
+
+            var msg = ms.ToArray();
+            if (msg.Length < 4) return null;
+            uint bodyLen = BinaryPrimitives.ReadUInt32BigEndian(msg.AsSpan(0, 4));
+            if (msg.Length < 4 + bodyLen) return null;
+            return msg.AsSpan(4, (int)bodyLen).ToArray();
+        }
+
+        public void Dispose()
+        {
+            StopSessionAsync().GetAwaiter().GetResult();
+        }
+    }
+}

--- a/Services/Audio/RadioAudioBridgeService.cs
+++ b/Services/Audio/RadioAudioBridgeService.cs
@@ -160,18 +160,25 @@ namespace Yaesu_Web_Control.Services.Audio
                 return;
             }
 
+            // Client sends codecs in preference order; pick the first we support.
+            // Opus is preferred for bandwidth; PCM16 remains the fallback.
             _codecName = AudioConstants.CodecPcm16;
             if (root.TryGetProperty("codecs", out var codecs) && codecs.ValueKind == JsonValueKind.Array)
             {
-                bool wantsOpus = false, wantsPcm = false;
                 foreach (var el in codecs.EnumerateArray())
                 {
                     var s = el.GetString();
-                    if (s == AudioConstants.CodecOpus) wantsOpus = true;
-                    if (s == AudioConstants.CodecPcm16) wantsPcm = true;
+                    if (s == AudioConstants.CodecOpus)
+                    {
+                        _codecName = AudioConstants.CodecOpus;
+                        break;
+                    }
+                    if (s == AudioConstants.CodecPcm16)
+                    {
+                        _codecName = AudioConstants.CodecPcm16;
+                        break;
+                    }
                 }
-                if (wantsPcm) _codecName = AudioConstants.CodecPcm16;
-                else if (wantsOpus) _codecName = AudioConstants.CodecOpus;
             }
 
             string? openError = OpenDevices(settings);
@@ -249,22 +256,34 @@ namespace Yaesu_Web_Control.Services.Audio
 
         private void HandleTxAudio(byte msgType, ReadOnlySpan<byte> payload)
         {
-            Span<float> pcm = stackalloc float[AudioConstants.FrameSamples];
+            // Opus decode needs room for WebCodecs' default 20 ms packets (or longer).
+            Span<float> pcm = stackalloc float[AudioConstants.OpusDecodeMaxSamples];
             int n;
-            if (msgType == AudioConstants.MsgOpusTx)
+            try
             {
-                if (_codec == null) return;
-                n = _codec.Decode(payload, pcm);
-            }
-            else
-            {
-                n = Math.Min(AudioConstants.FrameSamples, payload.Length / 2);
-                for (int i = 0; i < n; i++)
+                if (msgType == AudioConstants.MsgOpusTx)
                 {
-                    short s = BinaryPrimitives.ReadInt16LittleEndian(payload.Slice(i * 2, 2));
-                    pcm[i] = s / 32768f;
+                    if (_codec == null) return;
+                    n = _codec.Decode(payload, pcm);
+                }
+                else
+                {
+                    n = Math.Min(AudioConstants.FrameSamples, payload.Length / 2);
+                    for (int i = 0; i < n; i++)
+                    {
+                        short s = BinaryPrimitives.ReadInt16LittleEndian(payload.Slice(i * 2, 2));
+                        pcm[i] = s / 32768f;
+                    }
                 }
             }
+            catch (Exception ex)
+            {
+                // A single bad Opus packet must not tear down the WebSocket session.
+                _logger.LogDebug(ex, "Dropping bad TX audio frame (type={Type}, {Bytes} bytes)", msgType, payload.Length);
+                return;
+            }
+
+            if (n <= 0) return;
 
             float peak = 0;
             for (int i = 0; i < n; i++)
@@ -535,8 +554,20 @@ namespace Yaesu_Web_Control.Services.Audio
                     byte msgType;
                     if (_codecName == AudioConstants.CodecOpus && _codec != null)
                     {
-                        packet = _codec.Encode(frame);
-                        msgType = AudioConstants.MsgOpusRx;
+                        try
+                        {
+                            packet = _codec.Encode(frame);
+                            msgType = AudioConstants.MsgOpusRx;
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogDebug(ex, "Opus RX encode failed — dropping frame");
+                            int remainErr = _captureAccumLen - AudioConstants.FrameSamples;
+                            if (remainErr > 0)
+                                Array.Copy(_captureAccum, AudioConstants.FrameSamples, _captureAccum, 0, remainErr);
+                            _captureAccumLen = remainErr;
+                            continue;
+                        }
                     }
                     else
                     {

--- a/Services/Audio/RadioAudioBridgeService.cs
+++ b/Services/Audio/RadioAudioBridgeService.cs
@@ -339,13 +339,16 @@ namespace Yaesu_Web_Control.Services.Audio
                 {
                     AudioDeviceEnumerator.EnsureInitialized();
 
+                    // Never fall back to the OS default I/O devices. Blank TX in
+                    // particular opens the PC speakers and loops the browser mic
+                    // into the room (and never reaches the radio USB codec).
+                    if (string.IsNullOrWhiteSpace(settings.AudioRadioRxDevice))
+                        return "Radio RX (capture) device is not set. Pick the radio USB recording endpoint in Settings → Remote Audio.";
+                    if (string.IsNullOrWhiteSpace(settings.AudioRadioTxDevice))
+                        return "Radio TX (playback) device is not set. Pick the radio USB Speakers/playback endpoint in Settings → Remote Audio (blank would use PC speakers and cause mic feedback).";
+
                     int rxIndex = AudioDeviceEnumerator.FindDeviceIndex(settings.AudioRadioRxDevice, requireInput: true, requireOutput: false);
                     int txIndex = AudioDeviceEnumerator.FindDeviceIndex(settings.AudioRadioTxDevice, requireInput: false, requireOutput: true);
-
-                    if (rxIndex < 0 && string.IsNullOrWhiteSpace(settings.AudioRadioRxDevice))
-                        rxIndex = PortAudio.DefaultInputDevice;
-                    if (txIndex < 0 && string.IsNullOrWhiteSpace(settings.AudioRadioTxDevice))
-                        txIndex = PortAudio.DefaultOutputDevice;
 
                     if (rxIndex < 0)
                         return "Radio RX (capture) device not found. Pick it in Settings → Remote Audio.";

--- a/Services/BrowserLauncher.cs
+++ b/Services/BrowserLauncher.cs
@@ -7,6 +7,12 @@ namespace Yaesu_Web_Control.Services
     {
         private bool _opened = false;
         private readonly object _lock = new();
+        private readonly ISettingsService _settings;
+
+        public BrowserLauncher(ISettingsService settings)
+        {
+            _settings = settings;
+        }
 
         public void OpenOnce(string url)
         {
@@ -22,6 +28,16 @@ namespace Yaesu_Web_Control.Services
             // browser navigates — avoids a blank tab on first launch after install.
             Task.Run(async () =>
             {
+                try
+                {
+                    var settings = await _settings.GetSettingsAsync();
+                    if (!settings.OpenBrowserOnStartup) return;
+                }
+                catch
+                {
+                    // Settings read failed — keep the historical default (open).
+                }
+
                 await Task.Delay(600);
                 try
                 {

--- a/Services/HttpPortInfo.cs
+++ b/Services/HttpPortInfo.cs
@@ -1,27 +1,30 @@
 namespace Yaesu_Web_Control.Services
 {
     /// <summary>
-    /// Single source of truth for the HTTP port YWC is actually listening on.
-    /// Resolved once at startup in <c>Program.cs</c> by probing the user's
-    /// configured port and (if necessary) the nine fallbacks above it, then
-    /// registered as a singleton so every consumer — Kestrel, the browser
-    /// launcher, the system-tray tooltip and right-click menu, and the
-    /// Settings page UI — reads the same value.
-    ///
-    /// Replaces the previous pattern where the port was hardcoded as "8080"
-    /// in five different places that had to be kept in sync by hand
-    /// (Issue #13).
+    /// Single source of truth for the HTTP (and optional HTTPS) ports YWC is
+    /// actually listening on. Resolved once at startup in <c>Program.cs</c>.
     /// </summary>
     public sealed class HttpPortInfo
     {
         public int Port { get; }
+        public int? HttpsPort { get; }
+        public bool HttpsActive { get; }
 
-        /// <summary>Convenience: e.g. <c>http://localhost:8080</c>.</summary>
-        public string RootUrl => $"http://localhost:{Port}";
+        /// <summary>Preferred local URL — HTTPS when active, else HTTP.</summary>
+        public string RootUrl => HttpsActive && HttpsPort is int hp
+            ? $"https://localhost:{hp}"
+            : $"http://localhost:{Port}";
 
-        public HttpPortInfo(int port)
+        public string HttpRootUrl => $"http://localhost:{Port}";
+        public string? HttpsRootUrl => HttpsActive && HttpsPort is int hp
+            ? $"https://localhost:{hp}"
+            : null;
+
+        public HttpPortInfo(int port, int? httpsPort = null, bool httpsActive = false)
         {
             Port = port;
+            HttpsPort = httpsPort;
+            HttpsActive = httpsActive;
         }
     }
 }

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1366,8 +1366,8 @@ The files inside the zip are plain JSON; you can extract and inspect or hand-edi
 | Setting | Description |
 |---------|-------------|
 | Enable remote audio | Opt-in. When off, no audio devices are opened and the Index bar is hidden. |
-| Radio RX device (capture) | PortAudio input used for what you **hear** in the browser (usually Yaesu USB recording). Empty = system default input. |
-| Radio TX device (playback) | PortAudio output used for browser **mic → radio** (usually Yaesu USB playback). Empty = system default output. |
+| Radio RX device (capture) | PortAudio input used for what you **hear** in the browser (usually Yaesu USB recording). Empty = system default input. Entries are labelled with the PortAudio host API (e.g. `Windows WASAPI`) so Windows duplicates of the same USB CODEC are distinguishable — prefer **Windows WASAPI** when several appear. |
+| Radio TX device (playback) | PortAudio output used for browser **mic → radio** (usually Yaesu USB playback). Empty = system default output. Same host-API labelling as RX. |
 | RX / TX gain | Software gain applied in the bridge (0.05–4). |
 
 Also configure **HTTPS** under [§6.2](#62-web-server-settings) if you will use a remote browser (not localhost). Full setup steps are in [§18 Remote Audio](#18-remote-audio).
@@ -2861,7 +2861,7 @@ Remote Audio streams **radio RX → browser speakers** and **browser microphone 
 
 1. Open **Settings → Remote Audio**.
 2. Enable **remote audio**.
-3. Pick **Radio RX device** (capture / what you hear) and **Radio TX device** (playback / where mic audio goes). Use **Refresh device list** after plugging the radio in.
+3. Pick **Radio RX device** (capture / what you hear) and **Radio TX device** (playback / where mic audio goes). Use **Refresh device list** after plugging the radio in. On Windows the same USB device may list several times (MME / DirectSound / WASAPI / WDM-KS) — choose the **Windows WASAPI** entry when available.
 4. Optionally adjust RX/TX gain.
 5. **Save Settings**.
 
@@ -2900,13 +2900,14 @@ Audio on the Index page stops when you leave Home (for example to open **Setting
 | Symptom | What to try |
 |---------|-------------|
 | Mic permission denied / “requires HTTPS” | Use the HTTPS URL; regenerate the cert with the IP you type in the address bar; restart after enabling HTTPS. |
-| No RX sound | Check Radio RX device; confirm radio AF gain / USB volume; look at the RX meter while Start audio is active. |
-| TX keys but no modulation | Confirm MOD SOURCE / USB; check Radio TX device; unmute mic; watch the TX meter while speaking. |
-| Choppy audio | Prefer wired Ethernet/VPN; reduce other load; stay on LAN/VPN (no TURN/WebRTC in v1). |
+| No RX sound | Check Radio RX device (on Windows try the **Windows WASAPI** entry); confirm radio AF gain / USB volume; look at the RX meter while Start audio is active. |
+| TX keys but no modulation | Confirm MOD SOURCE / USB; check Radio TX device (prefer **Windows WASAPI**); unmute mic; watch the TX meter while speaking. |
+| Choppy audio | Prefer wired Ethernet/VPN; reduce other load; stay on LAN/VPN (no TURN/WebRTC in v1). On Windows, avoid WDM-KS unless you need exclusive mode. |
 | “Audio session busy” | Stop audio in the other tab/browser (or pop-out window) first. |
 | Audio dies when opening Settings | Use **Pop out** before leaving Home so the session lives in the separate window. |
 | Pop-out blocked | Allow pop-ups for the YWC origin; click **Pop out** / **Open pop-out** again. |
 | Devices missing from the list | Unplug/replug USB; Refresh device list; check OS privacy permissions for microphone (host process). |
+| Same device listed many times (Windows) | Expected — PortAudio exposes each endpoint per host API. Labels show the API in brackets; pick **Windows WASAPI** and Save so the choice is remembered. |
 | Voice Control vs radio USB | Keep Voice Control’s mic on your headset; leave Remote Audio devices on the Yaesu USB endpoints. |
 
 ---

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -2888,7 +2888,7 @@ Local testing on the same PC can use `http://localhost:8080` without HTTPS.
 1. Open the Index page (over HTTPS if remote).
 2. Click **Start audio** on the Remote Audio bar. Grant microphone permission when asked.
 3. You should hear RX audio; speak into the mic (levels show on the bar). Use **Mic & Gain** to pick the browser microphone, choose **Opus** or **PCM16**, and adjust RX/TX software gain (codec and mic choice are remembered in the browser; gain is saved on the host).
-4. Use **TX** / your TX toggle key to key the radio. Audio flows continuously (like Mumble); CAT controls PTT.
+4. Use **TX** / your TX toggle key to key the radio (on Home or on the Remote Audio pop-out). Audio flows continuously (like Mumble); CAT controls PTT.
 5. **Mute mic** / **Mute RX** as needed. **Stop** ends the session and closes host audio devices.
 6. Only **one** audio session is allowed at a time; a second browser is rejected busy.
 
@@ -2900,7 +2900,7 @@ Audio on the Index page stops when you leave Home (for example to open **Setting
 
 1. Click **Pop out** on the Remote Audio bar. A small **Remote Audio** window opens.
 2. If you were already streaming, YWC hands the session to that window (brief reconnect). Otherwise click **Start audio** in the pop-out.
-3. Leave the pop-out open while you use Settings or other pages. Home shows status such as *In pop-out window (streaming)*; mute switches on Home still control the pop-out session. Filter-scope on Home keeps receiving live RX spectrum from the pop-out.
+3. Leave the pop-out open while you use Settings or other pages. Home shows status such as *In pop-out window (streaming)*; mute switches on Home still control the pop-out session. Filter-scope on Home keeps receiving live RX spectrum from the pop-out. The pop-out has its own **TX** button (same PTT as Home) and a **VFO A / VFO B** badge for the current transmit VFO; it also honours the same **TX toggle key** from Settings when that window is focused. TX on/off stays in sync with the main window when Home is open.
 4. **Stop** on Home stops the pop-out session. **Close** in the pop-out (or closing the window) ends audio and returns control to Home.
 5. If the browser blocks the window, allow pop-ups for the YWC site and try again.
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1372,8 +1372,8 @@ The files inside the zip are plain JSON; you can extract and inspect or hand-edi
 | Setting | Description |
 |---------|-------------|
 | Enable remote audio | Opt-in. When off, no audio devices are opened and the Index bar is hidden. |
-| Radio RX device (capture) | PortAudio input used for what you **hear** in the browser (usually Yaesu USB recording). Empty = system default input. On Windows the list is limited to **WASAPI** endpoints so the same USB CODEC is not repeated under MME / DirectSound / WDM-KS. |
-| Radio TX device (playback) | PortAudio output used for browser **mic → radio** (usually Yaesu USB playback). Empty = system default output. Same WASAPI-only listing on Windows as RX. |
+| Radio RX device (capture) | PortAudio input used for what you **hear** in the browser — usually the Yaesu USB **recording** endpoint (`Microphone (USB Audio CODEC)` / `Line (USB Audio CODEC)`, or a name you gave it in the OS). **Required** when remote audio is enabled (no system-default fallback). On Windows the list is limited to **WASAPI** endpoints so the same USB CODEC is not repeated under MME / DirectSound / WDM-KS. Names that look like a USB codec are sorted to the top and marked with ★. |
+| Radio TX device (playback) | PortAudio output for browser **mic → radio** — usually Yaesu USB **Speakers** / playback (`Speakers (USB Audio CODEC)`). **Required** when enabled. Do **not** leave blank or pick PC speakers / headphones: that loops the browser mic into the room and never reaches the radio. Same WASAPI-only listing and ★ hint as RX. |
 | RX / TX gain | Software gain applied in the bridge (0.05–4). On Home, open **Mic & Gain** on the Remote Audio bar (browser mic picker + RX/TX gain). The pop-out shows the same controls inline. |
 | Audio codec | Chosen on the Index **Mic & Gain** dialog or the pop-out (not a host setting). **Opus** (default) compresses speech to ~32 kb/s per direction; **PCM16** is uncompressed ~768 kb/s. See [§18.6](#186-audio-codecs-opus-vs-pcm16). |
 
@@ -2864,13 +2864,13 @@ Remote Audio streams **radio RX → browser speakers** and **browser microphone 
 
 1. Connect the radio’s USB cable so the PC sees both CAT and USB audio.
 2. In the radio menu, set **MOD SOURCE** to **REAR** with **REAR SELECT = USB**, or **MOD SOURCE = USB** on models that use that wording (e.g. FT-710). Same idea as FT-Control / digital-mode USB audio.
-3. Confirm the OS lists Yaesu (or “USB Audio”) playback and recording devices.
+3. Confirm the OS lists the radio’s USB audio endpoints. Factory names are usually variants of **USB Audio CODEC** (e.g. Microphone/Line for recording, Speakers for playback). Many operators rename them in the OS sound panel (e.g. to “FTDX101”) — that is fine; pick the renamed entry in YWC.
 
 ### 18.2 YWC host setup
 
 1. Open **Settings → Remote Audio**.
 2. Enable **remote audio**.
-3. Pick **Radio RX device** (capture / what you hear) and **Radio TX device** (playback / where mic audio goes). Use **Refresh device list** after plugging the radio in. On Windows only **WASAPI** devices are shown.
+3. Pick **Radio RX device** (capture / what you hear) and **Radio TX device** (playback / where mic audio goes). Both are **required** when the feature is on — YWC will not fall back to the PC’s default mic/speakers (blank TX previously caused browser-mic feedback into the room). Use **Refresh device list** after plugging the radio in. On Windows only **WASAPI** devices are shown. Entries that look like a USB codec are sorted first and marked with ★; renamed devices stay in the full list without a star.
 4. Optionally adjust RX/TX gain.
 5. **Save Settings**.
 
@@ -2912,7 +2912,8 @@ Audio on the Index page stops when you leave Home (for example to open **Setting
 |---------|-------------|
 | Mic permission denied / “requires HTTPS” | Use the HTTPS URL; regenerate the cert with the IP you type in the address bar; restart after enabling HTTPS. |
 | No RX sound | Check Radio RX device; confirm radio AF gain / USB volume; look at the RX meter while Start audio is active. |
-| TX keys but no modulation | Confirm MOD SOURCE / USB; check Radio TX device; unmute mic; watch the TX meter while speaking. |
+| TX keys but no modulation | Confirm MOD SOURCE / USB; check Radio TX device is the radio USB **Speakers**/playback endpoint (not PC speakers); unmute mic; watch the TX meter while speaking. |
+| TX keys and you hear yourself in the PC speakers | Radio TX device is wrong (or was left blank on an older build). Set it to the radio USB playback / Speakers endpoint and Save. |
 | Choppy audio | Prefer wired Ethernet/VPN; reduce other load; stay on LAN/VPN (no TURN/WebRTC in v1). Use **Opus** instead of PCM16 on limited links (see [§18.6](#186-audio-codecs-opus-vs-pcm16)). |
 | “Audio session busy” | Stop audio in the other tab/browser (or pop-out window) first. |
 | Audio dies when opening Settings | Use **Pop out** before leaving Home so the session lives in the separate window. |

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -93,6 +93,12 @@
     - 17.6 [Adding your own commands](#176-adding-your-own-commands)
     - 17.7 [More languages](#177-more-languages)
 18. [Remote Audio](#18-remote-audio)
+    - 18.1 [Radio setup](#181-radio-setup)
+    - 18.2 [YWC host setup](#182-ywc-host-setup)
+    - 18.3 [HTTPS for remote browsers](#183-https-for-remote-browsers)
+    - 18.4 [Operating](#184-operating)
+    - 18.5 [Troubleshooting](#185-troubleshooting)
+    - 18.6 [Audio codecs (Opus vs PCM16)](#186-audio-codecs-opus-vs-pcm16)
 
 ---
 
@@ -1369,6 +1375,7 @@ The files inside the zip are plain JSON; you can extract and inspect or hand-edi
 | Radio RX device (capture) | PortAudio input used for what you **hear** in the browser (usually Yaesu USB recording). Empty = system default input. On Windows the list is limited to **WASAPI** endpoints so the same USB CODEC is not repeated under MME / DirectSound / WDM-KS. |
 | Radio TX device (playback) | PortAudio output used for browser **mic → radio** (usually Yaesu USB playback). Empty = system default output. Same WASAPI-only listing on Windows as RX. |
 | RX / TX gain | Software gain applied in the bridge (0.05–4). On Home, open **Mic & Gain** on the Remote Audio bar (browser mic picker + RX/TX gain). The pop-out shows the same controls inline. |
+| Audio codec | Chosen on the Index **Mic & Gain** dialog or the pop-out (not a host setting). **Opus** (default) compresses speech to ~32 kb/s per direction; **PCM16** is uncompressed ~768 kb/s. See [§18.6](#186-audio-codecs-opus-vs-pcm16). |
 
 Also configure **HTTPS** under [§6.2](#62-web-server-settings) if you will use a remote browser (not localhost). Full setup steps are in [§18 Remote Audio](#18-remote-audio).
 
@@ -2880,10 +2887,12 @@ Local testing on the same PC can use `http://localhost:8080` without HTTPS.
 
 1. Open the Index page (over HTTPS if remote).
 2. Click **Start audio** on the Remote Audio bar. Grant microphone permission when asked.
-3. You should hear RX audio; speak into the mic (levels show on the bar). Use **Mic & Gain** to pick the browser microphone and adjust RX/TX software gain (saved automatically).
+3. You should hear RX audio; speak into the mic (levels show on the bar). Use **Mic & Gain** to pick the browser microphone, choose **Opus** or **PCM16**, and adjust RX/TX software gain (codec and mic choice are remembered in the browser; gain is saved on the host).
 4. Use **TX** / your TX toggle key to key the radio. Audio flows continuously (like Mumble); CAT controls PTT.
 5. **Mute mic** / **Mute RX** as needed. **Stop** ends the session and closes host audio devices.
 6. Only **one** audio session is allowed at a time; a second browser is rejected busy.
+
+The status line shows the active codec while streaming (for example `Streaming (opus)`). Change codec only while stopped — it applies on the next **Start**.
 
 #### Pop-out window (keep audio while changing pages)
 
@@ -2902,13 +2911,31 @@ Audio on the Index page stops when you leave Home (for example to open **Setting
 | Mic permission denied / “requires HTTPS” | Use the HTTPS URL; regenerate the cert with the IP you type in the address bar; restart after enabling HTTPS. |
 | No RX sound | Check Radio RX device; confirm radio AF gain / USB volume; look at the RX meter while Start audio is active. |
 | TX keys but no modulation | Confirm MOD SOURCE / USB; check Radio TX device; unmute mic; watch the TX meter while speaking. |
-| Choppy audio | Prefer wired Ethernet/VPN; reduce other load; stay on LAN/VPN (no TURN/WebRTC in v1). |
+| Choppy audio | Prefer wired Ethernet/VPN; reduce other load; stay on LAN/VPN (no TURN/WebRTC in v1). Use **Opus** instead of PCM16 on limited links (see [§18.6](#186-audio-codecs-opus-vs-pcm16)). |
 | “Audio session busy” | Stop audio in the other tab/browser (or pop-out window) first. |
 | Audio dies when opening Settings | Use **Pop out** before leaving Home so the session lives in the separate window. |
 | Pop-out blocked | Allow pop-ups for the YWC origin; click **Pop out** / **Open pop-out** again. |
 | Devices missing from the list | Unplug/replug USB; Refresh device list; check OS privacy permissions for microphone (host process). |
 | Wrong browser mic | Open **Mic & Gain** on the Remote Audio bar (or use the pop-out controls) and pick the right browser microphone. Choice is remembered in the browser. |
+| Opus unavailable / forced to PCM16 | The browser needs WebCodecs `AudioEncoder` / `AudioDecoder` (current Chrome, Edge, or Chromium). Older Safari/Firefox builds may only offer PCM16. |
 | Voice Control vs radio USB | Keep Voice Control’s mic on your headset; leave Remote Audio devices on the Yaesu USB endpoints. |
+
+### 18.6 Audio codecs (Opus vs PCM16)
+
+Remote Audio always samples at **48 kHz mono** on the host bridge. What changes is how those samples are packed on the WebSocket:
+
+| | **Opus** (default / recommended) | **PCM16** |
+|--|--|--|
+| What it is | Compressed speech (VOIP-style) | Uncompressed 16-bit samples |
+| Approx. payload per direction | **~32 kb/s** | **~768 kb/s** |
+| Duplex (RX + TX) | Roughly **~64 kb/s** (+ framing) | Roughly **~1.5 Mb/s** (+ framing) |
+| Audio quality | Good for SSB / voice; may soften noise floor slightly vs PCM | Bit-for-bit transparent (aside from gain / device resampling) |
+| Best for | Limited bandwidth, VPN, cellular, choppy links | Fast LAN when you want maximum fidelity or Opus is unavailable |
+| Browser requirement | WebCodecs Opus encode/decode | Any modern browser |
+
+**Preference:** YWC offers **Opus first** whenever the browser supports it. Choose **PCM16** only if you need uncompressed audio on a fast LAN, or if Opus is greyed out in your browser.
+
+Both directions use the same codec for a session. Stop and Start again after changing the selector.
 
 ---
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -124,7 +124,7 @@ The **shipped installer** is for **Windows 10/11 (64-bit)** and includes the ful
 | Voice *announcements* (browser TTS) | Yes | Yes | Yes |
 | Launch WSJT-X / JTAlert / etc. from YWC | Yes (Windows paths) | Buttons exist but target Windows-style paths — run those apps yourself and point them at YWC's rigctld | Same — use host/network apps |
 | Serial port form | `COM3`, `COM4`, … | `/dev/cu.*` | `/dev/ttyUSB*` / `/dev/ttyACM*` (pass device into the container for Docker) |
-| USB serial driver | [Silicon Labs CP210x VCP](https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads) required on **Windows, macOS, and Linux** — **reboot the host after install** (see [§2.4](#24-usb-serial-driver-windows--macos--linux)) |
+| USB serial driver | **Windows / macOS:** if the radio's COM / `/dev/cu.*` ports are missing or CAT never answers, install [Silicon Labs CP210x VCP](https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads) and **reboot** ([§2.4](#24-usb-serial-driver-windows--macos--linux)). **Linux:** usually skip — the kernel already includes CP210x support. |
 | Settings / logs folder | `%APPDATA%\MM5AGM\Yaesu Web Control\` | `~/.config/MM5AGM/Yaesu Web Control/` | Volume `./data/ywc` → `/data/MM5AGM/Yaesu Web Control/` (Docker); same `~/.config/…` path when run from source |
 | Auto-exit when no browser | Default **on** | Default **on** (turn **off** for a headless shack) | Forced **off** in containers; default **on** from source |
 | Opens a local browser on start | Yes | Yes | No (Docker); yes from source on a desktop |
@@ -177,15 +177,16 @@ The application was written for operators who want a large, clean, touchscreen-f
 
 ## 2. Installation
 
-> **Before connecting the radio over USB:** install the Silicon Labs CP210x VCP driver and **reboot the computer**. Required on Windows, macOS, and Linux — see [§2.4](#24-usb-serial-driver-windows--macos--linux).
+> **USB CAT tip:** if the radio's serial ports never appear, or **Test Connection** fails with no reply from the radio, install the Silicon Labs CP210x VCP driver on **Windows or macOS** and reboot — see [§2.4](#24-usb-serial-driver-windows--macos--linux). **Linux** users can normally skip this (CP210x is in the kernel).
 
 ### 2.1 Windows (installer)
 
-1. Install the [Silicon Labs CP210x VCP driver](https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads) and **reboot** (see [§2.4](#24-usb-serial-driver-windows--macos--linux)).
-2. Download the installer from the [GitHub Releases page](https://github.com/mm5agm/Yaesu_Web_Control/releases).
-3. Run the installer. .NET 10 is bundled — you do not need to install it separately.
-4. A desktop shortcut and a Start Menu entry are created automatically.
-5. The first time you run the app, Windows may show a **Smart App Control** or **Unknown Publisher** warning. Click **More info → Run anyway** to proceed. This warning appears because the installer is not signed with a commercial certificate.
+1. Download the installer from the [GitHub Releases page](https://github.com/mm5agm/Yaesu_Web_Control/releases).
+2. Run the installer. .NET 10 is bundled — you do not need to install it separately.
+3. A desktop shortcut and a Start Menu entry are created automatically.
+4. The first time you run the app, Windows may show a **Smart App Control** or **Unknown Publisher** warning. Click **More info → Run anyway** to proceed. This warning appears because the installer is not signed with a commercial certificate.
+
+If Device Manager never shows the radio's COM ports, or **Test Connection** fails later, install the [Silicon Labs CP210x VCP driver](https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads), **reboot**, and try again ([§2.4](#24-usb-serial-driver-windows--macos--linux)).
 
 This is the supported product build: tray icon, SDR spectrum, and Voice Control.
 
@@ -193,15 +194,16 @@ This is the supported product build: tray icon, SDR spectrum, and Voice Control.
 
 macOS ships as an **unsigned CAT-only** app (menu-bar status item; no SDR spectrum or Windows Voice Control). There is no Apple Developer ID / notarization — this is an open-source project and that licence costs money every year. Gatekeeper will warn the first time you open a download from the internet, the same way Windows warns about the unsigned installer.
 
-1. Install the [Silicon Labs CP210x VCP driver](https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads) and **reboot** (see [§2.4](#24-usb-serial-driver-windows--macos--linux)).
-2. Download the DMG that matches your Mac from the [GitHub Releases page](https://github.com/mm5agm/Yaesu_Web_Control/releases):
+1. Download the DMG that matches your Mac from the [GitHub Releases page](https://github.com/mm5agm/Yaesu_Web_Control/releases):
    - Apple Silicon (M1 / M2 / M3 / …): `Yaesu_Web_Control_CAT_*_macos-arm64.dmg`
    - Intel: `Yaesu_Web_Control_CAT_*_macos-x64.dmg`
-3. Open the DMG and drag **Yaesu Web Control** into **Applications**.
-4. The first time you launch it, macOS Gatekeeper will block an unsigned app. Do one of the following:
+2. Open the DMG and drag **Yaesu Web Control** into **Applications**.
+3. The first time you launch it, macOS Gatekeeper will block an unsigned app. Do one of the following:
    - **Right-click** (or Control-click) **Yaesu Web Control** in Applications → **Open** → **Open** again in the dialog, or
    - Try to open it normally, then open **System Settings → Privacy & Security**, scroll to the message about YWC being blocked, and click **Open Anyway**.
-5. A menu-bar status item appears (Open / About / Open user data folder / Exit). The browser UI is at `http://localhost:8080` (or the port shown in the menu-bar tooltip). .NET is bundled — you do not need to install the SDK.
+4. A menu-bar status item appears (Open / About / Open user data folder / Exit). The browser UI is at `http://localhost:8080` (or the port shown in the menu-bar tooltip). .NET is bundled — you do not need to install the SDK.
+
+If `/dev/cu.usbserial-…` devices never appear, or **Test Connection** fails later, install the [Silicon Labs CP210x VCP driver](https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads), **reboot**, allow the Driver Extension if prompted, and try again ([§2.4](#24-usb-serial-driver-windows--macos--linux)).
 
 Set **Serial Port** to a `/dev/cu.*` device (see §3). SDR and Voice Control sections are hidden on this host.
 
@@ -225,9 +227,9 @@ Then open `http://localhost:8080` (or the port shown in the console / menu-bar t
 
 For an always-on CAT controller on an x64 PC or arm64 Pi, use the published multi-arch image (`linux/amd64` and `linux/arm64`) from the GitHub Container Registry, or build locally from the repo `Dockerfile` / `docker-compose.yml`.
 
-**Image:** `ghcr.io/mm5agm/yaesu_web_control` — tags `latest` and each release (e.g. `v2.4.2`).
+**Image:** `ghcr.io/mm5agm/yaesu_web_control` — each release is tagged (e.g. `v2.4.2`, `v2.4.3-pre6`); `latest` tracks the newest **full** release only (not pre-releases).
 
-Install the [Silicon Labs CP210x VCP driver](https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads) on the **host** (not inside the container) and **reboot the host** before first use — see [§2.4](#24-usb-serial-driver-windows--macos--linux). Then clone or copy `docker-compose.yml` from the repo and run:
+On a **Linux** host you normally do **not** need Silicon Labs' CP210x package — support is already in the kernel. Plug the radio in, confirm a `/dev/ttyUSB*` or `/dev/ttyACM*` node appears, then clone or copy `docker-compose.yml` from the repo and run:
 
 ```bash
 # Find the radio's USB-serial node on the host
@@ -253,32 +255,30 @@ Open `http://<host>:8080`. Settings and logs persist under `./data/ywc` by defau
 
 ### 2.4 USB serial driver (Windows / macOS / Linux)
 
-Modern Yaesu HF radios (FTdx101, FTdx10, FT-710, and similar) talk CAT over USB through a built-in **Silicon Labs CP210x** USB-to-UART bridge. The host OS must have the official **CP210x Virtual COM Port (VCP)** driver installed:
+Modern Yaesu HF radios (FTdx101, FTdx10, FT-710, and similar) talk CAT over USB through a built-in **Silicon Labs CP210x** USB-to-UART bridge. You only need Silicon Labs' official **CP210x Virtual COM Port (VCP)** package when the OS does not already present working ports — most often on a fresh **Windows** or **macOS** install after CAT or port discovery fails. **Linux** already includes a CP210x kernel module, so skip the Silicon Labs download there unless something is clearly broken.
 
 **[CP210x USB to UART Bridge VCP Drivers (Silicon Labs downloads)](https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads)**
 
 | OS | What to do |
 |---|---|
-| **Windows** | Download and install the Windows VCP package from that page, then **reboot**. |
-| **macOS** | Download and install the Macintosh VCP package from that page, then **reboot**. Allow the Driver Extension under System Settings if prompted. |
-| **Linux** | Install the matching Linux VCP package from that page when required for your distribution/kernel, then **reboot**. (Some kernels already include a CP210x module; if ports appear but CAT never answers, still install Silicon Labs' package and reboot.) |
+| **Windows** | If Device Manager never lists the radio's COM ports, or **Test Connection** opens the port but the radio never answers, download and install the Windows VCP package from that page, then **reboot**. |
+| **macOS** | If `/dev/cu.usbserial-…` devices never appear, or CAT never answers, install the Macintosh VCP package from that page, then **reboot**. Allow the Driver Extension under System Settings if prompted. |
+| **Linux** | **Skip the Silicon Labs package.** The in-kernel `cp210x` driver normally creates `/dev/ttyUSB*` (or similar) as soon as you plug the radio in. If ports are missing, check the cable, USB power, and that your user is in the `dialout` group — not a vendor VCP install. |
 
-**After installing, reboot the host.** Skipping the reboot is a common reason the port appears in the OS (or opens in YWC) but **Test Connection** fails with no reply from the radio.
+**After installing the Silicon Labs package (Windows / macOS), reboot the host.** Skipping the reboot is a common reason the port appears in the OS (or opens in YWC) but **Test Connection** fails with no reply from the radio.
 
 Many of these radios expose **two** virtual ports on one USB cable:
 
 - **Enhanced** — CAT (frequency, mode, meters). **This is the port YWC must use.**
 - **Standard** — TX controls (PTT, CW keying, digital). Not for CAT.
 
-On Windows, Device Manager labels them clearly. On macOS they show as two `/dev/cu.usbserial-…` devices — if Test Connection fails on one, try the other after the driver + reboot.
+On Windows, Device Manager labels them clearly. On macOS they show as two `/dev/cu.usbserial-…` devices — if Test Connection fails on one, try the other (and install the VCP driver + reboot only if neither works).
 
 ---
 
 ## 3. First-Time Setup
 
 Before the app can communicate with your radio you need to tell it which serial port the radio is connected to and what baud rate to use.
-
-Confirm the [Silicon Labs CP210x VCP driver](https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads) is installed and that you **rebooted** after installing it ([§2.4](#24-usb-serial-driver-windows--macos--linux)).
 
 **Required — radio connection:**
 
@@ -298,7 +298,7 @@ Confirm the [Silicon Labs CP210x VCP driver](https://www.silabs.com/software-and
 8. On a headless macOS/Linux/Docker host, turn **off** **Automatically exit when no browser is connected** in Settings (Docker already forces this off) so closing the browser does not stop the CAT server.
 9. Click **Save Settings**, then **Test Connection**. A green tick means the app is talking to the radio.
 
-If you see a red cross, double-check the serial port (Enhanced vs Standard), baud rate, and that the Silicon Labs driver was installed with a reboot. On Linux, confirm your user (or the container's dialout group) can open the device. See [§15.11](#1511-test-connection-fails--cat-does-not-respond-over-usb).
+If you see a red cross, double-check the serial port (Enhanced vs Standard) and baud rate. On **Windows or macOS**, if the ports are missing or CAT still never answers, install the Silicon Labs CP210x VCP driver and reboot ([§2.4](#24-usb-serial-driver-windows--macos--linux)). On **Linux**, confirm your user (or the container's dialout group) can open the device — you normally do not need Silicon Labs' package. See [§15.11](#1511-test-connection-fails--cat-does-not-respond-over-usb).
 
 
 **Optional — extras you can set up later in Settings:**
@@ -1056,7 +1056,7 @@ Clicking **Restart Now** stops YWC and (when running as the installed exe) autom
 | Setting | Description |
 |---------|-------------|
 | Radio Model | **FTdx101MP** (200 W, dual RX), **FTdx101D** (100 W, dual RX), **FTDX3000** (100 W, single RX), **FTdx10** (100 W, single RX), or **FT-710** (100 W, single RX) |
-| Serial Port | Path to the radio's **Enhanced** (CAT) USB/serial port. **Windows:** `COM3`, `COM4`, … (Device Manager: *Enhanced COM Port*). **macOS:** `/dev/cu.usbserial-…` (prefer `cu.*` over `tty.*`). **Linux / Docker:** `/dev/ttyUSB0`, `/dev/ttyACM0`, or `/dev/serial/by-id/…`. Requires the [Silicon Labs CP210x VCP driver](https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads) and a **host reboot** after install — [§2.4](#24-usb-serial-driver-windows--macos--linux). |
+| Serial Port | Path to the radio's **Enhanced** (CAT) USB/serial port. **Windows:** `COM3`, `COM4`, … (Device Manager: *Enhanced COM Port*). **macOS:** `/dev/cu.usbserial-…` (prefer `cu.*` over `tty.*`). **Linux / Docker:** `/dev/ttyUSB0`, `/dev/ttyACM0`, or `/dev/serial/by-id/…`. If ports are missing or CAT never answers on Windows/macOS, install the [Silicon Labs CP210x VCP driver](https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads) and reboot — [§2.4](#24-usb-serial-driver-windows--macos--linux). Linux can normally skip that. |
 | Baud Rate | Must match the radio's CAT Rate setting. Default: 38400 |
 | Band Plan | **IARU Region 1** (Europe, Africa, Middle East — includes 4m), **IARU Region 2** (Americas), **IARU Region 3** (Asia-Pacific), or **Japan** (JARL). Affects which bands and segment frequencies are shown. UK is Region 1; USA, Canada, and South America are Region 2; Australia, New Zealand, and most of Asia (except Japan) are Region 3. |
 
@@ -2178,7 +2178,7 @@ This matters most **after you change the Radio Model or other settings**: the pa
 **App shows "Initialising…" and never clears**
 
 - Check that the radio is powered on.
-- Confirm the [Silicon Labs CP210x VCP driver](https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads) is installed and that you **rebooted** afterwards ([§2.4](#24-usb-serial-driver-windows--macos--linux)).
+- On **Windows or macOS**, if ports are missing or CAT never answers, install the [Silicon Labs CP210x VCP driver](https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads) and **reboot** ([§2.4](#24-usb-serial-driver-windows--macos--linux)). On **Linux**, skip that package — check cable, permissions (`dialout`), and the `/dev/…` path instead.
 - Check the COM / `/dev/…` port in Settings — use the **Enhanced** (CAT) port, not Standard. Go to **Diagnostics → Ports** to see which ports are available.
 - Check the baud rate in Settings matches the radio's **Menu → CAT Rate** setting (default 38400).
 - Click **Test Connection** in Settings.
@@ -2196,7 +2196,7 @@ Up to and including v2.4.2 — and in the v2.4.3 pre-releases up to pre3 — the
 
 - The radio may not be responding to CAT commands. Test the connection from the Settings page.
 - Check that no other software (e.g., another instance of the app, Ham Radio Deluxe, WSJT-X in direct CAT mode, Omni-rig) is using the same COM port. If you use Log4OM with Omni-rig, see Section 9.3 — Omni-rig is not needed and will conflict with this app.
-- On a fresh Mac/PC, install the Silicon Labs VCP driver and reboot before blaming the cable ([§15.11](#1511-test-connection-fails--cat-does-not-respond-over-usb)).
+- On a fresh Mac or Windows PC, if CAT still fails after checking port and baud, install the Silicon Labs VCP driver and reboot before blaming the cable ([§15.11](#1511-test-connection-fails--cat-does-not-respond-over-usb)).
 
 **WSJT-X does not show as connected**
 
@@ -2419,7 +2419,7 @@ As a safety backstop, YWC (v2.4.2 and later) will force the radio back to receiv
 | Getting the app | Windows: unsigned installer from Releases. macOS: unsigned CAT-only DMG from Releases (Apple Silicon or Intel) — Gatekeeper needs **Open** / **Open Anyway** the first time ([§2.2](#22-macos-dmg)). Linux: build `net10.0` from source, or Docker (`ghcr.io/mm5agm/yaesu_web_control`, amd64 + arm64). |
 | Host chrome | Windows tray · macOS menu-bar item · Linux/Docker console only |
 | Serial port | `COMn` on Windows; `/dev/cu.*` on macOS; `/dev/ttyUSB*` / `/dev/ttyACM*` on Linux (pass through with `YWC_SERIAL_DEVICE` in Docker). Always use the **Enhanced** CAT port when two CP210x ports appear. |
-| USB serial driver | Same on all three: install [Silicon Labs CP210x VCP](https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads) and **reboot** ([§2.4](#24-usb-serial-driver-windows--macos--linux)) |
+| USB serial driver | **Windows / macOS:** install [Silicon Labs CP210x VCP](https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads) and **reboot** only if ports are missing or CAT never answers ([§2.4](#24-usb-serial-driver-windows--macos--linux)). **Linux:** skip — in-kernel CP210x is enough. |
 | Settings & logs | Windows `%APPDATA%\MM5AGM\Yaesu Web Control\` · Unix `~/.config/MM5AGM/Yaesu Web Control/` · Docker volume under `/data/…` |
 | Leaving the shack with no browser open | Turn **off** “Automatically exit when no browser is connected”. Docker already forces that behaviour. |
 | SDR / Voice Control | Not on macOS/Linux/Docker. Use a Windows host if you need those. |
@@ -2431,16 +2431,18 @@ The browser UI from a phone or tablet is the same regardless of which OS hosts Y
 
 ### 15.11 Test Connection fails / CAT does not respond over USB
 
-**Most common fix:** install the official [Silicon Labs CP210x VCP driver](https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads) for your OS (**Windows, macOS, or Linux**) and **reboot the host**. Built-in or incomplete USB-serial stacks can make the port show up and even open in YWC while CAT commands (`ID;`, etc.) get no reply. After a proper install + reboot, Test Connection should start working once the baud rate and Enhanced port are correct.
+**Windows / macOS — if ports are missing or CAT never answers:** install the official [Silicon Labs CP210x VCP driver](https://www.silabs.com/software-and-tools/usb-to-uart-bridge-vcp-drivers?tab=downloads) and **reboot the host**. Incomplete or missing USB-serial stacks can make a port show up and even open in YWC while CAT commands (`ID;`, etc.) get no reply. After install + reboot, Test Connection should work once baud rate and the Enhanced port are correct.
+
+**Linux:** do **not** install Silicon Labs' VCP package first — CP210x support is already in the kernel. Check cable, power, `dialout` group membership, and that you picked the right `/dev/ttyUSB*` / `/dev/ttyACM*` node (Enhanced vs Standard when two appear).
 
 Checklist:
 
-1. Driver installed from the Silicon Labs downloads page above, then **reboot**.
-2. Radio powered on; rear-panel USB cable connected.
-3. Settings baud rate matches **Menu → CAT Rate** (usually **38400**).
-4. Serial Port is the **Enhanced** (CAT) virtual port, not Standard / TX-only. On macOS try the other `/dev/cu.usbserial-…` if the first fails.
-5. No other app is holding the same port.
-6. Prefer a direct USB port over a flaky hub when diagnosing.
+1. Radio powered on; rear-panel USB cable connected.
+2. Settings baud rate matches **Menu → CAT Rate** (usually **38400**).
+3. Serial Port is the **Enhanced** (CAT) virtual port, not Standard / TX-only. On macOS try the other `/dev/cu.usbserial-…` if the first fails.
+4. No other app is holding the same port.
+5. Prefer a direct USB port over a flaky hub when diagnosing.
+6. **Windows / macOS only:** if the steps above still fail, install the Silicon Labs VCP driver from the link above, then **reboot**.
 
 See also [§2.4](#24-usb-serial-driver-windows--macos--linux) and [§3](#3-first-time-setup).
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -2892,7 +2892,7 @@ Local testing on the same PC can use `http://localhost:8080` without HTTPS.
 5. **Mute mic** / **Mute RX** as needed. **Stop** ends the session and closes host audio devices.
 6. Only **one** audio session is allowed at a time; a second browser is rejected busy.
 
-The status line shows the active codec while streaming (for example `Streaming (opus)`). Change codec only while stopped — it applies on the next **Start**.
+The status line shows the active codec while streaming (for example `Streaming (opus)`). A codec change requires stopping and reconnecting remote audio — it does not apply to an active session.
 
 #### Pop-out window (keep audio while changing pages)
 
@@ -2935,7 +2935,7 @@ Remote Audio always samples at **48 kHz mono** on the host bridge. What changes 
 
 **Preference:** YWC offers **Opus first** whenever the browser supports it. Choose **PCM16** only if you need uncompressed audio on a fast LAN, or if Opus is greyed out in your browser.
 
-Both directions use the same codec for a session. Stop and Start again after changing the selector.
+Both directions use the same codec for a session. Stop remote audio and connect again after changing the selector.
 
 ---
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1366,8 +1366,8 @@ The files inside the zip are plain JSON; you can extract and inspect or hand-edi
 | Setting | Description |
 |---------|-------------|
 | Enable remote audio | Opt-in. When off, no audio devices are opened and the Index bar is hidden. |
-| Radio RX device (capture) | PortAudio input used for what you **hear** in the browser (usually Yaesu USB recording). Empty = system default input. Entries are labelled with the PortAudio host API (e.g. `Windows WASAPI`) so Windows duplicates of the same USB CODEC are distinguishable — prefer **Windows WASAPI** when several appear. |
-| Radio TX device (playback) | PortAudio output used for browser **mic → radio** (usually Yaesu USB playback). Empty = system default output. Same host-API labelling as RX. |
+| Radio RX device (capture) | PortAudio input used for what you **hear** in the browser (usually Yaesu USB recording). Empty = system default input. On Windows the list is limited to **WASAPI** endpoints so the same USB CODEC is not repeated under MME / DirectSound / WDM-KS. |
+| Radio TX device (playback) | PortAudio output used for browser **mic → radio** (usually Yaesu USB playback). Empty = system default output. Same WASAPI-only listing on Windows as RX. |
 | RX / TX gain | Software gain applied in the bridge (0.05–4). |
 
 Also configure **HTTPS** under [§6.2](#62-web-server-settings) if you will use a remote browser (not localhost). Full setup steps are in [§18 Remote Audio](#18-remote-audio).
@@ -2861,7 +2861,7 @@ Remote Audio streams **radio RX → browser speakers** and **browser microphone 
 
 1. Open **Settings → Remote Audio**.
 2. Enable **remote audio**.
-3. Pick **Radio RX device** (capture / what you hear) and **Radio TX device** (playback / where mic audio goes). Use **Refresh device list** after plugging the radio in. On Windows the same USB device may list several times (MME / DirectSound / WASAPI / WDM-KS) — choose the **Windows WASAPI** entry when available.
+3. Pick **Radio RX device** (capture / what you hear) and **Radio TX device** (playback / where mic audio goes). Use **Refresh device list** after plugging the radio in. On Windows only **WASAPI** devices are shown.
 4. Optionally adjust RX/TX gain.
 5. **Save Settings**.
 
@@ -2880,7 +2880,7 @@ Local testing on the same PC can use `http://localhost:8080` without HTTPS.
 
 1. Open the Index page (over HTTPS if remote).
 2. Click **Start audio** on the Remote Audio bar. Grant microphone permission when asked.
-3. You should hear RX audio; speak into the mic (levels show on the bar).
+3. You should hear RX audio; speak into the mic (levels show on the bar). Use the **Mic** dropdown to pick which browser microphone is sent to the radio (saved in the browser).
 4. Use **TX** / your TX toggle key to key the radio. Audio flows continuously (like Mumble); CAT controls PTT.
 5. **Mute mic** / **Mute RX** as needed. **Stop** ends the session and closes host audio devices.
 6. Only **one** audio session is allowed at a time; a second browser is rejected busy.
@@ -2900,14 +2900,14 @@ Audio on the Index page stops when you leave Home (for example to open **Setting
 | Symptom | What to try |
 |---------|-------------|
 | Mic permission denied / “requires HTTPS” | Use the HTTPS URL; regenerate the cert with the IP you type in the address bar; restart after enabling HTTPS. |
-| No RX sound | Check Radio RX device (on Windows try the **Windows WASAPI** entry); confirm radio AF gain / USB volume; look at the RX meter while Start audio is active. |
-| TX keys but no modulation | Confirm MOD SOURCE / USB; check Radio TX device (prefer **Windows WASAPI**); unmute mic; watch the TX meter while speaking. |
-| Choppy audio | Prefer wired Ethernet/VPN; reduce other load; stay on LAN/VPN (no TURN/WebRTC in v1). On Windows, avoid WDM-KS unless you need exclusive mode. |
+| No RX sound | Check Radio RX device; confirm radio AF gain / USB volume; look at the RX meter while Start audio is active. |
+| TX keys but no modulation | Confirm MOD SOURCE / USB; check Radio TX device; unmute mic; watch the TX meter while speaking. |
+| Choppy audio | Prefer wired Ethernet/VPN; reduce other load; stay on LAN/VPN (no TURN/WebRTC in v1). |
 | “Audio session busy” | Stop audio in the other tab/browser (or pop-out window) first. |
 | Audio dies when opening Settings | Use **Pop out** before leaving Home so the session lives in the separate window. |
 | Pop-out blocked | Allow pop-ups for the YWC origin; click **Pop out** / **Open pop-out** again. |
 | Devices missing from the list | Unplug/replug USB; Refresh device list; check OS privacy permissions for microphone (host process). |
-| Same device listed many times (Windows) | Expected — PortAudio exposes each endpoint per host API. Labels show the API in brackets; pick **Windows WASAPI** and Save so the choice is remembered. |
+| Wrong browser mic | Use the **Mic** dropdown on the Remote Audio bar (Home or pop-out). Choice is remembered in the browser. |
 | Voice Control vs radio USB | Keep Voice Control’s mic on your headset; leave Remote Audio devices on the Yaesu USB endpoints. |
 
 ---

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1372,9 +1372,9 @@ The files inside the zip are plain JSON; you can extract and inspect or hand-edi
 | Setting | Description |
 |---------|-------------|
 | Enable remote audio | Opt-in. When off, no audio devices are opened and the Index bar is hidden. |
-| Radio RX device (capture) | PortAudio input used for what you **hear** in the browser — usually the Yaesu USB **recording** endpoint (`Microphone (USB Audio CODEC)` / `Line (USB Audio CODEC)`, or a name you gave it in the OS). **Required** when remote audio is enabled (no system-default fallback). On Windows the list is limited to **WASAPI** endpoints so the same USB CODEC is not repeated under MME / DirectSound / WDM-KS. Names that look like a USB codec are sorted to the top and marked with ★. |
-| Radio TX device (playback) | PortAudio output for browser **mic → radio** — usually Yaesu USB **Speakers** / playback (`Speakers (USB Audio CODEC)`). **Required** when enabled. Do **not** leave blank or pick PC speakers / headphones: that loops the browser mic into the room and never reaches the radio. Same WASAPI-only listing and ★ hint as RX. |
-| RX / TX gain | Software gain applied in the bridge (0.05–4). On Home, open **Mic & Gain** on the Remote Audio bar (browser mic picker + RX/TX gain). The pop-out shows the same controls inline. |
+| Radio RX device (capture) | PortAudio input used for what you **hear** in the browser — usually the Yaesu USB **recording** endpoint (`Microphone (USB Audio CODEC)` / `Line (USB Audio CODEC)`, or a name you gave it in the OS). **Required** when remote audio is enabled (no system-default fallback). On Windows the list is limited to **WASAPI** endpoints so the same USB CODEC is not repeated under MME / DirectSound / WDM-KS. Names that look like a USB codec are sorted to the top and marked with a radio icon (📻). |
+| Radio TX device (playback) | PortAudio output for browser **mic → radio** — usually Yaesu USB **Speakers** / playback (`Speakers (USB Audio CODEC)`). **Required** when enabled. Do **not** leave blank or pick PC speakers / headphones: that loops the browser mic into the room and never reaches the radio. Same WASAPI-only listing and radio-icon hint as RX. |
+| RX / TX gain | Software gain in the bridge (0.05–4). Adjusted live via **Mic & Gain** on the Index Remote Audio bar (or inline on the pop-out) — not on the Settings page. |
 | Audio codec | Chosen on the Index **Mic & Gain** dialog or the pop-out (not a host setting). **Opus** (default) compresses speech to ~32 kb/s per direction; **PCM16** is uncompressed ~768 kb/s. See [§18.6](#186-audio-codecs-opus-vs-pcm16). |
 
 Also configure **HTTPS** under [§6.2](#62-web-server-settings) if you will use a remote browser (not localhost). Full setup steps are in [§18 Remote Audio](#18-remote-audio).
@@ -2870,9 +2870,8 @@ Remote Audio streams **radio RX → browser speakers** and **browser microphone 
 
 1. Open **Settings → Remote Audio**.
 2. Enable **remote audio**.
-3. Pick **Radio RX device** (capture / what you hear) and **Radio TX device** (playback / where mic audio goes). Both are **required** when the feature is on — YWC will not fall back to the PC’s default mic/speakers (blank TX previously caused browser-mic feedback into the room). Use **Refresh device list** after plugging the radio in. On Windows only **WASAPI** devices are shown. Entries that look like a USB codec are sorted first and marked with ★; renamed devices stay in the full list without a star.
-4. Optionally adjust RX/TX gain.
-5. **Save Settings**.
+3. Pick **Radio RX device** (capture / what you hear) and **Radio TX device** (playback / where mic audio goes). Both are **required** when the feature is on — YWC will not fall back to the PC’s default mic/speakers (blank TX previously caused browser-mic feedback into the room). Use **Refresh device list** after plugging the radio in. On Windows only **WASAPI** devices are shown. Entries that look like a USB codec are sorted first and marked with a radio icon (📻); renamed devices stay in the full list without the icon.
+4. **Save Settings**. RX/TX software gain is adjusted later via **Mic & Gain** on Home (or the pop-out), not on this page.
 
 ### 18.3 HTTPS for remote browsers
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -2918,6 +2918,7 @@ Audio on the Index page stops when you leave Home (for example to open **Setting
 | Audio dies when opening Settings | Use **Pop out** before leaving Home so the session lives in the separate window. |
 | Pop-out blocked | Allow pop-ups for the YWC origin; click **Pop out** / **Open pop-out** again. |
 | Devices missing from the list | Unplug/replug USB; Refresh device list; check OS privacy permissions for microphone (host process). |
+| Session connects but no RX (RX meter stuck at 0) on macOS | macOS treats the radio USB **recording** endpoint as a microphone. Grant **System Settings → Privacy & Security → Microphone → Yaesu Web Control**. If the app was built without `NSMicrophoneUsageDescription`, macOS never prompts and PortAudio still “opens” the device but returns silence — rebuild/reinstall a DMG that includes that key (see `scripts/macos/build-dmg.sh`), then allow Microphone when prompted. |
 | Wrong browser mic | Open **Mic & Gain** on the Remote Audio bar (or use the pop-out controls) and pick the right browser microphone. Choice is remembered in the browser. |
 | Opus unavailable / forced to PCM16 | The browser needs WebCodecs `AudioEncoder` / `AudioDecoder` (current Chrome, Edge, or Chromium). Older Safari/Firefox builds may only offer PCM16. |
 | Voice Control vs radio USB | Keep Voice Control’s mic on your headset; leave Remote Audio devices on the Yaesu USB endpoints. |

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -311,7 +311,7 @@ None of these are required for basic operation. Get the radio connection working
 
 ### Windows
 
-Double-click the **Yaesu Web Control** shortcut on your desktop. The app starts in the background and your default browser opens automatically to whichever port YWC managed to bind (usually `http://localhost:8080`, but YWC will fall back to 8081–8089 if 8080 was already in use).
+Double-click the **Yaesu Web Control** shortcut on your desktop. The app starts in the background and — with **Open browser automatically on startup** enabled (the default) — your default browser opens to whichever port YWC managed to bind (usually `http://localhost:8080`, but YWC will fall back to 8081–8089 if 8080 was already in use). If you turned that setting off, use the tray icon’s **Open** action (or browse to the URL yourself).
 
 A small **YWC tray icon** appears in the Windows system tray (down by the clock, possibly under the **Show hidden icons ︿** arrow). The tray icon is your "the app is running" indicator and gives you a clean way to manage it without juggling Task Manager:
 
@@ -330,7 +330,7 @@ A small **YWC tray icon** appears in the Windows system tray (down by the clock,
 
 ### macOS (CAT-only host)
 
-Launch **Yaesu Web Control** from Applications (DMG install — [§2.2](#22-macos-dmg)), or run `dotnet run --framework net10.0` from a source checkout. Either way Kestrel starts and a **menu-bar status item** offers the same Open / About / Open user data folder / Exit actions as the Windows tray. User data lives under `~/.config/MM5AGM/Yaesu Web Control/`. The browser may open automatically on a desktop Mac; if not, use the menu-bar **Open** item or browse to the URL yourself.
+Launch **Yaesu Web Control** from Applications (DMG install — [§2.2](#22-macos-dmg)), or run `dotnet run --framework net10.0` from a source checkout. Either way Kestrel starts and a **menu-bar status item** offers the same Open / About / Open user data folder / Exit actions as the Windows tray. User data lives under `~/.config/MM5AGM/Yaesu Web Control/`. With **Open browser automatically on startup** enabled (default), the browser opens on a desktop Mac; if you turned it off (or it didn’t open), use the menu-bar **Open** item or browse to the URL yourself.
 
 ### Linux (from source)
 
@@ -1066,6 +1066,7 @@ After changing the serial port or baud rate, click **Test Connection** to verify
 |---------|-------------|
 | Network Interface | `localhost` (this PC only) or `0.0.0.0` (all interfaces, including LAN). Choose `0.0.0.0` to access the app from a tablet or phone |
 | HTTP port | Port Kestrel listens on (default **8080**; if busy, YWC tries 8081–8089 at startup). Changing this needs a restart. |
+| Open browser automatically on startup | When **on** (default), YWC opens your default browser to the control panel after the web server starts. Turn **off** to start quietly — open the UI from the system tray / menu bar, or browse to the URL yourself. Tray/menu **Open** still works when this is off. **Docker never auto-opens** a browser. |
 | Automatically exit when no browser is connected | When **on** (default on desktop hosts), YWC exits ~30 seconds after the last heartbeating browser tab closes. Turn **off** for a headless shack / always-on Pi so closing the browser does not stop CAT. **Docker always keeps the host running** regardless of this checkbox. |
 | Enable HTTPS | Optional TLS listener (default port **8443**) using a YWC-generated self-signed certificate. Required for **remote microphone** access (browsers block `getUserMedia` on plain `http://` except localhost). See [§18 Remote Audio](#18-remote-audio). |
 | HTTPS port | Port for the HTTPS listener when enabled (default **8443**). HTTP continues on the HTTP port (dual-listen). Restart required. |
@@ -1370,6 +1371,8 @@ The files inside the zip are plain JSON; you can extract and inspect or hand-edi
 | RX / TX gain | Software gain applied in the bridge (0.05–4). |
 
 Also configure **HTTPS** under [§6.2](#62-web-server-settings) if you will use a remote browser (not localhost). Full setup steps are in [§18 Remote Audio](#18-remote-audio).
+
+On the Index **Remote Audio** bar, **Pop out** opens a small dedicated window that owns the audio session. Use this before opening Settings (or any other page) so RX/TX keep running — navigating away from Home otherwise closes the in-page session. While audio is in the pop-out, Home still shows status/levels/mutes, and the filter-scope FFT on Home stays live. Only one audio session is allowed at a time; handing off briefly reconnects.
 
 ---
 
@@ -2882,6 +2885,16 @@ Local testing on the same PC can use `http://localhost:8080` without HTTPS.
 5. **Mute mic** / **Mute RX** as needed. **Stop** ends the session and closes host audio devices.
 6. Only **one** audio session is allowed at a time; a second browser is rejected busy.
 
+#### Pop-out window (keep audio while changing pages)
+
+Audio on the Index page stops when you leave Home (for example to open **Settings**). To keep streaming:
+
+1. Click **Pop out** on the Remote Audio bar. A small **Remote Audio** window opens.
+2. If you were already streaming, YWC hands the session to that window (brief reconnect). Otherwise click **Start audio** in the pop-out.
+3. Leave the pop-out open while you use Settings or other pages. Home shows status such as *In pop-out window (streaming)*; mute switches on Home still control the pop-out session. Filter-scope on Home keeps receiving live RX spectrum from the pop-out.
+4. **Stop** on Home stops the pop-out session. **Close** in the pop-out (or closing the window) ends audio and returns control to Home.
+5. If the browser blocks the window, allow pop-ups for the YWC site and try again.
+
 ### 18.5 Troubleshooting
 
 | Symptom | What to try |
@@ -2890,7 +2903,9 @@ Local testing on the same PC can use `http://localhost:8080` without HTTPS.
 | No RX sound | Check Radio RX device; confirm radio AF gain / USB volume; look at the RX meter while Start audio is active. |
 | TX keys but no modulation | Confirm MOD SOURCE / USB; check Radio TX device; unmute mic; watch the TX meter while speaking. |
 | Choppy audio | Prefer wired Ethernet/VPN; reduce other load; stay on LAN/VPN (no TURN/WebRTC in v1). |
-| “Audio session busy” | Stop audio in the other tab/browser first. |
+| “Audio session busy” | Stop audio in the other tab/browser (or pop-out window) first. |
+| Audio dies when opening Settings | Use **Pop out** before leaving Home so the session lives in the separate window. |
+| Pop-out blocked | Allow pop-ups for the YWC origin; click **Pop out** / **Open pop-out** again. |
 | Devices missing from the list | Unplug/replug USB; Refresh device list; check OS privacy permissions for microphone (host process). |
 | Voice Control vs radio USB | Keep Voice Control’s mic on your headset; leave Remote Audio devices on the Yaesu USB endpoints. |
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -40,6 +40,7 @@
    - 6.5 [CW Memory Messages](#65-cw-memory-messages-m1m5)
    - 6.6 [DX Cluster](#66-dx-cluster)
    - 6.7 [Backup &amp; Restore](#67-backup--restore)
+   - 6.8 [Remote Audio](#68-remote-audio)
 7. [Application Setup](#7-application-setup)
    - 7.1 [External App Buttons](#71-external-app-buttons)
    - 7.2 [WSJT-X UDP Settings](#72-wsjt-x-udp-settings)
@@ -91,6 +92,7 @@
     - 17.5 [Privacy](#175-privacy)
     - 17.6 [Adding your own commands](#176-adding-your-own-commands)
     - 17.7 [More languages](#177-more-languages)
+18. [Remote Audio](#18-remote-audio)
 
 ---
 
@@ -1065,8 +1067,12 @@ After changing the serial port or baud rate, click **Test Connection** to verify
 | Network Interface | `localhost` (this PC only) or `0.0.0.0` (all interfaces, including LAN). Choose `0.0.0.0` to access the app from a tablet or phone |
 | HTTP port | Port Kestrel listens on (default **8080**; if busy, YWC tries 8081–8089 at startup). Changing this needs a restart. |
 | Automatically exit when no browser is connected | When **on** (default on desktop hosts), YWC exits ~30 seconds after the last heartbeating browser tab closes. Turn **off** for a headless shack / always-on Pi so closing the browser does not stop CAT. **Docker always keeps the host running** regardless of this checkbox. |
+| Enable HTTPS | Optional TLS listener (default port **8443**) using a YWC-generated self-signed certificate. Required for **remote microphone** access (browsers block `getUserMedia` on plain `http://` except localhost). See [§18 Remote Audio](#18-remote-audio). |
+| HTTPS port | Port for the HTTPS listener when enabled (default **8443**). HTTP continues on the HTTP port (dual-listen). Restart required. |
+| Certificate SAN hostnames / IPs | Extra names/IPs embedded in the self-signed cert (e.g. WireGuard IP). Always includes `localhost`. |
+| Generate self-signed certificate | Writes `https.pfx` under the YWC user-data folder. Overwrites any existing cert. **Restart YWC** after generating if HTTPS is enabled. |
 
-> **Note:** After changing the network interface or HTTP port, save settings and restart the application.
+> **Note:** After changing the network interface, HTTP/HTTPS port, or HTTPS enable flag, save settings and restart the application.
 
 The Settings page also shows the full URL for each detected network interface so you can bookmark the correct address on your tablet.
 
@@ -1349,6 +1355,21 @@ Click **Import full backup…**, pick a previously exported zip, and confirm the
 - **Experimenting safely** — export before trying something risky; import the file to revert if it goes wrong.
 
 The files inside the zip are plain JSON; you can extract and inspect or hand-edit them if needed. They live at `%APPDATA%\MM5AGM\Yaesu Web Control\` and are also accessible directly without going through the export.
+
+---
+
+### 6.8 Remote Audio
+
+**Settings → Remote Audio** enables in-browser send/receive audio between a remote operator and the radio’s USB sound devices on the YWC host (an alternative to Mumble/SonoBus for remote SSB over LAN or VPN).
+
+| Setting | Description |
+|---------|-------------|
+| Enable remote audio | Opt-in. When off, no audio devices are opened and the Index bar is hidden. |
+| Radio RX device (capture) | PortAudio input used for what you **hear** in the browser (usually Yaesu USB recording). Empty = system default input. |
+| Radio TX device (playback) | PortAudio output used for browser **mic → radio** (usually Yaesu USB playback). Empty = system default output. |
+| RX / TX gain | Software gain applied in the bridge (0.05–4). |
+
+Also configure **HTTPS** under [§6.2](#62-web-server-settings) if you will use a remote browser (not localhost). Full setup steps are in [§18 Remote Audio](#18-remote-audio).
 
 ---
 
@@ -2341,21 +2362,21 @@ The Alexa code **isn't deleted** — it lives on a parked branch and can be revi
 
 ### 15.7 What is the TX button for? When I press it the radio goes into TX mode but there's no audio from my microphone.
 
-The TX button in YWC sends the `TX1;` CAT command, which puts the radio into transmit mode (PTT engaged) but **does not route any audio into the radio**. With nothing modulating the carrier, what actually goes on-air depends on the current mode:
+The TX button in YWC sends the `TX1;` CAT command, which puts the radio into transmit mode (PTT engaged) but **by itself does not create microphone audio**. With nothing modulating the carrier, what actually goes on-air depends on the current mode and how audio is fed:
 
 - **CW** — an unmodulated carrier (a steady tone). Useful for tune-up, SWR measurement, or driving an external tuner / amplifier into its tune cycle.
-- **SSB / AM / FM** — the TX path is open but no audio is being injected, so the on-air signal is effectively silent.
-- **DATA / digital modes** — the same as SSB until something else (WSJT-X via the rear DATA jack or USB audio) is feeding audio in.
+- **SSB / AM / FM** — the TX path is open; you need audio into the radio (front mic, or USB/REAR audio from the PC).
+- **DATA / digital modes** — typically USB audio from WSJT-X (or similar) into the rear DATA/USB path.
 
-In short, the TX button is "key the radio for testing", not "open the mic". The radio's microphone input is only routed to the TX path when the mic's own **PTT button** (or footswitch, or VOX) triggers TX. YWC doesn't intercept or route audio at all — that side is between your mic and the radio.
+**Local mic:** press the PTT on the hand mic / footswitch / VOX as usual.
 
-What people use it for in practice:
+**Remote browser mic:** enable [Remote Audio](#18-remote-audio), pick the radio’s USB devices in Settings, use HTTPS for non-localhost browsers, click **Start audio** on the Index page, then use the TX button (or TX toggle key) for PTT. On the radio, set **MOD SOURCE** to USB / REAR (USB).
+
+What people use the TX button for without remote audio:
 
 1. **Tune-up.** Switch to CW, click TX, watch your SWR or let your ATU find a match.
 2. **Driving an external amplifier or antenna tuner** into its auto-tune cycle.
-3. **Digital-mode keying tests.** When WSJT-X (or similar) is feeding audio into the rear DATA jack, the TX button gives you a CAT-driven way to verify the keying side of the path without starting a real QSO.
-
-To transmit voice from your microphone, press the PTT button on the mic itself.
+3. **Digital-mode keying tests.** When WSJT-X is feeding audio into USB, the TX button verifies CAT keying.
 
 ---
 
@@ -2818,6 +2839,60 @@ Only **English (UK)** ships as the built-in default, but the language pack syste
 3. **Switching locale takes effect immediately** — no restart needed, unlike the initial enable toggle.
 
 The **Voice Phrases editor** itself currently only edits the **en-GB** pack in place; editing an *installed non-English pack* through the same in-app grid isn't wired up yet — for now, translate by hand-editing that culture's JSON file directly, or ask a fluent speaker to export their pack after editing it locally. If you'd like a particular language prioritised for a built-in default, or want the editor to support editing other locales directly, please open a GitHub discussion or issue and mention it.
+
+---
+
+## 18. Remote Audio
+
+Remote Audio streams **radio RX → browser speakers** and **browser microphone → radio TX** over a dedicated WebSocket on the YWC host. PTT remains the normal Index **TX** button (or optional TX toggle key). It is intended for **LAN or VPN** use (for example WireGuard) as a simpler alternative to running Mumble or SonoBus alongside YWC.
+
+> **Not supported in Docker for v1.** USB audio device access from containers is host-specific and unreliable; run the native host on Windows, macOS, or Linux instead.
+
+### 18.1 Radio setup
+
+1. Connect the radio’s USB cable so the PC sees both CAT and USB audio.
+2. In the radio menu, set **MOD SOURCE** to **REAR** with **REAR SELECT = USB**, or **MOD SOURCE = USB** on models that use that wording (e.g. FT-710). Same idea as FT-Control / digital-mode USB audio.
+3. Confirm the OS lists Yaesu (or “USB Audio”) playback and recording devices.
+
+### 18.2 YWC host setup
+
+1. Open **Settings → Remote Audio**.
+2. Enable **remote audio**.
+3. Pick **Radio RX device** (capture / what you hear) and **Radio TX device** (playback / where mic audio goes). Use **Refresh device list** after plugging the radio in.
+4. Optionally adjust RX/TX gain.
+5. **Save Settings**.
+
+### 18.3 HTTPS for remote browsers
+
+Browsers only allow the microphone on a **secure context** (`https://` or `localhost`).
+
+1. Under **Settings → Web / HTTP**, enter any WireGuard/LAN IPs or hostnames under **Certificate SAN hostnames / IPs**.
+2. Click **Generate self-signed certificate**.
+3. Enable **HTTPS**, note the HTTPS port (default **8443**), **Save Settings**, and **restart YWC**.
+4. On the remote machine, open `https://<host>:8443` (not the HTTP port). Accept the certificate warning once (Advanced → Proceed), or trust the cert in the OS if you prefer.
+
+Local testing on the same PC can use `http://localhost:8080` without HTTPS.
+
+### 18.4 Operating
+
+1. Open the Index page (over HTTPS if remote).
+2. Click **Start audio** on the Remote Audio bar. Grant microphone permission when asked.
+3. You should hear RX audio; speak into the mic (levels show on the bar).
+4. Use **TX** / your TX toggle key to key the radio. Audio flows continuously (like Mumble); CAT controls PTT.
+5. **Mute mic** / **Mute RX** as needed. **Stop** ends the session and closes host audio devices.
+6. Only **one** audio session is allowed at a time; a second browser is rejected busy.
+
+### 18.5 Troubleshooting
+
+| Symptom | What to try |
+|---------|-------------|
+| Mic permission denied / “requires HTTPS” | Use the HTTPS URL; regenerate the cert with the IP you type in the address bar; restart after enabling HTTPS. |
+| No RX sound | Check Radio RX device; confirm radio AF gain / USB volume; look at the RX meter while Start audio is active. |
+| TX keys but no modulation | Confirm MOD SOURCE / USB; check Radio TX device; unmute mic; watch the TX meter while speaking. |
+| Choppy audio | Prefer wired Ethernet/VPN; reduce other load; stay on LAN/VPN (no TURN/WebRTC in v1). |
+| “Audio session busy” | Stop audio in the other tab/browser first. |
+| Devices missing from the list | Unplug/replug USB; Refresh device list; check OS privacy permissions for microphone (host process). |
+| Voice Control vs radio USB | Keep Voice Control’s mic on your headset; leave Remote Audio devices on the Yaesu USB endpoints. |
 
 ---
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1368,7 +1368,7 @@ The files inside the zip are plain JSON; you can extract and inspect or hand-edi
 | Enable remote audio | Opt-in. When off, no audio devices are opened and the Index bar is hidden. |
 | Radio RX device (capture) | PortAudio input used for what you **hear** in the browser (usually Yaesu USB recording). Empty = system default input. On Windows the list is limited to **WASAPI** endpoints so the same USB CODEC is not repeated under MME / DirectSound / WDM-KS. |
 | Radio TX device (playback) | PortAudio output used for browser **mic → radio** (usually Yaesu USB playback). Empty = system default output. Same WASAPI-only listing on Windows as RX. |
-| RX / TX gain | Software gain applied in the bridge (0.05–4). |
+| RX / TX gain | Software gain applied in the bridge (0.05–4). On Home, open **Mic & Gain** on the Remote Audio bar (browser mic picker + RX/TX gain). The pop-out shows the same controls inline. |
 
 Also configure **HTTPS** under [§6.2](#62-web-server-settings) if you will use a remote browser (not localhost). Full setup steps are in [§18 Remote Audio](#18-remote-audio).
 
@@ -2880,7 +2880,7 @@ Local testing on the same PC can use `http://localhost:8080` without HTTPS.
 
 1. Open the Index page (over HTTPS if remote).
 2. Click **Start audio** on the Remote Audio bar. Grant microphone permission when asked.
-3. You should hear RX audio; speak into the mic (levels show on the bar). Use the **Mic** dropdown to pick which browser microphone is sent to the radio (saved in the browser).
+3. You should hear RX audio; speak into the mic (levels show on the bar). Use **Mic & Gain** to pick the browser microphone and adjust RX/TX software gain (saved automatically).
 4. Use **TX** / your TX toggle key to key the radio. Audio flows continuously (like Mumble); CAT controls PTT.
 5. **Mute mic** / **Mute RX** as needed. **Stop** ends the session and closes host audio devices.
 6. Only **one** audio session is allowed at a time; a second browser is rejected busy.
@@ -2907,7 +2907,7 @@ Audio on the Index page stops when you leave Home (for example to open **Setting
 | Audio dies when opening Settings | Use **Pop out** before leaving Home so the session lives in the separate window. |
 | Pop-out blocked | Allow pop-ups for the YWC origin; click **Pop out** / **Open pop-out** again. |
 | Devices missing from the list | Unplug/replug USB; Refresh device list; check OS privacy permissions for microphone (host process). |
-| Wrong browser mic | Use the **Mic** dropdown on the Remote Audio bar (Home or pop-out). Choice is remembered in the browser. |
+| Wrong browser mic | Open **Mic & Gain** on the Remote Audio bar (or use the pop-out controls) and pick the right browser microphone. Choice is remembered in the browser. |
 | Voice Control vs radio USB | Keep Voice Control’s mic on your headset; leave Remote Audio devices on the Yaesu USB endpoints. |
 
 ---

--- a/Yaesu_Web_Control.csproj
+++ b/Yaesu_Web_Control.csproj
@@ -101,8 +101,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Concentus" Version="2.2.2" />
     <PackageReference Include="Markdig" Version="1.2.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
+    <PackageReference Include="PortAudioSharp2" Version="1.0.6" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/scripts/macos/build-dmg.sh
+++ b/scripts/macos/build-dmg.sh
@@ -106,6 +106,8 @@ write_info_plist() {
 	<true/>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Yaesu Web Control captures the radio USB audio codec (and optionally the Mac microphone) for Remote Audio in the browser.</string>
 EOF
   if [[ "$include_icon" == "1" ]]; then
     cat >>"$plist" <<EOF

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -873,6 +873,13 @@ fieldset.calibration-card {
 #remoteAudioLevelsDialog > div:first-child:active {
     cursor: grabbing;
 }
+/* Bootstrap form-text / text-muted are dark-on-light; lighten for this dark dialog. */
+#remoteAudioLevelsDialog .form-text,
+#remoteAudioLevelsDialog .text-muted {
+    color: #9aa0a6 !important;
+    font-size: 0.75rem;
+    line-height: 1.35;
+}
 
 /* ── Frequency Keyboard Dialog ──────────────────────────────────────────── */
 

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -857,6 +857,23 @@ fieldset.calibration-card {
     margin: 0;
 }
 
+/* Remote Audio Levels — must sit above spectrum / meter stacks (modeless show()). */
+#remoteAudioLevelsDialog {
+    position: fixed;
+    top: 120px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 9998;
+    margin: 0;
+}
+#remoteAudioLevelsDialog > div:first-child {
+    cursor: grab;
+    user-select: none;
+}
+#remoteAudioLevelsDialog > div:first-child:active {
+    cursor: grabbing;
+}
+
 /* ── Frequency Keyboard Dialog ──────────────────────────────────────────── */
 
 .fkb-dialog {

--- a/wwwroot/js/audio/audio-capture.js
+++ b/wwwroot/js/audio/audio-capture.js
@@ -1,5 +1,5 @@
 import {
-  SAMPLE_RATE, FRAME_SAMPLES, MSG_OPUS_TX, MSG_PCM_TX,
+  SAMPLE_RATE, FRAME_SAMPLES, MSG_OPUS_TX, MSG_PCM_TX, OPUS_FRAME_DURATION_US,
   frameMessage, floatToPcm16, supportsWebCodecsOpus
 } from './audio-protocol.js';
 
@@ -99,10 +99,11 @@ export class AudioCapture {
     this._pendingChunks = [];
     this._encoder = new AudioEncoder({
       output: (chunk) => {
+        // Skip empty / config-only chunks — Concentus only wants Opus packets.
+        if (!chunk || chunk.byteLength < 1) return;
         const buf = new ArrayBuffer(chunk.byteLength);
         chunk.copyTo(buf);
-        const type = MSG_OPUS_TX;
-        const framed = frameMessage(type, this._seq++, buf);
+        const framed = frameMessage(MSG_OPUS_TX, this._seq++, buf);
         this._onFrame(framed);
       },
       error: (e) => console.warn('AudioEncoder error', e)
@@ -111,34 +112,43 @@ export class AudioCapture {
       codec: 'opus',
       sampleRate: SAMPLE_RATE,
       numberOfChannels: 1,
-      bitrate: 32000
+      bitrate: 32000,
+      opus: {
+        application: 'voip',
+        frameDuration: OPUS_FRAME_DURATION_US
+      }
     });
   }
 
   _onSamples(float32) {
     if (this._muted) return;
 
-    // Accumulate to 20 ms frames
+    // Accumulate to 10 ms frames
     const merged = new Float32Array(this._accum.length + float32.length);
     merged.set(this._accum);
     merged.set(float32, this._accum.length);
     this._accum = merged;
 
     while (this._accum.length >= FRAME_SAMPLES) {
-      const frame = this._accum.subarray(0, FRAME_SAMPLES);
+      // Own a contiguous copy — AudioEncoder may hold the buffer asynchronously.
+      const frame = this._accum.slice(0, FRAME_SAMPLES);
       this._accum = this._accum.slice(FRAME_SAMPLES);
 
       if (this._codec === 'opus' && this._encoder) {
-        const audioData = new AudioData({
-          format: 'f32-planar',
-          sampleRate: SAMPLE_RATE,
-          numberOfFrames: FRAME_SAMPLES,
-          numberOfChannels: 1,
-          timestamp: performance.now() * 1000,
-          data: frame
-        });
-        this._encoder.encode(audioData);
-        audioData.close();
+        try {
+          const audioData = new AudioData({
+            format: 'f32-planar',
+            sampleRate: SAMPLE_RATE,
+            numberOfFrames: FRAME_SAMPLES,
+            numberOfChannels: 1,
+            timestamp: performance.now() * 1000,
+            data: frame
+          });
+          this._encoder.encode(audioData);
+          audioData.close();
+        } catch (e) {
+          console.warn('Opus encode failed', e);
+        }
       } else {
         const pcm = floatToPcm16(frame);
         const framed = frameMessage(MSG_PCM_TX, this._seq++, pcm);

--- a/wwwroot/js/audio/audio-capture.js
+++ b/wwwroot/js/audio/audio-capture.js
@@ -1,0 +1,142 @@
+import {
+  SAMPLE_RATE, FRAME_SAMPLES, MSG_OPUS_TX, MSG_PCM_TX,
+  frameMessage, floatToPcm16, supportsWebCodecsOpus
+} from './audio-protocol.js';
+
+/**
+ * Captures microphone PCM, encodes Opus (WebCodecs) or PCM16, sends via callback.
+ */
+export class AudioCapture {
+  constructor({ onFrame, codec = 'pcm16' }) {
+    this._onFrame = onFrame;
+    this._codec = codec;
+    this._seq = 1;
+    this._stream = null;
+    this._ctx = null;
+    this._worklet = null;
+    this._encoder = null;
+    this._muted = false;
+    this._accum = new Float32Array(0);
+  }
+
+  get muted() { return this._muted; }
+  set muted(v) { this._muted = !!v; }
+
+  async start() {
+    this._stream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+        channelCount: 1,
+        sampleRate: SAMPLE_RATE
+      }
+    });
+
+    this._ctx = new AudioContext({ sampleRate: SAMPLE_RATE });
+    const source = this._ctx.createMediaStreamSource(this._stream);
+
+    if (this._codec === 'opus' && supportsWebCodecsOpus()) {
+      try {
+        await this._startOpusEncoder();
+      } catch (e) {
+        console.warn('Opus encode unavailable, using PCM16', e);
+        this._codec = 'pcm16';
+      }
+    }
+
+    const processorCode = `
+      class YwcCaptureProcessor extends AudioWorkletProcessor {
+        process(inputs) {
+          const input = inputs[0];
+          if (input && input[0] && input[0].length) {
+            const copy = new Float32Array(input[0]);
+            this.port.postMessage(copy, [copy.buffer]);
+          }
+          return true;
+        }
+      }
+      registerProcessor('ywc-capture', YwcCaptureProcessor);
+    `;
+    const blob = new Blob([processorCode], { type: 'application/javascript' });
+    const url = URL.createObjectURL(blob);
+    await this._ctx.audioWorklet.addModule(url);
+    URL.revokeObjectURL(url);
+
+    this._worklet = new AudioWorkletNode(this._ctx, 'ywc-capture');
+    this._worklet.port.onmessage = (ev) => this._onSamples(ev.data);
+    source.connect(this._worklet);
+    // Keep graph alive without monitoring locally
+    this._worklet.connect(this._ctx.createGain()).connect(this._ctx.destination);
+    this._worklet.context.createGain; // silence via gain 0
+    const silent = this._ctx.createGain();
+    silent.gain.value = 0;
+    this._worklet.disconnect();
+    source.connect(this._worklet);
+    this._worklet.connect(silent);
+    silent.connect(this._ctx.destination);
+  }
+
+  async _startOpusEncoder() {
+    this._pendingChunks = [];
+    this._encoder = new AudioEncoder({
+      output: (chunk) => {
+        const buf = new ArrayBuffer(chunk.byteLength);
+        chunk.copyTo(buf);
+        const type = MSG_OPUS_TX;
+        const framed = frameMessage(type, this._seq++, buf);
+        this._onFrame(framed);
+      },
+      error: (e) => console.warn('AudioEncoder error', e)
+    });
+    this._encoder.configure({
+      codec: 'opus',
+      sampleRate: SAMPLE_RATE,
+      numberOfChannels: 1,
+      bitrate: 32000
+    });
+  }
+
+  _onSamples(float32) {
+    if (this._muted) return;
+
+    // Accumulate to 20 ms frames
+    const merged = new Float32Array(this._accum.length + float32.length);
+    merged.set(this._accum);
+    merged.set(float32, this._accum.length);
+    this._accum = merged;
+
+    while (this._accum.length >= FRAME_SAMPLES) {
+      const frame = this._accum.subarray(0, FRAME_SAMPLES);
+      this._accum = this._accum.slice(FRAME_SAMPLES);
+
+      if (this._codec === 'opus' && this._encoder) {
+        const audioData = new AudioData({
+          format: 'f32-planar',
+          sampleRate: SAMPLE_RATE,
+          numberOfFrames: FRAME_SAMPLES,
+          numberOfChannels: 1,
+          timestamp: performance.now() * 1000,
+          data: frame
+        });
+        this._encoder.encode(audioData);
+        audioData.close();
+      } else {
+        const pcm = floatToPcm16(frame);
+        const framed = frameMessage(MSG_PCM_TX, this._seq++, pcm);
+        this._onFrame(framed);
+      }
+    }
+  }
+
+  async stop() {
+    try { this._encoder?.close(); } catch { /* ignore */ }
+    this._encoder = null;
+    try { this._worklet?.disconnect(); } catch { /* ignore */ }
+    try { await this._ctx?.close(); } catch { /* ignore */ }
+    this._ctx = null;
+    this._stream?.getTracks().forEach(t => t.stop());
+    this._stream = null;
+    this._accum = new Float32Array(0);
+  }
+}

--- a/wwwroot/js/audio/audio-capture.js
+++ b/wwwroot/js/audio/audio-capture.js
@@ -33,7 +33,10 @@ export class AudioCapture {
       }
     });
 
-    this._ctx = new AudioContext({ sampleRate: SAMPLE_RATE });
+    this._ctx = new AudioContext({
+      sampleRate: SAMPLE_RATE,
+      latencyHint: 'interactive'
+    });
     const source = this._ctx.createMediaStreamSource(this._stream);
 
     if (this._codec === 'opus' && supportsWebCodecsOpus()) {

--- a/wwwroot/js/audio/audio-capture.js
+++ b/wwwroot/js/audio/audio-capture.js
@@ -22,16 +22,31 @@ export class AudioCapture {
   get muted() { return this._muted; }
   set muted(v) { this._muted = !!v; }
 
-  async start() {
-    this._stream = await navigator.mediaDevices.getUserMedia({
-      audio: {
-        echoCancellation: false,
-        noiseSuppression: false,
-        autoGainControl: false,
-        channelCount: 1,
-        sampleRate: SAMPLE_RATE
+  /**
+   * @param {{ deviceId?: string }} [opts] — browser audioinput deviceId; empty = default.
+   */
+  async start(opts = {}) {
+    const deviceId = (opts.deviceId || '').trim();
+    const audio = {
+      echoCancellation: false,
+      noiseSuppression: false,
+      autoGainControl: false,
+      channelCount: 1,
+      sampleRate: SAMPLE_RATE
+    };
+    if (deviceId) audio.deviceId = { exact: deviceId };
+
+    try {
+      this._stream = await navigator.mediaDevices.getUserMedia({ audio });
+    } catch (e) {
+      // Stale saved deviceId — fall back to the default mic.
+      if (deviceId && (e.name === 'OverconstrainedError' || e.name === 'NotFoundError' || e.name === 'NotReadableError')) {
+        delete audio.deviceId;
+        this._stream = await navigator.mediaDevices.getUserMedia({ audio });
+      } else {
+        throw e;
       }
-    });
+    }
 
     this._ctx = new AudioContext({
       sampleRate: SAMPLE_RATE,

--- a/wwwroot/js/audio/audio-playback.js
+++ b/wwwroot/js/audio/audio-playback.js
@@ -1,0 +1,141 @@
+import {
+  SAMPLE_RATE, FRAME_SAMPLES, MSG_OPUS_RX, MSG_PCM_RX,
+  pcm16ToFloat, supportsWebCodecsOpus
+} from './audio-protocol.js';
+
+/**
+ * Jitter-buffered playback of RX Opus or PCM16 frames.
+ */
+export class AudioPlayback {
+  constructor() {
+    this._ctx = null;
+    this._worklet = null;
+    this._decoder = null;
+    this._codec = 'pcm16';
+    this._muted = false;
+    this._queue = []; // Float32Array frames
+    this._maxQueue = 8; // ~160 ms
+  }
+
+  get muted() { return this._muted; }
+  set muted(v) { this._muted = !!v; }
+
+  async start(codec) {
+    this._codec = codec || 'pcm16';
+    this._ctx = new AudioContext({ sampleRate: SAMPLE_RATE });
+
+    if (this._codec === 'opus' && supportsWebCodecsOpus()) {
+      try {
+        await this._startOpusDecoder();
+      } catch (e) {
+        console.warn('Opus decode unavailable', e);
+        this._codec = 'pcm16';
+      }
+    }
+
+    const processorCode = `
+      class YwcPlaybackProcessor extends AudioWorkletProcessor {
+        constructor() {
+          super();
+          this.queue = [];
+          this.offset = 0;
+          this.port.onmessage = (ev) => {
+            if (ev.data && ev.data.length) this.queue.push(ev.data);
+          };
+        }
+        process(inputs, outputs) {
+          const out = outputs[0][0];
+          if (!out) return true;
+          let i = 0;
+          while (i < out.length) {
+            if (!this.queue.length) {
+              out.fill(0, i);
+              break;
+            }
+            const cur = this.queue[0];
+            const avail = cur.length - this.offset;
+            const need = out.length - i;
+            const take = Math.min(avail, need);
+            out.set(cur.subarray(this.offset, this.offset + take), i);
+            i += take;
+            this.offset += take;
+            if (this.offset >= cur.length) {
+              this.queue.shift();
+              this.offset = 0;
+            }
+          }
+          return true;
+        }
+      }
+      registerProcessor('ywc-playback', YwcPlaybackProcessor);
+    `;
+    const blob = new Blob([processorCode], { type: 'application/javascript' });
+    const url = URL.createObjectURL(blob);
+    await this._ctx.audioWorklet.addModule(url);
+    URL.revokeObjectURL(url);
+
+    this._worklet = new AudioWorkletNode(this._ctx, 'ywc-playback');
+    this._worklet.connect(this._ctx.destination);
+    if (this._ctx.state === 'suspended') await this._ctx.resume();
+  }
+
+  async _startOpusDecoder() {
+    this._decoder = new AudioDecoder({
+      output: (audioData) => {
+        const planes = audioData.numberOfChannels;
+        const frames = audioData.numberOfFrames;
+        const buf = new Float32Array(frames);
+        // copyTo planar channel 0
+        audioData.copyTo(buf, { planeIndex: 0 });
+        audioData.close();
+        this._enqueue(buf);
+      },
+      error: (e) => console.warn('AudioDecoder error', e)
+    });
+    this._decoder.configure({
+      codec: 'opus',
+      sampleRate: SAMPLE_RATE,
+      numberOfChannels: 1
+    });
+  }
+
+  handlePacket(type, payload) {
+    if (this._muted) return;
+
+    if (type === MSG_PCM_RX) {
+      this._enqueue(pcm16ToFloat(payload));
+      return;
+    }
+
+    if (type === MSG_OPUS_RX) {
+      if (this._decoder) {
+        const chunk = new EncodedAudioChunk({
+          type: 'key',
+          timestamp: performance.now() * 1000,
+          data: payload
+        });
+        try { this._decoder.decode(chunk); }
+        catch (e) { console.warn('decode failed', e); }
+      }
+    }
+  }
+
+  _enqueue(float32) {
+    if (!this._worklet) return;
+    // Cap queue to limit latency
+    this._queue.push(float32);
+    while (this._queue.length > this._maxQueue) this._queue.shift();
+    const frame = this._queue.shift();
+    if (frame) this._worklet.port.postMessage(frame, [frame.buffer]);
+  }
+
+  async stop() {
+    try { this._decoder?.close(); } catch { /* ignore */ }
+    this._decoder = null;
+    try { this._worklet?.disconnect(); } catch { /* ignore */ }
+    try { await this._ctx?.close(); } catch { /* ignore */ }
+    this._ctx = null;
+    this._worklet = null;
+    this._queue = [];
+  }
+}

--- a/wwwroot/js/audio/audio-playback.js
+++ b/wwwroot/js/audio/audio-playback.js
@@ -4,7 +4,8 @@ import {
 } from './audio-protocol.js';
 
 /**
- * Jitter-buffered playback of RX Opus or PCM16 frames.
+ * Low-latency playback of RX Opus or PCM16 frames.
+ * Worklet queue is hard-capped (~30 ms) so bursts cannot accumulate delay.
  */
 export class AudioPlayback {
   constructor() {
@@ -13,8 +14,8 @@ export class AudioPlayback {
     this._decoder = null;
     this._codec = 'pcm16';
     this._muted = false;
-    this._queue = []; // Float32Array frames
-    this._maxQueue = 8; // ~160 ms
+    /** Max queued frames in the worklet (~3 × 10 ms). */
+    this._maxQueueFrames = 3;
   }
 
   get muted() { return this._muted; }
@@ -22,7 +23,11 @@ export class AudioPlayback {
 
   async start(codec) {
     this._codec = codec || 'pcm16';
-    this._ctx = new AudioContext({ sampleRate: SAMPLE_RATE });
+    // Prefer low output latency when the browser supports it.
+    this._ctx = new AudioContext({
+      sampleRate: SAMPLE_RATE,
+      latencyHint: 'interactive'
+    });
 
     if (this._codec === 'opus' && supportsWebCodecsOpus()) {
       try {
@@ -33,14 +38,21 @@ export class AudioPlayback {
       }
     }
 
+    const maxFrames = this._maxQueueFrames;
     const processorCode = `
       class YwcPlaybackProcessor extends AudioWorkletProcessor {
         constructor() {
           super();
           this.queue = [];
           this.offset = 0;
+          this.maxFrames = ${maxFrames};
           this.port.onmessage = (ev) => {
-            if (ev.data && ev.data.length) this.queue.push(ev.data);
+            if (!ev.data || !ev.data.length) return;
+            this.queue.push(ev.data);
+            while (this.queue.length > this.maxFrames) {
+              this.queue.shift();
+              this.offset = 0;
+            }
           };
         }
         process(inputs, outputs) {
@@ -82,10 +94,8 @@ export class AudioPlayback {
   async _startOpusDecoder() {
     this._decoder = new AudioDecoder({
       output: (audioData) => {
-        const planes = audioData.numberOfChannels;
         const frames = audioData.numberOfFrames;
         const buf = new Float32Array(frames);
-        // copyTo planar channel 0
         audioData.copyTo(buf, { planeIndex: 0 });
         audioData.close();
         this._enqueue(buf);
@@ -107,26 +117,21 @@ export class AudioPlayback {
       return;
     }
 
-    if (type === MSG_OPUS_RX) {
-      if (this._decoder) {
-        const chunk = new EncodedAudioChunk({
-          type: 'key',
-          timestamp: performance.now() * 1000,
-          data: payload
-        });
-        try { this._decoder.decode(chunk); }
-        catch (e) { console.warn('decode failed', e); }
-      }
+    if (type === MSG_OPUS_RX && this._decoder) {
+      const chunk = new EncodedAudioChunk({
+        type: 'key',
+        timestamp: performance.now() * 1000,
+        data: payload
+      });
+      try { this._decoder.decode(chunk); }
+      catch (e) { console.warn('decode failed', e); }
     }
   }
 
   _enqueue(float32) {
     if (!this._worklet) return;
-    // Cap queue to limit latency
-    this._queue.push(float32);
-    while (this._queue.length > this._maxQueue) this._queue.shift();
-    const frame = this._queue.shift();
-    if (frame) this._worklet.port.postMessage(frame, [frame.buffer]);
+    // Transfer ownership to the worklet (zero-copy).
+    this._worklet.port.postMessage(float32, [float32.buffer]);
   }
 
   async stop() {
@@ -136,6 +141,5 @@ export class AudioPlayback {
     try { await this._ctx?.close(); } catch { /* ignore */ }
     this._ctx = null;
     this._worklet = null;
-    this._queue = [];
   }
 }

--- a/wwwroot/js/audio/audio-playback.js
+++ b/wwwroot/js/audio/audio-playback.js
@@ -11,6 +11,8 @@ export class AudioPlayback {
   constructor() {
     this._ctx = null;
     this._worklet = null;
+    this._analyser = null;
+    this._freqBuf = null;
     this._decoder = null;
     this._codec = 'pcm16';
     this._muted = false;
@@ -20,6 +22,21 @@ export class AudioPlayback {
 
   get muted() { return this._muted; }
   set muted(v) { this._muted = !!v; }
+
+  /**
+   * Live FFT magnitude bins for the filter-scope display, or null when
+   * muted / not started (caller should fall back to decorative bars).
+   * @returns {{ data: Uint8Array, sampleRate: number, fftSize: number } | null}
+   */
+  getSpectrum() {
+    if (!this._analyser || !this._freqBuf || this._muted) return null;
+    this._analyser.getByteFrequencyData(this._freqBuf);
+    return {
+      data: this._freqBuf,
+      sampleRate: this._ctx.sampleRate,
+      fftSize: this._analyser.fftSize
+    };
+  }
 
   async start(codec) {
     this._codec = codec || 'pcm16';
@@ -87,7 +104,15 @@ export class AudioPlayback {
     URL.revokeObjectURL(url);
 
     this._worklet = new AudioWorkletNode(this._ctx, 'ywc-playback');
-    this._worklet.connect(this._ctx.destination);
+    // Analyser sits on the playback path so filter-scope can show real RX spectrum.
+    this._analyser = this._ctx.createAnalyser();
+    this._analyser.fftSize = 512;
+    this._analyser.smoothingTimeConstant = 0.7;
+    this._analyser.minDecibels = -90;
+    this._analyser.maxDecibels = -20;
+    this._freqBuf = new Uint8Array(this._analyser.frequencyBinCount);
+    this._worklet.connect(this._analyser);
+    this._analyser.connect(this._ctx.destination);
     if (this._ctx.state === 'suspended') await this._ctx.resume();
   }
 
@@ -138,8 +163,11 @@ export class AudioPlayback {
     try { this._decoder?.close(); } catch { /* ignore */ }
     this._decoder = null;
     try { this._worklet?.disconnect(); } catch { /* ignore */ }
+    try { this._analyser?.disconnect(); } catch { /* ignore */ }
     try { await this._ctx?.close(); } catch { /* ignore */ }
     this._ctx = null;
     this._worklet = null;
+    this._analyser = null;
+    this._freqBuf = null;
   }
 }

--- a/wwwroot/js/audio/audio-protocol.js
+++ b/wwwroot/js/audio/audio-protocol.js
@@ -1,6 +1,7 @@
 /** Shared wire constants — keep in sync with Services/Audio/AudioConstants.cs */
 export const SAMPLE_RATE = 48000;
-export const FRAME_SAMPLES = 960;
+/** 10 ms frames — lower packetization delay than 20 ms. */
+export const FRAME_SAMPLES = 480;
 export const MSG_OPUS_RX = 0x01;
 export const MSG_OPUS_TX = 0x02;
 export const MSG_PCM_RX = 0x03;

--- a/wwwroot/js/audio/audio-protocol.js
+++ b/wwwroot/js/audio/audio-protocol.js
@@ -2,6 +2,8 @@
 export const SAMPLE_RATE = 48000;
 /** 10 ms frames — lower packetization delay than 20 ms. */
 export const FRAME_SAMPLES = 480;
+/** Match host Opus encode; WebCodecs defaults to 20000 if omitted. */
+export const OPUS_FRAME_DURATION_US = 10000;
 export const MSG_OPUS_RX = 0x01;
 export const MSG_OPUS_TX = 0x02;
 export const MSG_PCM_RX = 0x03;
@@ -48,4 +50,18 @@ export function pcm16ToFloat(bytes) {
 
 export function supportsWebCodecsOpus() {
   return typeof AudioEncoder !== 'undefined' && typeof AudioDecoder !== 'undefined';
+}
+
+/** Codecs this browser can offer, preferred first (Opus when WebCodecs is available). */
+export function buildCodecOfferList(preferred = 'opus') {
+  const available = [];
+  if (supportsWebCodecsOpus()) available.push('opus');
+  available.push('pcm16');
+  const want = preferred === 'pcm16' ? 'pcm16' : 'opus';
+  const ordered = [];
+  if (available.includes(want)) ordered.push(want);
+  for (const c of available) {
+    if (!ordered.includes(c)) ordered.push(c);
+  }
+  return ordered;
 }

--- a/wwwroot/js/audio/audio-protocol.js
+++ b/wwwroot/js/audio/audio-protocol.js
@@ -1,0 +1,50 @@
+/** Shared wire constants — keep in sync with Services/Audio/AudioConstants.cs */
+export const SAMPLE_RATE = 48000;
+export const FRAME_SAMPLES = 960;
+export const MSG_OPUS_RX = 0x01;
+export const MSG_OPUS_TX = 0x02;
+export const MSG_PCM_RX = 0x03;
+export const MSG_PCM_TX = 0x04;
+export const MSG_CONTROL = 0x10;
+
+export function frameMessage(type, seq, payload) {
+  const bodyLen = 1 + 4 + payload.byteLength;
+  const buf = new ArrayBuffer(4 + bodyLen);
+  const view = new DataView(buf);
+  view.setUint32(0, bodyLen, false);
+  view.setUint8(4, type);
+  view.setUint32(5, seq, false);
+  new Uint8Array(buf, 9).set(new Uint8Array(payload));
+  return buf;
+}
+
+export function parseBody(body) {
+  if (body.byteLength < 5) return null;
+  const view = new DataView(body.buffer, body.byteOffset, body.byteLength);
+  const type = view.getUint8(0);
+  const seq = view.getUint32(1, false);
+  const payload = body.subarray(5);
+  return { type, seq, payload };
+}
+
+export function floatToPcm16(float32) {
+  const out = new ArrayBuffer(float32.length * 2);
+  const view = new DataView(out);
+  for (let i = 0; i < float32.length; i++) {
+    const s = Math.max(-1, Math.min(1, float32[i]));
+    view.setInt16(i * 2, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+  }
+  return out;
+}
+
+export function pcm16ToFloat(bytes) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const n = (bytes.byteLength / 2) | 0;
+  const out = new Float32Array(n);
+  for (let i = 0; i < n; i++) out[i] = view.getInt16(i * 2, true) / 32768;
+  return out;
+}
+
+export function supportsWebCodecsOpus() {
+  return typeof AudioEncoder !== 'undefined' && typeof AudioDecoder !== 'undefined';
+}

--- a/wwwroot/js/audio/audio-session.js
+++ b/wwwroot/js/audio/audio-session.js
@@ -1,0 +1,157 @@
+import {
+  MSG_CONTROL, MSG_OPUS_RX, MSG_PCM_RX,
+  frameMessage, parseBody, supportsWebCodecsOpus
+} from './audio-protocol.js';
+import { AudioCapture } from './audio-capture.js';
+import { AudioPlayback } from './audio-playback.js';
+
+/**
+ * Owns the /audio WebSocket session and wires capture ↔ playback.
+ */
+export class AudioSession {
+  constructor({ onStatus, onLevels, onError } = {}) {
+    this._onStatus = onStatus || (() => {});
+    this._onLevels = onLevels || (() => {});
+    this._onError = onError || (() => {});
+    this._ws = null;
+    this._capture = null;
+    this._playback = null;
+    this._running = false;
+    this._codec = 'pcm16';
+  }
+
+  get running() { return this._running; }
+
+  async start() {
+    if (this._running) return;
+    if (!window.isSecureContext && location.hostname !== 'localhost' && location.hostname !== '127.0.0.1') {
+      throw new Error('Microphone requires HTTPS (or localhost). Enable HTTPS in Settings → Web / HTTP, restart, and open the HTTPS URL.');
+    }
+
+    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const url = `${proto}//${location.host}/audio`;
+    this._ws = new WebSocket(url);
+    this._ws.binaryType = 'arraybuffer';
+
+    await new Promise((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('WebSocket connect timeout')), 10000);
+      this._ws.onopen = () => { clearTimeout(t); resolve(); };
+      this._ws.onerror = () => { clearTimeout(t); reject(new Error('WebSocket failed to connect')); };
+    });
+
+    const codecs = ['pcm16'];
+    if (supportsWebCodecsOpus()) codecs.unshift('opus');
+
+    this._ws.send(frameMessage(MSG_CONTROL, 0, new TextEncoder().encode(JSON.stringify({
+      cmd: 'hello',
+      codecs
+    }))));
+
+    const ready = await this._waitReady();
+    this._codec = ready.codec || 'pcm16';
+
+    this._playback = new AudioPlayback();
+    await this._playback.start(this._codec);
+
+    this._capture = new AudioCapture({
+      codec: this._codec,
+      onFrame: (buf) => {
+        if (this._ws && this._ws.readyState === WebSocket.OPEN)
+          this._ws.send(buf);
+      }
+    });
+    await this._capture.start();
+
+    this._ws.onmessage = (ev) => this._onMessage(ev.data);
+    this._ws.onclose = () => {
+      this._running = false;
+      this._onStatus('disconnected');
+      this.stop();
+    };
+
+    this._running = true;
+    this._onStatus('streaming', this._codec);
+  }
+
+  _waitReady() {
+    return new Promise((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('No ready from server')), 15000);
+      this._ws.onmessage = (ev) => {
+        const bytes = new Uint8Array(ev.data);
+        if (bytes.byteLength < 4) return;
+        const bodyLen = new DataView(bytes.buffer).getUint32(0, false);
+        const body = bytes.subarray(4, 4 + bodyLen);
+        const msg = parseBody(body);
+        if (!msg || msg.type !== MSG_CONTROL) return;
+        try {
+          const obj = JSON.parse(new TextDecoder().decode(msg.payload));
+          if (obj.cmd === 'busy') {
+            clearTimeout(t);
+            reject(new Error(obj.message || 'Audio session busy'));
+            return;
+          }
+          if (obj.cmd === 'error') {
+            clearTimeout(t);
+            reject(new Error(obj.message || 'Audio error'));
+            return;
+          }
+          if (obj.cmd === 'ready') {
+            clearTimeout(t);
+            // Switch to normal handler after ready
+            this._ws.onmessage = (e) => this._onMessage(e.data);
+            resolve(obj);
+          }
+        } catch (e) {
+          clearTimeout(t);
+          reject(e);
+        }
+      };
+    });
+  }
+
+  _onMessage(data) {
+    const bytes = new Uint8Array(data);
+    if (bytes.byteLength < 4) return;
+    const bodyLen = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(0, false);
+    const body = bytes.subarray(4, 4 + bodyLen);
+    const msg = parseBody(body);
+    if (!msg) return;
+
+    if (msg.type === MSG_CONTROL) {
+      try {
+        const obj = JSON.parse(new TextDecoder().decode(msg.payload));
+        if (obj.cmd === 'levels') this._onLevels(obj.rx || 0, obj.tx || 0);
+        if (obj.cmd === 'error') this._onError(obj.message || 'Audio error');
+      } catch { /* ignore */ }
+      return;
+    }
+
+    if (msg.type === MSG_OPUS_RX || msg.type === MSG_PCM_RX)
+      this._playback?.handlePacket(msg.type, msg.payload);
+  }
+
+  setMicMuted(muted) {
+    if (this._capture) this._capture.muted = muted;
+  }
+
+  setRxMuted(muted) {
+    if (this._playback) this._playback.muted = muted;
+  }
+
+  async stop() {
+    this._running = false;
+    try { await this._capture?.stop(); } catch { /* ignore */ }
+    try { await this._playback?.stop(); } catch { /* ignore */ }
+    this._capture = null;
+    this._playback = null;
+    if (this._ws) {
+      try { this._ws.close(); } catch { /* ignore */ }
+      this._ws = null;
+    }
+    this._onStatus('stopped');
+  }
+}
+
+export function createAudioSession(handlers) {
+  return new AudioSession(handlers);
+}

--- a/wwwroot/js/audio/audio-session.js
+++ b/wwwroot/js/audio/audio-session.js
@@ -1,6 +1,6 @@
 import {
   MSG_CONTROL, MSG_OPUS_RX, MSG_PCM_RX,
-  frameMessage, parseBody, supportsWebCodecsOpus
+  frameMessage, parseBody, buildCodecOfferList
 } from './audio-protocol.js';
 import { AudioCapture } from './audio-capture.js';
 import { AudioPlayback } from './audio-playback.js';
@@ -23,7 +23,7 @@ export class AudioSession {
   get running() { return this._running; }
 
   /**
-   * @param {{ deviceId?: string }} [opts]
+   * @param {{ deviceId?: string, preferredCodec?: 'opus'|'pcm16' }} [opts]
    */
   async start(opts = {}) {
     if (this._running) return;
@@ -42,8 +42,7 @@ export class AudioSession {
       this._ws.onerror = () => { clearTimeout(t); reject(new Error('WebSocket failed to connect')); };
     });
 
-    const codecs = ['pcm16'];
-    if (supportsWebCodecsOpus()) codecs.unshift('opus');
+    const codecs = buildCodecOfferList(opts.preferredCodec || 'opus');
 
     this._ws.send(frameMessage(MSG_CONTROL, 0, new TextEncoder().encode(JSON.stringify({
       cmd: 'hello',

--- a/wwwroot/js/audio/audio-session.js
+++ b/wwwroot/js/audio/audio-session.js
@@ -22,7 +22,10 @@ export class AudioSession {
 
   get running() { return this._running; }
 
-  async start() {
+  /**
+   * @param {{ deviceId?: string }} [opts]
+   */
+  async start(opts = {}) {
     if (this._running) return;
     if (!window.isSecureContext && location.hostname !== 'localhost' && location.hostname !== '127.0.0.1') {
       throw new Error('Microphone requires HTTPS (or localhost). Enable HTTPS in Settings → Web / HTTP, restart, and open the HTTPS URL.');
@@ -60,7 +63,7 @@ export class AudioSession {
           this._ws.send(buf);
       }
     });
-    await this._capture.start();
+    await this._capture.start({ deviceId: opts.deviceId || '' });
 
     this._ws.onmessage = (ev) => this._onMessage(ev.data);
     this._ws.onclose = () => {

--- a/wwwroot/js/audio/audio-session.js
+++ b/wwwroot/js/audio/audio-session.js
@@ -138,6 +138,11 @@ export class AudioSession {
     if (this._playback) this._playback.muted = muted;
   }
 
+  /** Live RX FFT for filter-scope, or null when not streaming / muted. */
+  getSpectrum() {
+    return this._playback?.getSpectrum() ?? null;
+  }
+
   async stop() {
     this._running = false;
     try { await this._capture?.stop(); } catch { /* ignore */ }

--- a/wwwroot/js/audio/audio-session.js
+++ b/wwwroot/js/audio/audio-session.js
@@ -141,6 +141,15 @@ export class AudioSession {
     if (this._playback) this._playback.muted = muted;
   }
 
+  /** Live software gain on the host bridge (0.05–4). */
+  setGain({ rx, tx } = {}) {
+    if (!this._ws || this._ws.readyState !== WebSocket.OPEN) return;
+    const body = { cmd: 'setGain' };
+    if (typeof rx === 'number') body.rx = rx;
+    if (typeof tx === 'number') body.tx = tx;
+    this._ws.send(frameMessage(MSG_CONTROL, 0, new TextEncoder().encode(JSON.stringify(body))));
+  }
+
   /** Live RX FFT for filter-scope, or null when not streaming / muted. */
   getSpectrum() {
     return this._playback?.getSpectrum() ?? null;

--- a/wwwroot/js/audio/remote-audio-ui.js
+++ b/wwwroot/js/audio/remote-audio-ui.js
@@ -4,7 +4,7 @@ const CHANNEL_NAME = 'ywc-remote-audio';
 const POPOUT_STORAGE_KEY = 'ywc.remoteAudio.popout';
 const MIC_STORAGE_KEY = 'ywc.remoteAudio.browserMic';
 const POPOUT_WINDOW_NAME = 'ywc-remote-audio';
-const POPOUT_FEATURES = 'width=560,height=280,resizable=yes,scrollbars=no';
+const POPOUT_FEATURES = 'width=780,height=320,resizable=yes,scrollbars=no';
 const SPECTRUM_HZ = 15;
 const HEARTBEAT_MS = 2000;
 const HEARTBEAT_STALE_MS = 6000;
@@ -148,6 +148,12 @@ function bindRemoteAudioControls(role) {
   const rxMeter = document.getElementById('remoteAudioRxMeter');
   const txMeter = document.getElementById('remoteAudioTxMeter');
   const micSelect = document.getElementById('remoteAudioMicSelect');
+  const rxGainSlider = document.getElementById('remoteAudioRxGain');
+  const txGainSlider = document.getElementById('remoteAudioTxGain');
+  const rxGainVal = document.getElementById('remoteAudioRxGainVal');
+  const txGainVal = document.getElementById('remoteAudioTxGainVal');
+  const levelsBtn = document.getElementById('remoteAudioLevelsBtn');
+  const levelsDialog = document.getElementById('remoteAudioLevelsDialog');
 
   const channel = openChannel();
   let session = null;
@@ -159,9 +165,80 @@ function bindRemoteAudioControls(role) {
   let lastHeartbeat = remoteOwned ? Date.now() : 0;
   let streamStatus = 'idle';
   let streamCodec = null;
+  let gainSaveTimer = null;
+  let applyingRemoteGain = false;
 
   function selectedMicId() {
     return (micSelect?.value || getSavedMicId() || '').trim();
+  }
+
+  function clampGain(v) {
+    const n = Number(v);
+    if (!Number.isFinite(n)) return 1;
+    return Math.min(4, Math.max(0.05, n));
+  }
+
+  function formatGain(v) {
+    return clampGain(v).toFixed(2);
+  }
+
+  function readGainUi() {
+    return {
+      rx: clampGain(rxGainSlider?.value ?? 1),
+      tx: clampGain(txGainSlider?.value ?? 1)
+    };
+  }
+
+  function setGainUi(rx, tx, { silent } = {}) {
+    applyingRemoteGain = true;
+    try {
+      if (typeof rx === 'number' && rxGainSlider) {
+        rxGainSlider.value = String(clampGain(rx));
+        if (rxGainVal) rxGainVal.textContent = formatGain(rx);
+      }
+      if (typeof tx === 'number' && txGainSlider) {
+        txGainSlider.value = String(clampGain(tx));
+        if (txGainVal) txGainVal.textContent = formatGain(tx);
+      }
+    } finally {
+      applyingRemoteGain = false;
+    }
+    if (!silent) {
+      // no-op — callers decide whether to persist/broadcast
+    }
+  }
+
+  function applyGainLive(rx, tx) {
+    if (role === 'index' && remoteOwned && streamStatus === 'streaming') {
+      post({ type: 'setGain', rx, tx });
+      return;
+    }
+    session?.setGain({ rx, tx });
+  }
+
+  function persistGain(rx, tx) {
+    clearTimeout(gainSaveTimer);
+    gainSaveTimer = setTimeout(async () => {
+      try {
+        await fetch('/api/audio/gain', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ rx, tx })
+        });
+      } catch (e) {
+        console.warn('Failed to save audio gain', e);
+      }
+    }, 400);
+  }
+
+  function onGainInput() {
+    if (applyingRemoteGain) return;
+    const { rx, tx } = readGainUi();
+    if (rxGainVal) rxGainVal.textContent = formatGain(rx);
+    if (txGainVal) txGainVal.textContent = formatGain(tx);
+    applyGainLive(rx, tx);
+    persistGain(rx, tx);
+    post({ type: 'gain', rx, tx });
   }
 
   async function refreshMicList() {
@@ -448,6 +525,10 @@ function bindRemoteAudioControls(role) {
           if (typeof msg.rx === 'boolean') setRxMuteUi(rxMute, rxMuteIcon, rxMuteTip, msg.rx);
           return;
         }
+        if (msg.type === 'gain') {
+          setGainUi(msg.rx, msg.tx);
+          return;
+        }
         if (msg.type === 'spectrum') {
           if (!msg.data) {
             latestSpectrum = null;
@@ -475,6 +556,15 @@ function bindRemoteAudioControls(role) {
         }
         return;
       }
+      if (msg.type === 'setGain') {
+        setGainUi(msg.rx, msg.tx);
+        session?.setGain({ rx: msg.rx, tx: msg.tx });
+        return;
+      }
+      if (msg.type === 'gain') {
+        setGainUi(msg.rx, msg.tx);
+        return;
+      }
       if (msg.type === 'stop') {
         stopLocal();
         return;
@@ -486,6 +576,8 @@ function bindRemoteAudioControls(role) {
           mic: isTogglePressed(micMute),
           rx: isTogglePressed(rxMute)
         });
+        const g = readGainUi();
+        post({ type: 'gain', rx: g.rx, tx: g.tx });
       }
     };
   }
@@ -525,6 +617,15 @@ function bindRemoteAudioControls(role) {
 
   micSelect?.addEventListener('change', () => {
     saveMicId(micSelect.value || '');
+  });
+
+  rxGainSlider?.addEventListener('input', onGainInput);
+  txGainSlider?.addEventListener('input', onGainInput);
+
+  levelsBtn?.addEventListener('click', () => {
+    if (!levelsDialog) return;
+    if (typeof levelsDialog.show === 'function') levelsDialog.show();
+    else levelsDialog.setAttribute('open', '');
   });
 
   popoutBtn?.addEventListener('click', async () => {
@@ -608,10 +709,14 @@ export async function initRemoteAudioUi() {
   if (!bar) return;
 
   let enabled = false;
+  let rxGain = 1;
+  let txGain = 1;
   try {
     const res = await fetch('/api/audio/status');
     const data = await res.json();
     enabled = !!data.enabled;
+    if (typeof data.rxGain === 'number') rxGain = data.rxGain;
+    if (typeof data.txGain === 'number') txGain = data.txGain;
   } catch {
     enabled = false;
   }
@@ -623,6 +728,14 @@ export async function initRemoteAudioUi() {
 
   bar.style.display = '';
   bindRemoteAudioControls('index');
+  const rx = document.getElementById('remoteAudioRxGain');
+  const tx = document.getElementById('remoteAudioTxGain');
+  const rxV = document.getElementById('remoteAudioRxGainVal');
+  const txV = document.getElementById('remoteAudioTxGainVal');
+  if (rx) rx.value = String(rxGain);
+  if (tx) tx.value = String(txGain);
+  if (rxV) rxV.textContent = Number(rxGain).toFixed(2);
+  if (txV) txV.textContent = Number(txGain).toFixed(2);
 }
 
 /**
@@ -633,10 +746,14 @@ export async function initRemoteAudioPopout() {
   if (!bar) return;
 
   let enabled = false;
+  let rxGain = 1;
+  let txGain = 1;
   try {
     const res = await fetch('/api/audio/status');
     const data = await res.json();
     enabled = !!data.enabled;
+    if (typeof data.rxGain === 'number') rxGain = data.rxGain;
+    if (typeof data.txGain === 'number') txGain = data.txGain;
   } catch {
     enabled = false;
   }
@@ -650,4 +767,12 @@ export async function initRemoteAudioPopout() {
   }
 
   bindRemoteAudioControls('popout');
+  const rx = document.getElementById('remoteAudioRxGain');
+  const tx = document.getElementById('remoteAudioTxGain');
+  const rxV = document.getElementById('remoteAudioRxGainVal');
+  const txV = document.getElementById('remoteAudioTxGainVal');
+  if (rx) rx.value = String(rxGain);
+  if (tx) tx.value = String(txGain);
+  if (rxV) rxV.textContent = Number(rxGain).toFixed(2);
+  if (txV) txV.textContent = Number(txGain).toFixed(2);
 }

--- a/wwwroot/js/audio/remote-audio-ui.js
+++ b/wwwroot/js/audio/remote-audio-ui.js
@@ -1,10 +1,12 @@
 import { createAudioSession } from './audio-session.js';
+import { supportsWebCodecsOpus } from './audio-protocol.js';
 
 const CHANNEL_NAME = 'ywc-remote-audio';
 const POPOUT_STORAGE_KEY = 'ywc.remoteAudio.popout';
 const MIC_STORAGE_KEY = 'ywc.remoteAudio.browserMic';
+const CODEC_STORAGE_KEY = 'ywc.remoteAudio.codec';
 const POPOUT_WINDOW_NAME = 'ywc-remote-audio';
-const POPOUT_FEATURES = 'width=780,height=320,resizable=yes,scrollbars=no';
+const POPOUT_FEATURES = 'width=780,height=380,resizable=yes,scrollbars=no';
 const SPECTRUM_HZ = 15;
 const HEARTBEAT_MS = 2000;
 const HEARTBEAT_STALE_MS = 6000;
@@ -123,6 +125,26 @@ function saveMicId(id) {
   } catch { /* ignore */ }
 }
 
+function getSavedCodec() {
+  try {
+    const v = localStorage.getItem(CODEC_STORAGE_KEY);
+    if (v === 'pcm16' || v === 'opus') return v;
+  } catch { /* ignore */ }
+  return 'opus';
+}
+
+function saveCodec(codec) {
+  try {
+    localStorage.setItem(CODEC_STORAGE_KEY, codec === 'pcm16' ? 'pcm16' : 'opus');
+  } catch { /* ignore */ }
+}
+
+function preferredCodecForSession() {
+  const saved = getSavedCodec();
+  if (saved === 'opus' && !supportsWebCodecsOpus()) return 'pcm16';
+  return saved;
+}
+
 function openPopoutWindow(autostart) {
   const q = autostart ? '?autostart=1' : '';
   return window.open(`/RemoteAudio${q}`, POPOUT_WINDOW_NAME, POPOUT_FEATURES);
@@ -148,6 +170,8 @@ function bindRemoteAudioControls(role) {
   const rxMeter = document.getElementById('remoteAudioRxMeter');
   const txMeter = document.getElementById('remoteAudioTxMeter');
   const micSelect = document.getElementById('remoteAudioMicSelect');
+  const codecSelect = document.getElementById('remoteAudioCodecSelect');
+  const codecHint = document.getElementById('remoteAudioCodecHint');
   const rxGainSlider = document.getElementById('remoteAudioRxGain');
   const txGainSlider = document.getElementById('remoteAudioTxGain');
   const rxGainVal = document.getElementById('remoteAudioRxGainVal');
@@ -167,9 +191,34 @@ function bindRemoteAudioControls(role) {
   let streamCodec = null;
   let gainSaveTimer = null;
   let applyingRemoteGain = false;
+  let applyingRemoteCodec = false;
 
   function selectedMicId() {
     return (micSelect?.value || getSavedMicId() || '').trim();
+  }
+
+  function initCodecSelect() {
+    if (!codecSelect) return;
+    const opusOk = supportsWebCodecsOpus();
+    const opusOpt = [...codecSelect.options].find(o => o.value === 'opus');
+    if (opusOpt) {
+      opusOpt.disabled = !opusOk;
+      opusOpt.textContent = opusOk
+        ? 'Opus (~32 kb/s) — recommended'
+        : 'Opus — not supported in this browser';
+    }
+    const saved = getSavedCodec();
+    codecSelect.value = (saved === 'opus' && !opusOk) ? 'pcm16' : saved;
+    if (codecHint) {
+      codecHint.textContent = opusOk
+        ? 'Opus uses far less bandwidth than PCM16. Takes effect on the next Start.'
+        : 'This browser cannot encode Opus (WebCodecs); PCM16 will be used.';
+    }
+  }
+
+  function selectedCodec() {
+    if (codecSelect?.value === 'pcm16') return 'pcm16';
+    return preferredCodecForSession();
   }
 
   function clampGain(v) {
@@ -290,6 +339,7 @@ function bindRemoteAudioControls(role) {
     if (rxMute) rxMute.disabled = !streaming;
     // Index locks the mic picker only while the popout is actively streaming.
     if (micSelect) micSelect.disabled = role === 'index' && remoteOwned && streaming;
+    if (codecSelect) codecSelect.disabled = streaming;
     if (!streaming) {
       setMicMuteUi(micMute, micMuteIcon, micMuteTip, false);
       setRxMuteUi(rxMute, rxMuteIcon, rxMuteTip, false);
@@ -402,7 +452,10 @@ function bindRemoteAudioControls(role) {
   async function startLocal() {
     try {
       setStatusText('Connecting…');
-      await ensureSession().start({ deviceId: selectedMicId() });
+      await ensureSession().start({
+        deviceId: selectedMicId(),
+        preferredCodec: selectedCodec()
+      });
       await refreshMicList(); // labels appear after permission grant
     } catch (e) {
       const msg = e.message || String(e);
@@ -565,6 +618,19 @@ function bindRemoteAudioControls(role) {
         setGainUi(msg.rx, msg.tx);
         return;
       }
+      if (msg.type === 'codecPref') {
+        if (!codecSelect || streamStatus === 'streaming') return;
+        applyingRemoteCodec = true;
+        try {
+          const next = msg.codec === 'pcm16' ? 'pcm16' : 'opus';
+          if (next === 'opus' && !supportsWebCodecsOpus()) return;
+          codecSelect.value = next;
+          saveCodec(next);
+        } finally {
+          applyingRemoteCodec = false;
+        }
+        return;
+      }
       if (msg.type === 'stop') {
         stopLocal();
         return;
@@ -578,6 +644,7 @@ function bindRemoteAudioControls(role) {
         });
         const g = readGainUi();
         post({ type: 'gain', rx: g.rx, tx: g.tx });
+        post({ type: 'codecPref', codec: selectedCodec() });
       }
     };
   }
@@ -617,6 +684,17 @@ function bindRemoteAudioControls(role) {
 
   micSelect?.addEventListener('change', () => {
     saveMicId(micSelect.value || '');
+  });
+
+  codecSelect?.addEventListener('change', () => {
+    if (applyingRemoteCodec) return;
+    const next = codecSelect.value === 'pcm16' ? 'pcm16' : 'opus';
+    if (next === 'opus' && !supportsWebCodecsOpus()) {
+      codecSelect.value = 'pcm16';
+      return;
+    }
+    saveCodec(next);
+    post({ type: 'codecPref', codec: next });
   });
 
   rxGainSlider?.addEventListener('input', onGainInput);
@@ -693,6 +771,7 @@ function bindRemoteAudioControls(role) {
   if (stopBtn) stopBtn.disabled = true;
   setMicMuteUi(micMute, micMuteIcon, micMuteTip, false);
   setRxMuteUi(rxMute, rxMuteIcon, rxMuteTip, false);
+  initCodecSelect();
   updateLocalButtons();
   ensureRemoteAudioTooltips();
   refreshMicList();

--- a/wwwroot/js/audio/remote-audio-ui.js
+++ b/wwwroot/js/audio/remote-audio-ui.js
@@ -22,6 +22,9 @@ const TIP_MIC_ON = 'Mute microphone';
 const TIP_MIC_OFF = 'Unmute microphone';
 const TIP_RX_ON = 'Deafen — mute received audio';
 const TIP_RX_OFF = 'Undeafen — hear received audio';
+const TIP_TX_OFF = 'Toggle transmit (PTT)';
+const TIP_TX_ON = 'Click to stop transmitting';
+const TX_POLL_MS = 1500;
 
 function isTogglePressed(el) {
   return el?.getAttribute('aria-pressed') === 'true';
@@ -45,6 +48,20 @@ function setRxMuteUi(btn, icon, tipWrap, muted) {
   btn.classList.add(muted ? 'btn-warning' : 'btn-success');
   if (icon) icon.className = `bi ${muted ? 'bi-volume-mute-fill' : 'bi-headphones'} remote-audio-btn-icon`;
   const tip = muted ? TIP_RX_OFF : TIP_RX_ON;
+  btn.setAttribute('aria-label', tip);
+  setTipText(tipWrap, tip);
+}
+
+function setTxButtonUi(btn, tipWrap, transmitting) {
+  if (!btn) return;
+  const on = !!transmitting;
+  btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+  btn.classList.remove('btn-warning', 'btn-danger');
+  btn.classList.add(on ? 'btn-danger' : 'btn-warning');
+  btn.innerHTML = on
+    ? '<i class="bi bi-broadcast" aria-hidden="true"></i> TX ON'
+    : '<i class="bi bi-broadcast" aria-hidden="true"></i> TX';
+  const tip = on ? TIP_TX_ON : TIP_TX_OFF;
   btn.setAttribute('aria-label', tip);
   setTipText(tipWrap, tip);
 }
@@ -166,6 +183,9 @@ function bindRemoteAudioControls(role) {
   const rxMuteIcon = rxMute?.querySelector('i');
   const micMuteTip = document.getElementById('remoteAudioMicMuteTip');
   const rxMuteTip = document.getElementById('remoteAudioRxMuteTip');
+  const txBtn = document.getElementById('remoteAudioTxBtn');
+  const txTip = document.getElementById('remoteAudioTxTip');
+  const txVfoBadge = document.getElementById('remoteAudioTxVfo');
   const statusEl = document.getElementById('remoteAudioStatus');
   const rxMeter = document.getElementById('remoteAudioRxMeter');
   const txMeter = document.getElementById('remoteAudioTxMeter');
@@ -186,12 +206,16 @@ function bindRemoteAudioControls(role) {
   let spectrumTimer = null;
   let heartbeatTimer = null;
   let staleTimer = null;
+  let txPollTimer = null;
   let lastHeartbeat = remoteOwned ? Date.now() : 0;
   let streamStatus = 'idle';
   let streamCodec = null;
   let gainSaveTimer = null;
   let applyingRemoteGain = false;
   let applyingRemoteCodec = false;
+  let transmitting = false;
+  let txVfo = 0; // 0 = A, 1 = B (effective TX VFO)
+  let txBusy = false;
 
   function selectedMicId() {
     return (micSelect?.value || getSavedMicId() || '').trim();
@@ -219,6 +243,88 @@ function bindRemoteAudioControls(role) {
   function selectedCodec() {
     if (codecSelect?.value === 'pcm16') return 'pcm16';
     return preferredCodecForSession();
+  }
+
+  function applyTxState(next, { broadcast, txVfo: nextVfo } = {}) {
+    transmitting = !!next;
+    if (typeof nextVfo === 'number' && (nextVfo === 0 || nextVfo === 1))
+      txVfo = nextVfo;
+    setTxButtonUi(txBtn, txTip, transmitting);
+    setTxVfoBadge(txVfoBadge, txVfo, transmitting);
+    if (broadcast) post({ type: 'txState', transmitting, txVfo });
+  }
+
+  function setTxVfoBadge(el, vfo, on) {
+    if (!el) return;
+    const letter = vfo === 1 ? 'B' : 'A';
+    el.textContent = `VFO ${letter}`;
+    el.classList.remove('text-bg-secondary', 'text-bg-warning', 'text-bg-danger');
+    el.classList.add(on ? 'text-bg-danger' : 'text-bg-secondary');
+    el.title = on
+      ? `Transmitting on VFO ${letter}`
+      : `Transmit VFO is ${letter}`;
+    el.setAttribute('aria-label', el.title);
+  }
+
+  async function fetchTxState() {
+    try {
+      const res = await fetch('/api/cat/tx');
+      if (!res.ok) return;
+      const data = await res.json();
+      const nextOn = typeof data.transmitting === 'boolean' ? data.transmitting : transmitting;
+      const nextVfo = (data.txVfo === 0 || data.txVfo === 1) ? data.txVfo : txVfo;
+      if (nextOn !== transmitting || nextVfo !== txVfo)
+        applyTxState(nextOn, { broadcast: role === 'popout', txVfo: nextVfo });
+    } catch { /* ignore */ }
+  }
+
+  async function toggleRemoteTx() {
+    if (txBusy) return;
+    txBusy = true;
+    if (txBtn) txBtn.disabled = true;
+    try {
+      const res = await fetch('/api/cat/tx', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ transmit: !transmitting })
+      });
+      if (!res.ok) throw new Error('TX toggle failed');
+      const data = await res.json();
+      applyTxState(!!data.transmitting, { broadcast: true });
+    } catch (e) {
+      console.warn('Remote audio TX toggle failed', e);
+      setStatusText(e.message || 'TX toggle failed');
+    } finally {
+      txBusy = false;
+      if (txBtn) txBtn.disabled = false;
+    }
+  }
+
+  function isTxShortcutBlocked() {
+    const active = document.activeElement;
+    if (!active || active === document.body || active === document.documentElement)
+      return false;
+    if (active.isContentEditable) return true;
+    const tag = active.tagName;
+    if (tag === 'TEXTAREA' || tag === 'SELECT') return true;
+    if (tag === 'INPUT') {
+      const type = (active.getAttribute('type') || 'text').toLowerCase();
+      // Gain sliders are inputs — do not treat them as text entry.
+      if (['range', 'checkbox', 'radio', 'button', 'submit', 'reset', 'file', 'color', 'hidden'].includes(type))
+        return false;
+      return true;
+    }
+    return false;
+  }
+
+  function txShortcutMatches(e, configuredKey) {
+    if (configuredKey == null || configuredKey === '') return false;
+    const isSpaceShortcut = configuredKey === 'Space' || configuredKey === ' ';
+    if (isSpaceShortcut)
+      return e.key === ' ' || e.code === 'Space';
+    if (configuredKey.length === 1 && e.key.length === 1)
+      return e.key.toLowerCase() === configuredKey.toLowerCase();
+    return e.key === configuredKey || e.code === configuredKey;
   }
 
   function clampGain(v) {
@@ -529,6 +635,7 @@ function bindRemoteAudioControls(role) {
           setStatusText('In pop-out window');
           setPopoutHints(true);
           post({ type: 'requestStatus' });
+          window.publishTxState?.();
           updateLocalButtons();
           return;
         }
@@ -594,10 +701,27 @@ function bindRemoteAudioControls(role) {
           };
           return;
         }
+        if (msg.type === 'txState') {
+          if (typeof msg.transmitting === 'boolean')
+            window.applySharedTxState?.(msg.transmitting);
+          return;
+        }
+        if (msg.type === 'requestTxState') {
+          window.publishTxState?.();
+          return;
+        }
         return;
       }
 
       // popout role
+      if (msg.type === 'txState') {
+        if (typeof msg.transmitting === 'boolean' || typeof msg.txVfo === 'number')
+          applyTxState(
+            typeof msg.transmitting === 'boolean' ? msg.transmitting : transmitting,
+            { txVfo: msg.txVfo }
+          );
+        return;
+      }
       if (msg.type === 'setMute') {
         if (typeof msg.mic === 'boolean') {
           setMicMuteUi(micMute, micMuteIcon, micMuteTip, msg.mic);
@@ -645,6 +769,8 @@ function bindRemoteAudioControls(role) {
         const g = readGainUi();
         post({ type: 'gain', rx: g.rx, tx: g.tx });
         post({ type: 'codecPref', codec: selectedCodec() });
+        post({ type: 'txState', transmitting, txVfo });
+        post({ type: 'requestTxState' });
       }
     };
   }
@@ -681,6 +807,8 @@ function bindRemoteAudioControls(role) {
     }
     session?.setRxMuted(next);
   });
+
+  txBtn?.addEventListener('click', () => { toggleRemoteTx(); });
 
   micSelect?.addEventListener('change', () => {
     saveMicId(micSelect.value || '');
@@ -743,8 +871,32 @@ function bindRemoteAudioControls(role) {
       status: streamStatus,
       codec: streamCodec
     }), HEARTBEAT_MS);
+    fetchTxState();
+    txPollTimer = setInterval(fetchTxState, TX_POLL_MS);
+    post({ type: 'requestTxState' });
+
+    // Same TX toggle shortcut as Home (Settings → TX toggle key).
+    // Capture phase so we beat focused buttons (Space would otherwise
+    // activate the button and can double-toggle TX).
+    document.addEventListener('keydown', (e) => {
+      const configuredKey = window.ywcTxToggleKey;
+      if (configuredKey == null || configuredKey === '' || e.ctrlKey || e.metaKey || e.altKey || e.repeat)
+        return;
+      if (isTxShortcutBlocked()) return;
+      if (!txShortcutMatches(e, configuredKey)) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+      // Blur focused buttons so Space doesn't also synthesize a click.
+      const active = document.activeElement;
+      if (active && typeof active.blur === 'function' && active.tagName === 'BUTTON')
+        active.blur();
+      toggleRemoteTx();
+    }, true);
+
     window.addEventListener('beforeunload', () => {
       try { session?.stop(); } catch { /* ignore */ }
+      if (txPollTimer) clearInterval(txPollTimer);
       releasePopoutOwnership();
     });
 
@@ -759,6 +911,7 @@ function bindRemoteAudioControls(role) {
       setStatusText('In pop-out window');
       setPopoutHints(true);
       post({ type: 'requestStatus' });
+      window.publishTxState?.();
     }
     staleTimer = setInterval(() => {
       if (!remoteOwned) return;
@@ -771,6 +924,8 @@ function bindRemoteAudioControls(role) {
   if (stopBtn) stopBtn.disabled = true;
   setMicMuteUi(micMute, micMuteIcon, micMuteTip, false);
   setRxMuteUi(rxMute, rxMuteIcon, rxMuteTip, false);
+  setTxButtonUi(txBtn, txTip, false);
+  setTxVfoBadge(txVfoBadge, 0, false);
   initCodecSelect();
   updateLocalButtons();
   ensureRemoteAudioTooltips();

--- a/wwwroot/js/audio/remote-audio-ui.js
+++ b/wwwroot/js/audio/remote-audio-ui.js
@@ -211,7 +211,7 @@ function bindRemoteAudioControls(role) {
     codecSelect.value = (saved === 'opus' && !opusOk) ? 'pcm16' : saved;
     if (codecHint) {
       codecHint.textContent = opusOk
-        ? 'Opus uses far less bandwidth than PCM16. Takes effect on the next Start.'
+        ? 'Opus uses far less bandwidth than PCM16. Stop and reconnect remote audio for a codec change to apply.'
         : 'This browser cannot encode Opus (WebCodecs); PCM16 will be used.';
     }
   }

--- a/wwwroot/js/audio/remote-audio-ui.js
+++ b/wwwroot/js/audio/remote-audio-ui.js
@@ -1,0 +1,75 @@
+import { createAudioSession } from './audio-session.js';
+
+/**
+ * Index-page Remote Audio controls. Shown only when Settings has audio enabled.
+ */
+export async function initRemoteAudioUi() {
+  const bar = document.getElementById('remoteAudioBar');
+  if (!bar) return;
+
+  let enabled = false;
+  try {
+    const res = await fetch('/api/audio/status');
+    const data = await res.json();
+    enabled = !!data.enabled;
+  } catch {
+    enabled = false;
+  }
+
+  if (!enabled) {
+    bar.style.display = 'none';
+    return;
+  }
+
+  bar.style.display = '';
+  const startBtn = document.getElementById('remoteAudioStartBtn');
+  const stopBtn = document.getElementById('remoteAudioStopBtn');
+  const micMute = document.getElementById('remoteAudioMicMute');
+  const rxMute = document.getElementById('remoteAudioRxMute');
+  const statusEl = document.getElementById('remoteAudioStatus');
+  const rxMeter = document.getElementById('remoteAudioRxMeter');
+  const txMeter = document.getElementById('remoteAudioTxMeter');
+
+  const session = createAudioSession({
+    onStatus: (s, codec) => {
+      if (statusEl) {
+        statusEl.textContent = s === 'streaming'
+          ? `Streaming (${codec})`
+          : s.charAt(0).toUpperCase() + s.slice(1);
+      }
+      if (startBtn) startBtn.disabled = s === 'streaming';
+      if (stopBtn) stopBtn.disabled = s !== 'streaming';
+    },
+    onLevels: (rx, tx) => {
+      if (rxMeter) rxMeter.style.width = `${Math.min(100, Math.round(rx * 100))}%`;
+      if (txMeter) txMeter.style.width = `${Math.min(100, Math.round(tx * 100))}%`;
+    },
+    onError: (msg) => {
+      if (statusEl) statusEl.textContent = msg;
+      alert(msg);
+    }
+  });
+
+  startBtn?.addEventListener('click', async () => {
+    try {
+      statusEl.textContent = 'Connecting…';
+      await session.start();
+    } catch (e) {
+      statusEl.textContent = e.message || String(e);
+      alert(e.message || String(e));
+    }
+  });
+
+  stopBtn?.addEventListener('click', async () => {
+    await session.stop();
+  });
+
+  micMute?.addEventListener('change', () => {
+    session.setMicMuted(micMute.checked);
+  });
+  rxMute?.addEventListener('change', () => {
+    session.setRxMuted(rxMute.checked);
+  });
+
+  if (stopBtn) stopBtn.disabled = true;
+}

--- a/wwwroot/js/audio/remote-audio-ui.js
+++ b/wwwroot/js/audio/remote-audio-ui.js
@@ -1,7 +1,83 @@
 import { createAudioSession } from './audio-session.js';
 
-function attachFilterScopeSpectrum(session) {
-  const provider = () => session.getSpectrum();
+const CHANNEL_NAME = 'ywc-remote-audio';
+const POPOUT_STORAGE_KEY = 'ywc.remoteAudio.popout';
+const POPOUT_WINDOW_NAME = 'ywc-remote-audio';
+const POPOUT_FEATURES = 'width=560,height=240,resizable=yes,scrollbars=no';
+const SPECTRUM_HZ = 15;
+const HEARTBEAT_MS = 2000;
+const HEARTBEAT_STALE_MS = 6000;
+
+const TIP_CONNECT = 'Connect to transceiver audio';
+const TIP_DISCONNECT = 'Disconnect transceiver audio';
+const TIP_POPOUT =
+  'Popout audio, useful to navigate YWC without interrupting the audio stream';
+const TIP_POPOUT_REOPEN =
+  'Re-open the audio pop-out window';
+
+const TIP_MIC_ON = 'Mute microphone';
+const TIP_MIC_OFF = 'Unmute microphone';
+const TIP_RX_ON = 'Deafen — mute received audio';
+const TIP_RX_OFF = 'Undeafen — hear received audio';
+
+function isTogglePressed(el) {
+  return el?.getAttribute('aria-pressed') === 'true';
+}
+
+function setMicMuteUi(btn, icon, tipWrap, muted) {
+  if (!btn) return;
+  btn.setAttribute('aria-pressed', muted ? 'true' : 'false');
+  btn.classList.remove('btn-success', 'btn-warning', 'btn-outline-success', 'btn-outline-warning');
+  btn.classList.add(muted ? 'btn-warning' : 'btn-success');
+  if (icon) icon.className = `bi ${muted ? 'bi-mic-mute-fill' : 'bi-mic-fill'} remote-audio-btn-icon`;
+  const tip = muted ? TIP_MIC_OFF : TIP_MIC_ON;
+  btn.setAttribute('aria-label', tip);
+  setTipText(tipWrap, tip);
+}
+
+function setRxMuteUi(btn, icon, tipWrap, muted) {
+  if (!btn) return;
+  btn.setAttribute('aria-pressed', muted ? 'true' : 'false');
+  btn.classList.remove('btn-success', 'btn-warning', 'btn-outline-success', 'btn-outline-warning');
+  btn.classList.add(muted ? 'btn-warning' : 'btn-success');
+  if (icon) icon.className = `bi ${muted ? 'bi-volume-mute-fill' : 'bi-headphones'} remote-audio-btn-icon`;
+  const tip = muted ? TIP_RX_OFF : TIP_RX_ON;
+  btn.setAttribute('aria-label', tip);
+  setTipText(tipWrap, tip);
+}
+
+function setTipText(el, text) {
+  if (!el) return;
+  el.setAttribute('data-bs-title', text);
+  el.setAttribute('aria-label', text);
+  if (typeof bootstrap === 'undefined') return;
+  const existing = bootstrap.Tooltip.getInstance(el);
+  if (existing) existing.dispose();
+  bootstrap.Tooltip.getOrCreateInstance(el, {
+    delay: { show: 200, hide: 50 },
+    trigger: 'hover focus',
+    placement: 'top'
+  });
+}
+
+function initRemoteAudioTooltips() {
+  if (typeof bootstrap === 'undefined') return false;
+  document.querySelectorAll('#remoteAudioBar .remote-audio-tip[data-bs-toggle="tooltip"]').forEach(el => {
+    bootstrap.Tooltip.getOrCreateInstance(el, {
+      delay: { show: 200, hide: 50 },
+      trigger: 'hover focus',
+      placement: 'top'
+    });
+  });
+  return true;
+}
+
+function ensureRemoteAudioTooltips() {
+  if (initRemoteAudioTooltips()) return;
+  window.addEventListener('load', () => initRemoteAudioTooltips(), { once: true });
+}
+
+function attachFilterScopeSpectrum(provider) {
   window.filterScopePanelA?.setSpectrumProvider?.(provider);
   window.filterScopePanelB?.setSpectrumProvider?.(provider);
 }
@@ -9,6 +85,458 @@ function attachFilterScopeSpectrum(session) {
 function clearFilterScopeSpectrum() {
   window.filterScopePanelA?.setSpectrumProvider?.(null);
   window.filterScopePanelB?.setSpectrumProvider?.(null);
+}
+
+function openChannel() {
+  try {
+    return typeof BroadcastChannel !== 'undefined' ? new BroadcastChannel(CHANNEL_NAME) : null;
+  } catch {
+    return null;
+  }
+}
+
+function setPopoutOwned(owned) {
+  try {
+    if (owned) localStorage.setItem(POPOUT_STORAGE_KEY, '1');
+    else localStorage.removeItem(POPOUT_STORAGE_KEY);
+  } catch { /* ignore */ }
+}
+
+function isPopoutOwned() {
+  try {
+    return localStorage.getItem(POPOUT_STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function openPopoutWindow(autostart) {
+  const q = autostart ? '?autostart=1' : '';
+  return window.open(`/RemoteAudio${q}`, POPOUT_WINDOW_NAME, POPOUT_FEATURES);
+}
+
+/**
+ * Wire Start/Stop/mute/meters for a remote-audio bar.
+ * @param {'index'|'popout'} role
+ */
+function bindRemoteAudioControls(role) {
+  const startBtn = document.getElementById('remoteAudioStartBtn');
+  const stopBtn = document.getElementById('remoteAudioStopBtn');
+  const popoutBtn = document.getElementById('remoteAudioPopoutBtn');
+  const popoutTip = document.getElementById('remoteAudioPopoutTip');
+  const closeBtn = document.getElementById('remoteAudioCloseBtn');
+  const micMute = document.getElementById('remoteAudioMicMute');
+  const rxMute = document.getElementById('remoteAudioRxMute');
+  const micMuteIcon = micMute?.querySelector('i');
+  const rxMuteIcon = rxMute?.querySelector('i');
+  const micMuteTip = document.getElementById('remoteAudioMicMuteTip');
+  const rxMuteTip = document.getElementById('remoteAudioRxMuteTip');
+  const statusEl = document.getElementById('remoteAudioStatus');
+  const rxMeter = document.getElementById('remoteAudioRxMeter');
+  const txMeter = document.getElementById('remoteAudioTxMeter');
+
+  const channel = openChannel();
+  let session = null;
+  let remoteOwned = role === 'index' && isPopoutOwned();
+  let latestSpectrum = null;
+  let spectrumTimer = null;
+  let heartbeatTimer = null;
+  let staleTimer = null;
+  let lastHeartbeat = remoteOwned ? Date.now() : 0;
+  let streamStatus = 'idle';
+  let streamCodec = null;
+
+  function setStatusText(text) {
+    if (statusEl) statusEl.textContent = text;
+  }
+
+  function setMeters(rx, tx) {
+    if (rxMeter) rxMeter.style.width = `${Math.min(100, Math.round(rx * 100))}%`;
+    if (txMeter) txMeter.style.width = `${Math.min(100, Math.round(tx * 100))}%`;
+  }
+
+  function setPopoutHints(reopen) {
+    setTipText(popoutTip, reopen ? TIP_POPOUT_REOPEN : TIP_POPOUT);
+    if (popoutBtn) {
+      popoutBtn.setAttribute('aria-label', reopen ? TIP_POPOUT_REOPEN : TIP_POPOUT);
+    }
+  }
+
+  function updateLocalButtons() {
+    const streaming = streamStatus === 'streaming';
+    if (micMute) micMute.disabled = !streaming;
+    if (rxMute) rxMute.disabled = !streaming;
+    if (!streaming) {
+      setMicMuteUi(micMute, micMuteIcon, micMuteTip, false);
+      setRxMuteUi(rxMute, rxMuteIcon, rxMuteTip, false);
+    }
+    if (role === 'popout') {
+      if (startBtn) startBtn.disabled = streaming;
+      if (stopBtn) stopBtn.disabled = !streaming;
+      return;
+    }
+    if (remoteOwned) {
+      if (startBtn) startBtn.disabled = true;
+      if (stopBtn) stopBtn.disabled = !streaming;
+      setPopoutHints(true);
+    } else {
+      if (startBtn) startBtn.disabled = streaming;
+      if (stopBtn) stopBtn.disabled = !streaming;
+      setPopoutHints(false);
+    }
+  }
+
+  function post(msg) {
+    try { channel?.postMessage(msg); } catch { /* ignore */ }
+  }
+
+  function attachLocalSpectrum() {
+    if (!session) return;
+    attachFilterScopeSpectrum(() => session.getSpectrum());
+  }
+
+  function attachRemoteSpectrum() {
+    attachFilterScopeSpectrum(() => latestSpectrum);
+  }
+
+  function stopSpectrumRelay() {
+    if (spectrumTimer) {
+      clearInterval(spectrumTimer);
+      spectrumTimer = null;
+    }
+  }
+
+  function startSpectrumRelay() {
+    stopSpectrumRelay();
+    spectrumTimer = setInterval(() => {
+      if (!session || streamStatus !== 'streaming') return;
+      const spec = session.getSpectrum();
+      if (!spec || !spec.data) {
+        post({ type: 'spectrum', data: null });
+        return;
+      }
+      post({
+        type: 'spectrum',
+        data: Array.from(spec.data),
+        sampleRate: spec.sampleRate,
+        fftSize: spec.fftSize
+      });
+    }, Math.round(1000 / SPECTRUM_HZ));
+  }
+
+  function clearRemoteOwnershipUi() {
+    remoteOwned = false;
+    setPopoutOwned(false);
+    latestSpectrum = null;
+    clearFilterScopeSpectrum();
+    setMeters(0, 0);
+    streamStatus = 'idle';
+    streamCodec = null;
+    setStatusText('Idle');
+    updateLocalButtons();
+  }
+
+  function ensureSession() {
+    if (session) return session;
+    session = createAudioSession({
+      onStatus: (s, codec) => {
+        streamStatus = s;
+        streamCodec = codec || null;
+        if (role === 'popout') {
+          setStatusText(s === 'streaming'
+            ? `Streaming (${codec})`
+            : s.charAt(0).toUpperCase() + s.slice(1));
+          post({ type: 'status', status: s, codec: codec || null });
+          if (s === 'streaming') startSpectrumRelay();
+          else {
+            stopSpectrumRelay();
+            post({ type: 'spectrum', data: null });
+          }
+        } else if (!remoteOwned) {
+          setStatusText(s === 'streaming'
+            ? `Streaming (${codec})`
+            : s.charAt(0).toUpperCase() + s.slice(1));
+          if (s === 'streaming') attachLocalSpectrum();
+          else clearFilterScopeSpectrum();
+        }
+        updateLocalButtons();
+      },
+      onLevels: (rx, tx) => {
+        setMeters(rx, tx);
+        if (role === 'popout') post({ type: 'levels', rx, tx });
+      },
+      onError: (msg) => {
+        setStatusText(msg);
+        if (role === 'popout') post({ type: 'error', message: msg });
+        else if (!remoteOwned) alert(msg);
+      }
+    });
+    return session;
+  }
+
+  async function startLocal() {
+    try {
+      setStatusText('Connecting…');
+      await ensureSession().start();
+    } catch (e) {
+      const msg = e.message || String(e);
+      setStatusText(msg);
+      alert(msg);
+      updateLocalButtons();
+    }
+  }
+
+  async function stopLocal() {
+    if (session) await session.stop();
+    streamStatus = 'stopped';
+    streamCodec = null;
+    stopSpectrumRelay();
+    if (role === 'popout') {
+      post({ type: 'status', status: 'stopped' });
+      post({ type: 'spectrum', data: null });
+      setStatusText('Stopped');
+    } else if (!remoteOwned) {
+      clearFilterScopeSpectrum();
+      setStatusText('Stopped');
+    }
+    updateLocalButtons();
+  }
+
+  function claimPopoutOwnership() {
+    setPopoutOwned(true);
+    post({ type: 'ownership', owned: true });
+    post({ type: 'hello', role: 'popout' });
+  }
+
+  function releasePopoutOwnership() {
+    setPopoutOwned(false);
+    stopSpectrumRelay();
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = null;
+    }
+    post({ type: 'ownership', owned: false });
+    post({ type: 'popoutClosed' });
+    post({ type: 'spectrum', data: null });
+  }
+
+  if (channel) {
+    channel.onmessage = (ev) => {
+      const msg = ev.data;
+      if (!msg || typeof msg !== 'object') return;
+
+      if (role === 'index') {
+        if (msg.type === 'heartbeat') {
+          lastHeartbeat = Date.now();
+          if (!remoteOwned) {
+            remoteOwned = true;
+            setPopoutOwned(true);
+            attachRemoteSpectrum();
+          }
+          if (msg.status) {
+            streamStatus = msg.status === 'streaming' ? 'streaming' : msg.status;
+            streamCodec = msg.codec || null;
+            setStatusText(msg.status === 'streaming'
+              ? `In pop-out window (streaming${msg.codec ? ` · ${msg.codec}` : ''})`
+              : `In pop-out window (${msg.status})`);
+          }
+          updateLocalButtons();
+          return;
+        }
+        if (msg.type === 'hello' && msg.role === 'popout') {
+          lastHeartbeat = Date.now();
+          remoteOwned = true;
+          setPopoutOwned(true);
+          setStatusText('In pop-out window');
+          attachRemoteSpectrum();
+          updateLocalButtons();
+          post({ type: 'requestStatus' });
+          return;
+        }
+        if (msg.type === 'ownership') {
+          lastHeartbeat = Date.now();
+          if (!msg.owned) {
+            clearRemoteOwnershipUi();
+            return;
+          }
+          remoteOwned = true;
+          setPopoutOwned(true);
+          setStatusText('In pop-out window');
+          attachRemoteSpectrum();
+          updateLocalButtons();
+          return;
+        }
+        if (msg.type === 'popoutClosed') {
+          clearRemoteOwnershipUi();
+          return;
+        }
+        if (msg.type === 'status') {
+          remoteOwned = true;
+          setPopoutOwned(true);
+          lastHeartbeat = Date.now();
+          streamStatus = msg.status === 'streaming' ? 'streaming' : (msg.status || 'idle');
+          streamCodec = msg.codec || null;
+          setStatusText(msg.status === 'streaming'
+            ? `In pop-out window (streaming${msg.codec ? ` · ${msg.codec}` : ''})`
+            : `In pop-out window (${msg.status || 'idle'})`);
+          if (msg.status === 'streaming') attachRemoteSpectrum();
+          else {
+            latestSpectrum = null;
+            attachRemoteSpectrum();
+          }
+          updateLocalButtons();
+          return;
+        }
+        if (msg.type === 'levels') {
+          setMeters(msg.rx || 0, msg.tx || 0);
+          return;
+        }
+        if (msg.type === 'error') {
+          setStatusText(msg.message || 'Audio error');
+          return;
+        }
+        if (msg.type === 'muteState') {
+          if (typeof msg.mic === 'boolean') setMicMuteUi(micMute, micMuteIcon, micMuteTip, msg.mic);
+          if (typeof msg.rx === 'boolean') setRxMuteUi(rxMute, rxMuteIcon, rxMuteTip, msg.rx);
+          return;
+        }
+        if (msg.type === 'spectrum') {
+          if (!msg.data) {
+            latestSpectrum = null;
+            return;
+          }
+          latestSpectrum = {
+            data: msg.data instanceof Uint8Array ? msg.data : new Uint8Array(msg.data),
+            sampleRate: msg.sampleRate,
+            fftSize: msg.fftSize
+          };
+          return;
+        }
+        return;
+      }
+
+      // popout role
+      if (msg.type === 'setMute') {
+        if (typeof msg.mic === 'boolean') {
+          setMicMuteUi(micMute, micMuteIcon, micMuteTip, msg.mic);
+          session?.setMicMuted(msg.mic);
+        }
+        if (typeof msg.rx === 'boolean') {
+          setRxMuteUi(rxMute, rxMuteIcon, rxMuteTip, msg.rx);
+          session?.setRxMuted(msg.rx);
+        }
+        return;
+      }
+      if (msg.type === 'stop') {
+        stopLocal();
+        return;
+      }
+      if (msg.type === 'requestStatus') {
+        post({ type: 'status', status: streamStatus, codec: streamCodec });
+        post({
+          type: 'muteState',
+          mic: isTogglePressed(micMute),
+          rx: isTogglePressed(rxMute)
+        });
+      }
+    };
+  }
+
+  startBtn?.addEventListener('click', async () => {
+    if (role === 'index' && remoteOwned) return;
+    await startLocal();
+  });
+
+  stopBtn?.addEventListener('click', async () => {
+    if (role === 'index' && remoteOwned) {
+      post({ type: 'stop' });
+      return;
+    }
+    await stopLocal();
+  });
+
+  micMute?.addEventListener('click', () => {
+    const next = !isTogglePressed(micMute);
+    setMicMuteUi(micMute, micMuteIcon, micMuteTip, next);
+    if (role === 'index' && remoteOwned) {
+      post({ type: 'setMute', mic: next });
+      return;
+    }
+    session?.setMicMuted(next);
+  });
+
+  rxMute?.addEventListener('click', () => {
+    const next = !isTogglePressed(rxMute);
+    setRxMuteUi(rxMute, rxMuteIcon, rxMuteTip, next);
+    if (role === 'index' && remoteOwned) {
+      post({ type: 'setMute', rx: next });
+      return;
+    }
+    session?.setRxMuted(next);
+  });
+
+  popoutBtn?.addEventListener('click', async () => {
+    const wasStreaming = !!session?.running;
+    if (wasStreaming) {
+      await stopLocal();
+      await new Promise((r) => setTimeout(r, 150));
+    }
+    const win = openPopoutWindow(!!wasStreaming);
+    if (!win) {
+      setStatusText('Pop-out blocked — allow pop-ups for this site');
+      return;
+    }
+    remoteOwned = true;
+    setPopoutOwned(true);
+    lastHeartbeat = Date.now();
+    setStatusText(wasStreaming ? 'Handing off to pop-out…' : 'In pop-out window');
+    attachRemoteSpectrum();
+    updateLocalButtons();
+  });
+
+  closeBtn?.addEventListener('click', async () => {
+    await stopLocal();
+    releasePopoutOwnership();
+    window.close();
+  });
+
+  if (role === 'popout') {
+    claimPopoutOwnership();
+    heartbeatTimer = setInterval(() => post({
+      type: 'heartbeat',
+      status: streamStatus,
+      codec: streamCodec
+    }), HEARTBEAT_MS);
+    window.addEventListener('beforeunload', () => {
+      try { session?.stop(); } catch { /* ignore */ }
+      releasePopoutOwnership();
+    });
+
+    const params = new URLSearchParams(location.search);
+    if (params.get('autostart') === '1') {
+      // Start in the same turn as page script when possible (inherits
+      // transient activation from the Index click that opened us).
+      startLocal();
+    }
+  } else {
+    if (remoteOwned) {
+      setStatusText('In pop-out window');
+      attachRemoteSpectrum();
+      post({ type: 'requestStatus' });
+    }
+    staleTimer = setInterval(() => {
+      if (!remoteOwned) return;
+      if (Date.now() - lastHeartbeat > HEARTBEAT_STALE_MS) {
+        clearRemoteOwnershipUi();
+      }
+    }, HEARTBEAT_MS);
+  }
+
+  if (stopBtn) stopBtn.disabled = true;
+  setMicMuteUi(micMute, micMuteIcon, micMuteTip, false);
+  setRxMuteUi(rxMute, rxMuteIcon, rxMuteTip, false);
+  updateLocalButtons();
+  ensureRemoteAudioTooltips();
 }
 
 /**
@@ -33,56 +561,32 @@ export async function initRemoteAudioUi() {
   }
 
   bar.style.display = '';
-  const startBtn = document.getElementById('remoteAudioStartBtn');
-  const stopBtn = document.getElementById('remoteAudioStopBtn');
-  const micMute = document.getElementById('remoteAudioMicMute');
-  const rxMute = document.getElementById('remoteAudioRxMute');
-  const statusEl = document.getElementById('remoteAudioStatus');
-  const rxMeter = document.getElementById('remoteAudioRxMeter');
-  const txMeter = document.getElementById('remoteAudioTxMeter');
+  bindRemoteAudioControls('index');
+}
 
-  const session = createAudioSession({
-    onStatus: (s, codec) => {
-      if (statusEl) {
-        statusEl.textContent = s === 'streaming'
-          ? `Streaming (${codec})`
-          : s.charAt(0).toUpperCase() + s.slice(1);
-      }
-      if (startBtn) startBtn.disabled = s === 'streaming';
-      if (stopBtn) stopBtn.disabled = s !== 'streaming';
-      if (s === 'streaming') attachFilterScopeSpectrum(session);
-      else clearFilterScopeSpectrum();
-    },
-    onLevels: (rx, tx) => {
-      if (rxMeter) rxMeter.style.width = `${Math.min(100, Math.round(rx * 100))}%`;
-      if (txMeter) txMeter.style.width = `${Math.min(100, Math.round(tx * 100))}%`;
-    },
-    onError: (msg) => {
-      if (statusEl) statusEl.textContent = msg;
-      alert(msg);
-    }
-  });
+/**
+ * Pop-out window entry point (/RemoteAudio).
+ */
+export async function initRemoteAudioPopout() {
+  const bar = document.getElementById('remoteAudioBar');
+  if (!bar) return;
 
-  startBtn?.addEventListener('click', async () => {
-    try {
-      statusEl.textContent = 'Connecting…';
-      await session.start();
-    } catch (e) {
-      statusEl.textContent = e.message || String(e);
-      alert(e.message || String(e));
-    }
-  });
+  let enabled = false;
+  try {
+    const res = await fetch('/api/audio/status');
+    const data = await res.json();
+    enabled = !!data.enabled;
+  } catch {
+    enabled = false;
+  }
 
-  stopBtn?.addEventListener('click', async () => {
-    await session.stop();
-  });
+  if (!enabled) {
+    const statusEl = document.getElementById('remoteAudioStatus');
+    if (statusEl) statusEl.textContent = 'Remote audio is disabled in Settings';
+    const startBtn = document.getElementById('remoteAudioStartBtn');
+    if (startBtn) startBtn.disabled = true;
+    return;
+  }
 
-  micMute?.addEventListener('change', () => {
-    session.setMicMuted(micMute.checked);
-  });
-  rxMute?.addEventListener('change', () => {
-    session.setRxMuted(rxMute.checked);
-  });
-
-  if (stopBtn) stopBtn.disabled = true;
+  bindRemoteAudioControls('popout');
 }

--- a/wwwroot/js/audio/remote-audio-ui.js
+++ b/wwwroot/js/audio/remote-audio-ui.js
@@ -1,5 +1,16 @@
 import { createAudioSession } from './audio-session.js';
 
+function attachFilterScopeSpectrum(session) {
+  const provider = () => session.getSpectrum();
+  window.filterScopePanelA?.setSpectrumProvider?.(provider);
+  window.filterScopePanelB?.setSpectrumProvider?.(provider);
+}
+
+function clearFilterScopeSpectrum() {
+  window.filterScopePanelA?.setSpectrumProvider?.(null);
+  window.filterScopePanelB?.setSpectrumProvider?.(null);
+}
+
 /**
  * Index-page Remote Audio controls. Shown only when Settings has audio enabled.
  */
@@ -39,6 +50,8 @@ export async function initRemoteAudioUi() {
       }
       if (startBtn) startBtn.disabled = s === 'streaming';
       if (stopBtn) stopBtn.disabled = s !== 'streaming';
+      if (s === 'streaming') attachFilterScopeSpectrum(session);
+      else clearFilterScopeSpectrum();
     },
     onLevels: (rx, tx) => {
       if (rxMeter) rxMeter.style.width = `${Math.min(100, Math.round(rx * 100))}%`;

--- a/wwwroot/js/audio/remote-audio-ui.js
+++ b/wwwroot/js/audio/remote-audio-ui.js
@@ -97,9 +97,12 @@ function ensureRemoteAudioTooltips() {
   window.addEventListener('load', () => initRemoteAudioTooltips(), { once: true });
 }
 
+// Live FFT is MAIN/USB mono only today — attach to VFO A alone. VFO B keeps
+// the decorative random bars until stereo L→A / R→B lands (see
+// .cursor/plans/remote-audio-stereo-filter-scopes.plan.md).
 function attachFilterScopeSpectrum(provider) {
   window.filterScopePanelA?.setSpectrumProvider?.(provider);
-  window.filterScopePanelB?.setSpectrumProvider?.(provider);
+  window.filterScopePanelB?.setSpectrumProvider?.(null);
 }
 
 function clearFilterScopeSpectrum() {

--- a/wwwroot/js/audio/remote-audio-ui.js
+++ b/wwwroot/js/audio/remote-audio-ui.js
@@ -2,8 +2,9 @@ import { createAudioSession } from './audio-session.js';
 
 const CHANNEL_NAME = 'ywc-remote-audio';
 const POPOUT_STORAGE_KEY = 'ywc.remoteAudio.popout';
+const MIC_STORAGE_KEY = 'ywc.remoteAudio.browserMic';
 const POPOUT_WINDOW_NAME = 'ywc-remote-audio';
-const POPOUT_FEATURES = 'width=560,height=240,resizable=yes,scrollbars=no';
+const POPOUT_FEATURES = 'width=560,height=280,resizable=yes,scrollbars=no';
 const SPECTRUM_HZ = 15;
 const HEARTBEAT_MS = 2000;
 const HEARTBEAT_STALE_MS = 6000;
@@ -110,6 +111,18 @@ function isPopoutOwned() {
   }
 }
 
+function getSavedMicId() {
+  try { return localStorage.getItem(MIC_STORAGE_KEY) || ''; }
+  catch { return ''; }
+}
+
+function saveMicId(id) {
+  try {
+    if (id) localStorage.setItem(MIC_STORAGE_KEY, id);
+    else localStorage.removeItem(MIC_STORAGE_KEY);
+  } catch { /* ignore */ }
+}
+
 function openPopoutWindow(autostart) {
   const q = autostart ? '?autostart=1' : '';
   return window.open(`/RemoteAudio${q}`, POPOUT_WINDOW_NAME, POPOUT_FEATURES);
@@ -134,6 +147,7 @@ function bindRemoteAudioControls(role) {
   const statusEl = document.getElementById('remoteAudioStatus');
   const rxMeter = document.getElementById('remoteAudioRxMeter');
   const txMeter = document.getElementById('remoteAudioTxMeter');
+  const micSelect = document.getElementById('remoteAudioMicSelect');
 
   const channel = openChannel();
   let session = null;
@@ -145,6 +159,37 @@ function bindRemoteAudioControls(role) {
   let lastHeartbeat = remoteOwned ? Date.now() : 0;
   let streamStatus = 'idle';
   let streamCodec = null;
+
+  function selectedMicId() {
+    return (micSelect?.value || getSavedMicId() || '').trim();
+  }
+
+  async function refreshMicList() {
+    if (!micSelect || !navigator.mediaDevices?.enumerateDevices) return;
+    const saved = selectedMicId();
+    let devices = [];
+    try {
+      devices = await navigator.mediaDevices.enumerateDevices();
+    } catch {
+      return;
+    }
+    const mics = devices.filter(d => d.kind === 'audioinput');
+    micSelect.innerHTML = '';
+    const def = document.createElement('option');
+    def.value = '';
+    def.textContent = 'Default microphone';
+    micSelect.appendChild(def);
+    for (const d of mics) {
+      const opt = document.createElement('option');
+      opt.value = d.deviceId;
+      opt.textContent = d.label || `Microphone ${micSelect.options.length}`;
+      micSelect.appendChild(opt);
+    }
+    if (saved && [...micSelect.options].some(o => o.value === saved))
+      micSelect.value = saved;
+    else
+      micSelect.value = '';
+  }
 
   function setStatusText(text) {
     if (statusEl) statusEl.textContent = text;
@@ -166,6 +211,8 @@ function bindRemoteAudioControls(role) {
     const streaming = streamStatus === 'streaming';
     if (micMute) micMute.disabled = !streaming;
     if (rxMute) rxMute.disabled = !streaming;
+    // Index locks the mic picker only while the popout is actively streaming.
+    if (micSelect) micSelect.disabled = role === 'index' && remoteOwned && streaming;
     if (!streaming) {
       setMicMuteUi(micMute, micMuteIcon, micMuteTip, false);
       setRxMuteUi(rxMute, rxMuteIcon, rxMuteTip, false);
@@ -175,14 +222,15 @@ function bindRemoteAudioControls(role) {
       if (stopBtn) stopBtn.disabled = !streaming;
       return;
     }
-    if (remoteOwned) {
+    if (remoteOwned && streaming) {
       if (startBtn) startBtn.disabled = true;
-      if (stopBtn) stopBtn.disabled = !streaming;
+      if (stopBtn) stopBtn.disabled = false;
       setPopoutHints(true);
     } else {
+      // Popout stopped (or never started): unlock Start on the main bar.
       if (startBtn) startBtn.disabled = streaming;
       if (stopBtn) stopBtn.disabled = !streaming;
-      setPopoutHints(false);
+      setPopoutHints(!!(remoteOwned || isPopoutOwned()));
     }
   }
 
@@ -277,7 +325,8 @@ function bindRemoteAudioControls(role) {
   async function startLocal() {
     try {
       setStatusText('Connecting…');
-      await ensureSession().start();
+      await ensureSession().start({ deviceId: selectedMicId() });
+      await refreshMicList(); // labels appear after permission grant
     } catch (e) {
       const msg = e.message || String(e);
       setStatusText(msg);
@@ -292,6 +341,7 @@ function bindRemoteAudioControls(role) {
     streamCodec = null;
     stopSpectrumRelay();
     if (role === 'popout') {
+      // Unlock the Index bar — ownership only applies while streaming.
       post({ type: 'status', status: 'stopped' });
       post({ type: 'spectrum', data: null });
       setStatusText('Stopped');
@@ -328,29 +378,28 @@ function bindRemoteAudioControls(role) {
       if (role === 'index') {
         if (msg.type === 'heartbeat') {
           lastHeartbeat = Date.now();
-          if (!remoteOwned) {
+          const streaming = msg.status === 'streaming';
+          if (streaming) {
             remoteOwned = true;
             setPopoutOwned(true);
-            attachRemoteSpectrum();
-          }
-          if (msg.status) {
-            streamStatus = msg.status === 'streaming' ? 'streaming' : msg.status;
+            streamStatus = 'streaming';
             streamCodec = msg.codec || null;
-            setStatusText(msg.status === 'streaming'
-              ? `In pop-out window (streaming${msg.codec ? ` · ${msg.codec}` : ''})`
-              : `In pop-out window (${msg.status})`);
+            setStatusText(`In pop-out window (streaming${msg.codec ? ` · ${msg.codec}` : ''})`);
+            attachRemoteSpectrum();
+          } else if (remoteOwned) {
+            // Popout still open but no longer streaming — free the main bar.
+            clearRemoteOwnershipUi();
           }
           updateLocalButtons();
           return;
         }
         if (msg.type === 'hello' && msg.role === 'popout') {
           lastHeartbeat = Date.now();
-          remoteOwned = true;
-          setPopoutOwned(true);
+          // Don't lock Start until the popout is actually streaming.
           setStatusText('In pop-out window');
-          attachRemoteSpectrum();
-          updateLocalButtons();
+          setPopoutHints(true);
           post({ type: 'requestStatus' });
+          updateLocalButtons();
           return;
         }
         if (msg.type === 'ownership') {
@@ -359,10 +408,8 @@ function bindRemoteAudioControls(role) {
             clearRemoteOwnershipUi();
             return;
           }
-          remoteOwned = true;
-          setPopoutOwned(true);
           setStatusText('In pop-out window');
-          attachRemoteSpectrum();
+          setPopoutHints(true);
           updateLocalButtons();
           return;
         }
@@ -371,20 +418,21 @@ function bindRemoteAudioControls(role) {
           return;
         }
         if (msg.type === 'status') {
-          remoteOwned = true;
-          setPopoutOwned(true);
           lastHeartbeat = Date.now();
-          streamStatus = msg.status === 'streaming' ? 'streaming' : (msg.status || 'idle');
-          streamCodec = msg.codec || null;
-          setStatusText(msg.status === 'streaming'
-            ? `In pop-out window (streaming${msg.codec ? ` · ${msg.codec}` : ''})`
-            : `In pop-out window (${msg.status || 'idle'})`);
-          if (msg.status === 'streaming') attachRemoteSpectrum();
-          else {
-            latestSpectrum = null;
+          if (msg.status === 'streaming') {
+            remoteOwned = true;
+            setPopoutOwned(true);
+            streamStatus = 'streaming';
+            streamCodec = msg.codec || null;
+            setStatusText(`In pop-out window (streaming${msg.codec ? ` · ${msg.codec}` : ''})`);
             attachRemoteSpectrum();
+            updateLocalButtons();
+            return;
           }
-          updateLocalButtons();
+          // stopped / idle / disconnected from popout
+          clearRemoteOwnershipUi();
+          if (msg.status && msg.status !== 'idle')
+            setStatusText(msg.status.charAt(0).toUpperCase() + msg.status.slice(1));
           return;
         }
         if (msg.type === 'levels') {
@@ -443,12 +491,12 @@ function bindRemoteAudioControls(role) {
   }
 
   startBtn?.addEventListener('click', async () => {
-    if (role === 'index' && remoteOwned) return;
+    if (role === 'index' && remoteOwned && streamStatus === 'streaming') return;
     await startLocal();
   });
 
   stopBtn?.addEventListener('click', async () => {
-    if (role === 'index' && remoteOwned) {
+    if (role === 'index' && remoteOwned && streamStatus === 'streaming') {
       post({ type: 'stop' });
       return;
     }
@@ -458,7 +506,7 @@ function bindRemoteAudioControls(role) {
   micMute?.addEventListener('click', () => {
     const next = !isTogglePressed(micMute);
     setMicMuteUi(micMute, micMuteIcon, micMuteTip, next);
-    if (role === 'index' && remoteOwned) {
+    if (role === 'index' && remoteOwned && streamStatus === 'streaming') {
       post({ type: 'setMute', mic: next });
       return;
     }
@@ -468,11 +516,15 @@ function bindRemoteAudioControls(role) {
   rxMute?.addEventListener('click', () => {
     const next = !isTogglePressed(rxMute);
     setRxMuteUi(rxMute, rxMuteIcon, rxMuteTip, next);
-    if (role === 'index' && remoteOwned) {
+    if (role === 'index' && remoteOwned && streamStatus === 'streaming') {
       post({ type: 'setMute', rx: next });
       return;
     }
     session?.setRxMuted(next);
+  });
+
+  micSelect?.addEventListener('change', () => {
+    saveMicId(micSelect.value || '');
   });
 
   popoutBtn?.addEventListener('click', async () => {
@@ -486,11 +538,16 @@ function bindRemoteAudioControls(role) {
       setStatusText('Pop-out blocked — allow pop-ups for this site');
       return;
     }
-    remoteOwned = true;
-    setPopoutOwned(true);
     lastHeartbeat = Date.now();
     setStatusText(wasStreaming ? 'Handing off to pop-out…' : 'In pop-out window');
-    attachRemoteSpectrum();
+    setPopoutHints(true);
+    // Lock only once the popout reports streaming (or after autostart handoff).
+    if (wasStreaming) {
+      remoteOwned = true;
+      setPopoutOwned(true);
+      streamStatus = 'streaming';
+      attachRemoteSpectrum();
+    }
     updateLocalButtons();
   });
 
@@ -521,7 +578,7 @@ function bindRemoteAudioControls(role) {
   } else {
     if (remoteOwned) {
       setStatusText('In pop-out window');
-      attachRemoteSpectrum();
+      setPopoutHints(true);
       post({ type: 'requestStatus' });
     }
     staleTimer = setInterval(() => {
@@ -537,6 +594,10 @@ function bindRemoteAudioControls(role) {
   setRxMuteUi(rxMute, rxMuteIcon, rxMuteTip, false);
   updateLocalButtons();
   ensureRemoteAudioTooltips();
+  refreshMicList();
+  try {
+    navigator.mediaDevices?.addEventListener?.('devicechange', () => refreshMicList());
+  } catch { /* ignore */ }
 }
 
 /**

--- a/wwwroot/js/ui/filter-scope-panel.js
+++ b/wwwroot/js/ui/filter-scope-panel.js
@@ -1,6 +1,7 @@
 // filter-scope-panel.js — Filter Function Display canvas renderer
 // Shows DSP filter passband shape, roofing filter outline, notch, contour, and APF markers.
-// Pure computation from CAT state — no actual signal content.
+// Passband geometry is computed from CAT state. Green bars inside the passband are
+// decorative (random) unless a live RX spectrum provider is attached (remote audio).
 
 // IF Width code → Hz per radio model (mirrors ifWidthOptions in Index.cshtml)
 const IF_WIDTH_TABLES = {
@@ -55,12 +56,24 @@ export class FilterScopePanel {
             ...initialState
         };
 
+        /** Optional () => { data, sampleRate, fftSize } | null from remote audio RX. */
+        this._spectrumProvider = null;
+
         this._init();
     }
 
     setState(updates) {
         Object.assign(this._state, updates);
         this._render();
+    }
+
+    /**
+     * Attach or clear a live RX spectrum source. When the provider returns null
+     * (no session / muted), bars fall back to the decorative random animation.
+     * @param {(() => ({ data: Uint8Array, sampleRate: number, fftSize: number } | null)) | null} provider
+     */
+    setSpectrumProvider(provider) {
+        this._spectrumProvider = typeof provider === 'function' ? provider : null;
     }
 
     _init() {
@@ -223,7 +236,7 @@ export class FilterScopePanel {
         ctx.fillStyle = 'rgba(74,138,191,0.10)';
         ctx.fill();
 
-        // Clip to trapezoid, then draw animated signal bars inside it
+        // Clip to trapezoid, then draw signal bars inside it (live FFT or random)
         ctx.save();
         trapPath();
         ctx.clip();
@@ -231,8 +244,21 @@ export class FilterScopePanel {
         const barW    = 2;
         const maxBarH = Math.floor((pbBot - pbTop) * 0.85);
         const barBase = pbBot - 1;
+        const spectrum = this._spectrumProvider ? this._spectrumProvider() : null;
+        const hzPerBin = spectrum
+            ? spectrum.sampleRate / spectrum.fftSize
+            : 0;
+        const binCount = spectrum ? spectrum.data.length : 0;
+
         for (let bx = pxLo; bx <= pxHi; bx += barW) {
-            const nh = Math.random();
+            let nh;
+            if (spectrum && binCount > 0) {
+                const hz = rangeLo + ((bx + barW * 0.5) / W) * rangeHz;
+                const bin = Math.max(0, Math.min(binCount - 1, Math.round(hz / hzPerBin)));
+                nh = spectrum.data[bin] / 255;
+            } else {
+                nh = Math.random();
+            }
             const bh = Math.max(2, Math.round(nh * maxBarH));
             ctx.fillStyle = `rgba(80,210,80,${(0.4 + nh * 0.5).toFixed(2)})`;
             ctx.fillRect(bx, barBase - bh, barW - 1, bh);

--- a/wwwroot/js/ui/site.js
+++ b/wwwroot/js/ui/site.js
@@ -55,11 +55,17 @@ function showServerStoppedOverlay() {
 
 function isTypingIntoEditable() {
     const active = document.activeElement;
-    if (active && (
-        active.tagName === 'INPUT' ||
-        active.tagName === 'TEXTAREA' ||
-        active.isContentEditable
-    )) return true;
+    if (active) {
+        if (active.isContentEditable) return true;
+        if (active.tagName === 'TEXTAREA' || active.tagName === 'SELECT') return true;
+        if (active.tagName === 'INPUT') {
+            const type = (active.getAttribute('type') || 'text').toLowerCase();
+            // Range/checkbox/etc. are not text entry — allow TX shortcut.
+            if (['range', 'checkbox', 'radio', 'button', 'submit', 'reset', 'file', 'color', 'hidden'].includes(type))
+                return false;
+            return true;
+        }
+    }
     // The on-screen frequency keypad is a text-entry surface even though focus
     // sits on its buttons (a <dialog>, not an <input>). Treat it as "typing" so
     // global shortcuts (TX toggle, fullscreen) don't fire while a frequency is
@@ -103,15 +109,18 @@ document.addEventListener('keydown', function (e) {
     // Accept both the token and a legacy lone-space value.
     const isSpaceShortcut = configuredKey === 'Space' || configuredKey === ' ';
     const keyMatches = isSpaceShortcut
-        ? (e.key === ' ')
+        ? (e.key === ' ' || e.code === 'Space')
         : (configuredKey.length === 1 && e.key.length === 1
             ? e.key.toLowerCase() === configuredKey.toLowerCase()
-            : e.key === configuredKey);
+            : e.key === configuredKey || e.code === configuredKey);
     if (!keyMatches) return;
 
     e.preventDefault();
+    const active = document.activeElement;
+    if (active && typeof active.blur === 'function' && active.tagName === 'BUTTON')
+        active.blur();
     toggleTx();
-});
+}, true);
 
 // Add/remove fullscreen-mode class on body when entering/exiting fullscreen
 document.addEventListener('fullscreenchange', function () {
@@ -656,6 +665,61 @@ let txVfo = 0; // 0 = VFO A, 1 = VFO B (the TX VFO — only flips with split)
 // instead of activeVfo.
 let activeVfo = 0;
 
+// Sync TX PTT with the Remote Audio pop-out (same BroadcastChannel).
+const TX_SYNC_CHANNEL = 'ywc-remote-audio';
+let _txSyncChannel = null;
+function getTxSyncChannel() {
+    if (_txSyncChannel) return _txSyncChannel;
+    try {
+        if (typeof BroadcastChannel === 'undefined') return null;
+        _txSyncChannel = new BroadcastChannel(TX_SYNC_CHANNEL);
+        _txSyncChannel.onmessage = (ev) => {
+            const msg = ev.data;
+            if (!msg || typeof msg !== 'object') return;
+            if (msg.type === 'txState' && typeof msg.transmitting === 'boolean') {
+                if (!!msg.transmitting === isTransmitting) return;
+                applySharedTxState(msg.transmitting);
+                return;
+            }
+            if (msg.type === 'requestTxState')
+                publishTxState();
+        };
+    } catch {
+        _txSyncChannel = null;
+    }
+    return _txSyncChannel;
+}
+function effectiveTxVfo() {
+    const vfoRow = document.getElementById('vfoRow');
+    const isSingleReceiver = vfoRow?.dataset.singleReceiver === 'true';
+    if (isSingleReceiver) {
+        return (splitMode > 0)
+            ? (activeVfo === 0 ? 1 : 0)
+            : activeVfo;
+    }
+    return txVfo;
+}
+function publishTxState() {
+    try {
+        getTxSyncChannel()?.postMessage({
+            type: 'txState',
+            transmitting: isTransmitting,
+            txVfo: effectiveTxVfo()
+        });
+    } catch { /* ignore */ }
+}
+function applySharedTxState(transmitting, _sharedTxVfo) {
+    // Index owns VFO selection via SignalR; only PTT on/off syncs from pop-out.
+    isTransmitting = !!transmitting;
+    updateTxButton();
+    updateTxIndicators(isTransmitting);
+    if (typeof window.handleTxStateForTimeout === 'function')
+        window.handleTxStateForTimeout(isTransmitting);
+}
+window.publishTxState = publishTxState;
+window.applySharedTxState = applySharedTxState;
+document.addEventListener('DOMContentLoaded', () => { getTxSyncChannel(); });
+
 // Apply the .vfo-inactive class to whichever VFO panel is NOT the active
 // (RX) one — but only on single-receiver radios (FTdx10, FT-710, FTDX3000).
 // CSS greys only that panel's .card-body (header stays normal so TX looks
@@ -782,6 +846,7 @@ async function toggleTx() {
             isTransmitting = data.transmitting;
             updateTxButton();
             updateTxIndicators(isTransmitting);
+            publishTxState();
         } else {
 
         }
@@ -1273,6 +1338,7 @@ connection.on("RadioStateUpdate", function (update) {
         }
         updateTxButton();
         updateTxIndicators(update.value);
+        publishTxState();
         if (typeof window.handleTxStateForTimeout === 'function') {
             window.handleTxStateForTimeout(!!update.value);
         }
@@ -1283,6 +1349,7 @@ connection.on("RadioStateUpdate", function (update) {
         updateTxButton();
         applyVfoActiveStyling();
         updateRxTxSelectors();
+        publishTxState();
         if (typeof window.updateToolbarStatus === 'function') window.updateToolbarStatus('txVfo', update.value);
     }
     if (update.property === "ActiveVfo") {
@@ -1292,6 +1359,7 @@ connection.on("RadioStateUpdate", function (update) {
         // In normal mode on a single-receiver radio, the TX button position
         // follows activeVfo (the TX VFO IS the active VFO; FT doesn't move).
         updateTxButton();
+        publishTxState();
         // R8 (Jacek SP3L #34, 2026-06-21): in split mode the TX VFO is the
         // opposite of active, so the SPLIT TX badge and the red border have
         // to switch panels whenever the active VFO changes.
@@ -1310,6 +1378,7 @@ connection.on("RadioStateUpdate", function (update) {
         // on (becomes "opposite of activeVfo") but FT often doesn't move on
         // FTdx10 to trigger the TxVfo handler -- so do it here too.
         updateTxButton();
+        publishTxState();
         if (typeof window.updateToolbarStatus === 'function') window.updateToolbarStatus('split', update.value);
     }
 


### PR DESCRIPTION
⚠️ This is experimental, confirmed to work with a FTDX10 on MacOS :)

# Native remote audio (browser ↔ radio USB) + optional HTTPS

Tl,DR: This PR provides audio streaming to YWC, removing the requirement to fiddle with mumble or sonobus.
 It was designed to be as frictionless as possible, 
To test it in its current state: 
1. https needs to be enabled (is needed for the mic), the user can generate a self signed certificate in the settings
2. user must select the audio in and out interfaces for the radio in the settings
3.  Allow the browser to access the mic
4. Click Start Audio

## Summary

Adds **in-browser send/receive audio** so a remote operator on LAN/VPN can operate SSB without Mumble/SonoBus. Built on top of `feature/macos-and-linux-build` (this MR is **audio/HTTPS only** — no platform/Docker changes).

- **Remote Audio bridge:** PortAudio host I/O ↔ dedicated `/audio` WebSocket ↔ browser mic/speakers (PCM16 preferred; Opus via Concentus / WebCodecs when negotiated).
- **Settings:** opt-in Remote Audio section with radio RX (capture) / TX (playback) device pickers and gains; devices open only while a session is active.
- **Single session:** second browser is rejected busy; PTT stays on existing CAT TX controls.
- **Optional self-signed HTTPS:** generate cert in Settings, dual-listen HTTP + HTTPS after restart — required for remote `getUserMedia` (secure context).
- **Docs:** USER_MANUAL §6.2 / §6.8 / §18 and FAQ §15.7 updated.
<img width="895" height="77" alt="image" src="https://github.com/user-attachments/assets/92b4a769-234c-4d91-992b-28e7ef449cb8" />
<img width="1708" height="568" alt="image" src="https://github.com/user-attachments/assets/cdfb363a-a792-4cde-84c7-a54d13aa0714" />


### Notable code

| Area | Change |
|------|--------|
| `Services/Audio/*` | Bridge, PortAudio enumeration, Opus codec, wire protocol, HTTPS cert helper |
| `Controllers/AudioController.cs` | `/api/audio/devices`, status, cert generate |
| `Program.cs` | WebSockets `/audio`; Kestrel dual-bind when HTTPS enabled |
| `Pages/Settings.cshtml` | Remote Audio + HTTPS UI |
| `Pages/Index.cshtml` + `wwwroot/js/audio/*` | Start/Stop bar, mute, levels |
| `Models/ApplicationSettings.cs` | `AudioStreaming*`, `Https*` settings |
| `USER_MANUAL.md` | Remote audio setup, MOD SOURCE, TLS/VPN troubleshooting |

## Test plan

- [x] `dotnet build -f net10.0` and `-f net10.0-windows` succeed
- [x] Settings → Remote Audio: enable; RX/TX device lists populate (Refresh works); Save persists
- [x] Index Remote Audio bar appears only when enabled; Start prompts for mic; RX audible; TX meter moves when speaking
- [x] CAT TX button / toggle still keys the radio independently of the audio stream
- [x] Second browser Start audio → busy / rejected
- [x] Disable Remote Audio → bar hidden; no PortAudio devices held
- [x] HTTPS: Generate cert with SAN (LAN/WG IP); Enable HTTPS; Save; **restart**; open `https://…:8443`; accept warning; Start audio works remotely
- [x] Radio MOD SOURCE = USB/REAR; confirm TX audio modulates when keyed
- [ ] Voice Control mic (Windows) remains independent of radio USB device pickers
- [x] Diff vs `feature/macos-and-linux-build` contains only audio/HTTPS files (no Docker/macOS tray churn)
