### PR TITLE
Docs: alternative layouts become skins, not separate Razor pages (ADR 0004)

### DIFF
--- a/Plan.md
+++ b/Plan.md
@@ -139,20 +139,38 @@ MR/MW (full channel read/write) are deferred — they may already be in the memo
 
 ---
 
-## Phase 7 — SP3L Alternative GUI Layout *(Jacek SP3L — issue [#48](https://github.com/mm5agm/Yaesu_Web_Control/issues/48), PARKED)*
+## Phase 7 — Skins: switchable layouts from one set of markup *(issue [#48](https://github.com/mm5agm/Yaesu_Web_Control/issues/48), UNPARKED 2026-08-06)*
 
-**Status: blocked — waiting for Jacek to answer the spectrum placement question.**
+**Status: unblocked, not yet started. Sequenced after the IWC build — see "Sequencing" below.**
 
-Colin asked in the issue thread: *"Where would the SDR spectrum displays go?"* Jacek has not yet replied. Do not start implementation until that question has an answer, because the answer changes the layout fundamentally (spectrum below VFOs = tall scroll on 1080p; spectrum hidden behind toggle = layout only serves SDR-less users; spectrum replaces meter strip when enabled = different again).
+**Read [ADR 0004](docs/decisions/0004-skins-not-per-layout-pages.md) before touching this phase.** The mechanism agreed with Jacek — a second Razor page per layout — was **superseded on 2026-08-06**. Three layouts (Classic, SP3L, Fabio's) would have meant adding every control three times, fixing every bug three times, and writing every `data-a11y-key` three times. Alternative layouts are now **skins**.
 
-**What is agreed:**
+**The blocker is gone.** This phase was parked waiting for Jacek to answer *"where would the SDR spectrum displays go?"*, which he never did. Fabio Valente's prototype in [PR #93](https://github.com/mm5agm/Yaesu_Web_Control/pull/93) answers it with working desktop, tablet and mobile layouts.
 
-- A second Razor page (e.g. `IndexSp3l.cshtml`) plus a companion CSS file. All existing JS and C# control logic reused as-is — no new backend work.
-- User picks the layout in **Settings** via a new "GUI Layout" dropdown. Options: *Classic* (current) / *SP3L*.
-- The Settings dropdown label for Jacek's layout: **SP3L**.
-- A `feature/jacek-gui` branch already exists and has the Settings dropdown skeleton in place.
+**What a skin is (the mechanism — ADR 0004 has the full reasoning):**
 
-**What is agreed on the layout itself:**
+- **One set of markup, shared by every skin.** Every control declared exactly once. No per-skin HTML.
+- **A skin is a stylesheet.** Each control group is a named CSS grid area declared once in the shared markup; a skin supplies its own `grid-template-areas` plus colour/typography tokens.
+- **Hiding a control group is CSS**, not conditional Razor rendering.
+- **No per-skin Razor partial. This is absolute** — it is the loophole that reintroduces the duplication the decision exists to prevent.
+- **The current `Index.cshtml` arrangement becomes the default skin.** Skin zero, not privileged.
+- **Known limit, accepted:** CSS can move a control anywhere on the page but not into a different parent. Skins constrain layout freedom; that is the price of the maintenance property.
+
+**What is unchanged from what Jacek was promised** — the user-facing surface is identical, only the mechanism behind it differs:
+
+- User picks the layout in **Settings** via a "GUI Layout" dropdown. Options: *Classic* (current) / *SP3L* / others as they arrive.
+- The Settings dropdown label for Jacek's layout stays **SP3L**.
+- The `feature/jacek-gui` branch's Settings-dropdown skeleton is still useful; the rest of that branch's premise (a second Razor page) is not.
+
+**Sequencing — IWC first.** Build the skin mechanism in IWC (`docs/design/iwc-clone-split-plan.md` Phase 7, where the design already lives), then port to YWC. IWC has no contributors working in it, so the ~4,500-line `Index.cshtml` refactor cannot collide; YWC has three open PRs (#90, #92, #93) all touching `Index.cshtml`, `Settings.cshtml` and `site.js`. Layout-independent work — notably **keyboard shortcuts**, which are also a screen-reader path — can proceed in YWC meanwhile.
+
+**Open question:** is responsive (desktop/tablet/mobile) behaviour a property of each skin, carried by media queries inside every skin stylesheet, or a separate axis? Put to Fabio in the PR #93 thread; not yet answered.
+
+**Accessibility is a condition, not a preference.** A skin offered in the Settings dropdown or made default must carry its `data-a11y-key` attributes — voice control and screen-reader labelling exist for partially-sighted operators and regressions are release blockers. An experimental skin behind a flag and unlisted in Settings may ship without them if labelled as such.
+
+**The first two skins** are Jacek's layout (SP3L) and Fabio's. A high-contrast large-print skin for partially-sighted operators is wanted early, and under this mechanism is a stylesheet rather than a project.
+
+**What is agreed on Jacek's layout itself:**
 
 - Two panels per radio: **VFO-A** and **VFO-B** (not MAIN/SUB/VFO-A/VFO-B — MAIN≡VFO-A and SUB≡VFO-B on the FTdx101 family; on single-receiver radios one panel goes grey as per R1–R12).
 - A **global strip** at the bottom: Frequency Lock, RF Gain, AF Gain, BK-IN. On the FTdx101 family RF/AF Gain are per-panel (inside each VFO panel), not in the global strip.
@@ -161,17 +179,20 @@ Colin asked in the issue thread: *"Where would the SDR spectrum displays go?"* J
 
 **What still needs deciding before code starts:**
 
-1. **Spectrum placement** — Jacek's answer needed (see above).
-2. **"Button OFF" semantics** — does pressing a control button to OFF mean "send the radio's default value" (active write) or "this YWC panel stops tracking / go configure from front panel" (read-only handoff)? Needs resolution for IF Width and similar always-on controls.
-3. **Low Cut / Audio Filter** — in the current layout these are per-mode parameters accessed via the Audio Filter popout (EX commands). Jacek's mockup removed Low Cut. Needs a placement decision for the SP3L layout.
+1. ~~**Spectrum placement**~~ — **resolved.** Fabio's PR #93 screenshots answer it. Confirm the final choice against his layout rather than re-opening the question with Jacek.
+2. **"Button OFF" semantics** — does pressing a control button to OFF mean "send the radio's default value" (active write) or "this YWC panel stops tracking / go configure from front panel" (read-only handoff)? Needs resolution for IF Width and similar always-on controls. Skin-independent — it is a behaviour question, not a layout one.
+3. **Low Cut / Audio Filter** — in the current layout these are per-mode parameters accessed via the Audio Filter popout (EX commands). Jacek's mockup removed Low Cut. Under skins this becomes a control-manifest question: which skins show the group, which collapse it.
+4. **Responsive axis** — skin-carried media queries, or a separate axis? Put to Fabio, unanswered.
 
-**When unblocked, implementation order:**
+**Implementation order (revised for skins — supersedes the second-page order):**
 
-1. Finalise layout spec with Jacek (close open questions above).
-2. Create `Pages/IndexSp3l.cshtml` + `wwwroot/css/sp3l.css` — static HTML structure only, no JS yet.
-3. Wire Settings dropdown to switch the active layout (store choice in `appsettings.user.json`; serve `IndexSp3l` from `/` when SP3L is selected).
-4. Port all existing JS initialisation and SignalR handlers to work against the SP3L DOM.
-5. Test on FTdx101MP and FTdx10 (single-receiver grey-panel behaviour must match R1–R12 spec).
+1. **Build the mechanism in IWC first** and prove it there. Do not start in YWC while #90, #92 and #93 are open against `Index.cshtml`.
+2. Port to YWC: refactor `Pages/Index.cshtml` so every control group is a named CSS grid area, declared once. This is the bulk of the work (~4,500 lines). No behaviour change — the default skin must look identical to today when finished.
+3. Extract the current look into `wwwroot/css/skins/classic.css` as skin zero.
+4. Wire the Settings "GUI Layout" dropdown to the active skin (store choice in `appsettings.user.json`, apply via a class or attribute on the page root — **not** by serving a different Razor page). The `feature/jacek-gui` skeleton covers most of this.
+5. Add `sp3l.css` and Fabio's skin as stylesheets. No new Razor, no new JS init, no per-skin SignalR wiring — the DOM is the same DOM.
+6. Verify `data-a11y-key` coverage once, in the shared markup, and confirm voice control and screen-reader labels work in every listed skin.
+7. Test on FTdx101MP and FTdx10 (single-receiver grey-panel behaviour must match R1–R12 spec).
 
 ---
 
@@ -217,5 +238,5 @@ Colin asked in the issue thread: *"Where would the SDR spectrum displays go?"* J
 | 4 | SC | 2 | Scan button + mode popout | ~1 day |
 | 5 | MC, MA, MB, CH | 4 | CH step buttons, →VFO buttons | ~half day |
 | 6 | BY, PB, KM, KC, AB/BA, PS | 8 | Minor per-feature additions | ~pick & mix |
-| 7 | *(no CAT commands)* | 0 new | SP3L alternative GUI layout | ~1 week — **PARKED** pending Jacek's spectrum answer |
+| 7 | *(no CAT commands)* | 0 new | Skins — switchable layouts from one markup (see [ADR 0004](docs/decisions/0004-skins-not-per-layout-pages.md)) | Mechanism first in IWC, then port. `Index.cshtml` refactor is the bulk — **not** ~1 week |
 | 8 | *(no CAT commands)* | 0 new | Voice control v2 improvements | **WAITING** — v1 shipped in pre-release, no tester feedback yet |

--- a/Plan.md
+++ b/Plan.md
@@ -162,9 +162,9 @@ MR/MW (full channel read/write) are deferred — they may already be in the memo
 - The Settings dropdown label for Jacek's layout stays **SP3L**.
 - The `feature/jacek-gui` branch's Settings-dropdown skeleton is still useful; the rest of that branch's premise (a second Razor page) is not.
 
-**Sequencing — IWC first.** Build the skin mechanism in IWC (`docs/design/iwc-clone-split-plan.md` Phase 7, where the design already lives), then port to YWC. IWC has no contributors working in it, so the ~4,500-line `Index.cshtml` refactor cannot collide; YWC has three open PRs (#90, #92, #93) all touching `Index.cshtml`, `Settings.cshtml` and `site.js`. Layout-independent work — notably **keyboard shortcuts**, which are also a screen-reader path — can proceed in YWC meanwhile.
+**Sequencing — IWC first.** Build the skin mechanism in IWC (`docs/design/iwc-clone-split-plan.md` Phase 7, where the design already lives), then port to YWC. IWC has no contributors working in it, so the ~4,500-line `Index.cshtml` refactor cannot collide; YWC has two open draft PRs (#90, #92) touching `Index.cshtml`, `Settings.cshtml` and `site.js`. (#93 was a third until its author closed it on 2026-08-06 — it was a concept spike, never a merge request.) Layout-independent work — notably **keyboard shortcuts**, which are also a screen-reader path — can proceed in YWC meanwhile.
 
-**Open question:** is responsive (desktop/tablet/mobile) behaviour a property of each skin, carried by media queries inside every skin stylesheet, or a separate axis? Put to Fabio in the PR #93 thread; not yet answered.
+**Open question:** is responsive (desktop/tablet/mobile) behaviour a property of each skin, carried by media queries inside every skin stylesheet, or a separate axis? Put to Fabio in the PR #93 thread; unanswered there, and #93 is now closed — he said he would follow up by email, so **the answer will not appear in this repo unless it is copied back in.**
 
 **Accessibility is a condition, not a preference.** A skin offered in the Settings dropdown or made default must carry its `data-a11y-key` attributes — voice control and screen-reader labelling exist for partially-sighted operators and regressions are release blockers. An experimental skin behind a flag and unlisted in Settings may ship without them if labelled as such.
 
@@ -182,11 +182,11 @@ MR/MW (full channel read/write) are deferred — they may already be in the memo
 1. ~~**Spectrum placement**~~ — **resolved.** Fabio's PR #93 screenshots answer it. Confirm the final choice against his layout rather than re-opening the question with Jacek.
 2. **"Button OFF" semantics** — does pressing a control button to OFF mean "send the radio's default value" (active write) or "this YWC panel stops tracking / go configure from front panel" (read-only handoff)? Needs resolution for IF Width and similar always-on controls. Skin-independent — it is a behaviour question, not a layout one.
 3. **Low Cut / Audio Filter** — in the current layout these are per-mode parameters accessed via the Audio Filter popout (EX commands). Jacek's mockup removed Low Cut. Under skins this becomes a control-manifest question: which skins show the group, which collapse it.
-4. **Responsive axis** — skin-carried media queries, or a separate axis? Put to Fabio, unanswered.
+4. **Responsive axis** — skin-carried media queries, or a separate axis? Put to Fabio, unanswered; now moved to email with the closure of #93, so it needs chasing rather than waiting for.
 
 **Implementation order (revised for skins — supersedes the second-page order):**
 
-1. **Build the mechanism in IWC first** and prove it there. Do not start in YWC while #90, #92 and #93 are open against `Index.cshtml`.
+1. **Build the mechanism in IWC first** and prove it there. Do not start in YWC while #90 and #92 are open against `Index.cshtml`.
 2. Port to YWC: refactor `Pages/Index.cshtml` so every control group is a named CSS grid area, declared once. This is the bulk of the work (~4,500 lines). No behaviour change — the default skin must look identical to today when finished.
 3. Extract the current look into `wwwroot/css/skins/classic.css` as skin zero.
 4. Wire the Settings "GUI Layout" dropdown to the active skin (store choice in `appsettings.user.json`, apply via a class or attribute on the page root — **not** by serving a different Razor page). The `feature/jacek-gui` skeleton covers most of this.

--- a/docs/decisions/0004-skins-not-per-layout-pages.md
+++ b/docs/decisions/0004-skins-not-per-layout-pages.md
@@ -1,0 +1,146 @@
+# ADR 0004 — Alternative layouts are skins (one markup, CSS only), not separate Razor pages
+
+**Status:** ACCEPTED — 2026-08-06
+**Decision-makers:** Colin (MM5AGM)
+**Driven by:** [Issue #48](https://github.com/mm5agm/Yaesu_Web_Control/issues/48) (Jacek SP3L) — re-arrangement of the controls in the YWC GUI; and [PR #93](https://github.com/mm5agm/Yaesu_Web_Control/pull/93) (Fabio Valente) — UI experimentation
+**Supersedes:** the layout mechanism agreed in `Plan.md` Phase 7 ("SP3L Alternative GUI Layout")
+
+---
+
+## Context
+
+Two separate people have now asked for a different arrangement of the YWC home page.
+
+**Jacek SP3L** opened issue #48 in June 2026. The design agreed with him — recorded in
+`Plan.md` Phase 7 — was:
+
+> A second Razor page (e.g. `IndexSp3l.cshtml`) plus a companion CSS file. All existing
+> JS and C# control logic reused as-is — no new backend work. User picks the layout in
+> **Settings** via a new "GUI Layout" dropdown. Options: *Classic* (current) / *SP3L*.
+
+A `feature/jacek-gui` branch was created carrying the Settings-dropdown skeleton. The
+phase then **parked**, blocked on one unanswered question — *"where would the SDR
+spectrum displays go?"* — which Jacek did not come back on.
+
+**Fabio Valente** then, in August 2026 and without knowing Phase 7 existed, built
+`Pages/UiV2.cshtml` (1,318 lines) plus `wwwroot/css/ui-v2.css` (805 lines) as a draft in
+PR #93 — independently arriving at **exactly the agreed mechanism**: a second Razor page,
+a companion stylesheet, and a Settings switch. His screenshots also answer Jacek's
+spectrum-placement question, which unblocks the phase.
+
+So the second-page approach is not a contributor's misstep. It is what this project had
+already committed to, and two people reached it independently. It is being changed
+anyway, for one reason.
+
+## The problem with the agreed design
+
+Two layouts is tolerable. Three is not.
+
+With Classic, SP3L and Fabio's layout each being its own Razor page, **every new control
+must be added three times, every bug fixed three times, and every `data-a11y-key`
+accessibility attribute written three times.** They then drift apart, because in practice
+one of the three gets updated and the others do not. YWC is maintained by one person.
+
+ADR 0003 already predicted this cost, in its Consequences section, when it split the home
+page by receiver class:
+
+> **Negative:** Two distinct layouts to maintain. Future per-control changes need to be
+> applied to both unless we factor common pieces into shared partials.
+
+That warning is now being acted on rather than repeated a third time.
+
+There is a specific and non-negotiable version of the problem. Voice control and
+screen-reader labelling exist in these apps for **partially-sighted operators**;
+regressions in them are release blockers. Labels bind strictly on `data-a11y-key`
+attributes in the markup. N copies of the markup means N chances to omit the attribute,
+and the failure is silent — the control simply stops being reachable by voice or by a
+screen reader, with nothing to indicate it.
+
+## Decision
+
+**Alternative layouts are implemented as *skins*. A skin is CSS.**
+
+1. **One set of markup, shared by every skin.** Every control is declared exactly once,
+   in one place. There is no per-skin HTML.
+
+2. **A skin repositions; it does not re-declare.** Each control group is a named CSS grid
+   area, declared once in the shared markup. A skin is a stylesheet supplying its own
+   `grid-template-areas`, plus token values for colour and typography.
+
+3. **The control manifest is visibility, expressed in CSS.** Groups a skin does not want
+   are hidden by that skin's stylesheet. They are **not** conditionally un-rendered in
+   Razor, because conditional rendering fragments the markup again by another route.
+
+4. **There is no per-skin Razor partial, and this is absolute.** The IWC Phase 7 sketch
+   from which this design is drawn offered *"a CSS-grid `grid-template` **and/or** a
+   per-skin Razor partial"*. **The Razor-partial half of that is deleted.** It is the
+   loophole that reintroduces the exact N-way duplication this ADR exists to prevent.
+   Any future proposal to add one is a proposal to abandon this decision, and should be
+   treated as such.
+
+5. **The current `Index.cshtml` arrangement becomes the default skin.** It is not
+   privileged; it is skin zero.
+
+6. **The user-facing surface is unchanged from what Jacek was promised** — a "GUI Layout"
+   dropdown in Settings, with named options. Only the mechanism behind it changes. The
+   Settings-dropdown skeleton on `feature/jacek-gui` remains useful; the rest of that
+   branch's premise does not.
+
+Adding a control after this lands costs: the markup once, a `grid-area` name, and one
+line in each skin's area map. Fixing a bug costs once.
+
+## Consequences
+
+**Positive:**
+
+- One place to add a control, one place to fix a bug, one place for each
+  `data-a11y-key`. The accessibility failure mode above becomes structurally impossible
+  rather than merely discouraged.
+- Skins cost roughly a stylesheet each, so a fourth and fifth are cheap. Under the old
+  design each new layout was a new page and a permanent tax on every future change.
+- The CSS-custom-property token layer this needs is the same foundation the long-planned
+  dark-mode / high-contrast work needs. It gets built once.
+- A high-contrast, large-print skin for partially-sighted operators becomes a stylesheet
+  rather than a project.
+
+**Negative — accepted knowingly:**
+
+- **CSS can move a control anywhere on the page, but not into a different parent.** If a
+  skin wants a control nested somewhere the shared markup does not put it, the skin
+  cannot express it. Contributors' layout freedom is genuinely constrained; this is the
+  price of the maintenance property, and it is being paid deliberately.
+- **The one-off refactor is large.** `Index.cshtml` is ~4,500 lines. Getting every
+  control into a named grid area is the bulk of the work and is not a weekend.
+- **Most of the markup in PR #93 will be discarded.** Fabio's design survives — the
+  arrangement, the panel grouping, the promote/bury decisions, the tablet and mobile
+  work. His 1,318 lines of HTML do not. He was told this directly in the PR thread on
+  2026-08-06, before investing further.
+- **Responsive behaviour is not yet settled.** Whether a responsive breakpoint is a
+  property of each skin (media queries inside every skin stylesheet) or a separate axis
+  is an open question, put to Fabio in the same thread.
+
+## Sequencing
+
+Build the mechanism in **IWC first**, then port to YWC.
+
+- The design already lives in IWC (`docs/design/iwc-clone-split-plan.md`, Phase 7).
+- IWC has no contributors working in it, so a 4,500-line refactor of `Index.cshtml`
+  cannot collide with anyone. YWC currently has three open PRs (#90, #92, #93) all
+  touching `Index.cshtml`, `Settings.cshtml` and `site.js`.
+- IWC → YWC is the established direction of travel; `docs/design/` already holds five
+  `*-port-from-iwc.md` documents.
+
+Work that is layout-independent and survives the refactor untouched can proceed in YWC
+meanwhile — notably keyboard shortcuts, which are also a screen-reader path.
+
+## Related decisions and references
+
+- [`Plan.md`](../../Plan.md) Phase 7 — rewritten in the same change as this ADR
+- [ADR 0003](0003-single-vs-dual-receiver-ui.md) — predicted the two-layout maintenance
+  cost that this ADR acts on
+- [Issue #48](https://github.com/mm5agm/Yaesu_Web_Control/issues/48) — Jacek SP3L's
+  original request
+- [PR #93](https://github.com/mm5agm/Yaesu_Web_Control/pull/93) — Fabio Valente's
+  prototype, and the thread where this decision was explained to him
+- IWC `docs/design/iwc-clone-split-plan.md` Phase 7 — the skin design this adopts, minus
+  its per-skin-Razor-partial option

--- a/docs/decisions/0004-skins-not-per-layout-pages.md
+++ b/docs/decisions/0004-skins-not-per-layout-pages.md
@@ -28,6 +28,15 @@ PR #93 — independently arriving at **exactly the agreed mechanism**: a second 
 a companion stylesheet, and a Settings switch. His screenshots also answer Jacek's
 spectrum-placement question, which unblocks the phase.
 
+PR #93 was **never a merge request**, and its author closed it on 2026-08-06 saying so:
+*"this MR was never meant to be merged, but instead share some concepts… hence the whole
+separate stack for the UI, to leave the existing one as is/unaffected."* That is worth
+recording precisely, because it makes the evidence stronger rather than weaker. Nobody
+asked him to pick a mechanism, and nothing was riding on the one he picked — a second
+Razor page is simply what an experienced developer reaches for when exploring an
+alternative layout in this codebase as it stands today. The pull request is closed; the
+observation it produced is not.
+
 So the second-page approach is not a contributor's misstep. It is what this project had
 already committed to, and two people reached it independently. It is being changed
 anyway, for one reason.
@@ -111,10 +120,12 @@ line in each skin's area map. Fixing a bug costs once.
   price of the maintenance property, and it is being paid deliberately.
 - **The one-off refactor is large.** `Index.cshtml` is ~4,500 lines. Getting every
   control into a named grid area is the bulk of the work and is not a weekend.
-- **Most of the markup in PR #93 will be discarded.** Fabio's design survives — the
+- **The markup in PR #93 is not carried forward.** Fabio's design survives — the
   arrangement, the panel grouping, the promote/bury decisions, the tablet and mobile
-  work. His 1,318 lines of HTML do not. He was told this directly in the PR thread on
-  2026-08-06, before investing further.
+  work. His 1,318 lines of HTML do not. He was told this in the PR thread on 2026-08-06,
+  before investing further, and closed the PR the same day as a concept spike that had
+  served its purpose. So no contributed work is being rejected here; the cost is that
+  a future skin contributor cannot hand over a page, only a layout.
 - **Responsive behaviour is not yet settled.** Whether a responsive breakpoint is a
   property of each skin (media queries inside every skin stylesheet) or a separate axis
   is an open question, put to Fabio in the same thread.
@@ -141,6 +152,8 @@ meanwhile — notably keyboard shortcuts, which are also a screen-reader path.
 - [Issue #48](https://github.com/mm5agm/Yaesu_Web_Control/issues/48) — Jacek SP3L's
   original request
 - [PR #93](https://github.com/mm5agm/Yaesu_Web_Control/pull/93) — Fabio Valente's
-  prototype, and the thread where this decision was explained to him
+  prototype, and the thread where this decision was explained to him. **Closed** on
+  2026-08-06 by its author as a concept spike; GitHub keeps the diff and the screenshots,
+  so it stays readable as the design input this ADR treats it as.
 - IWC `docs/design/iwc-clone-split-plan.md` Phase 7 — the skin design this adopts, minus
   its per-skin-Razor-partial option


### PR DESCRIPTION
Records the layout decision made on 2026-08-06 and already explained to Fabio in [PR #93](https://github.com/mm5agm/Yaesu_Web_Control/pull/93#issuecomment-5206113555). Documentation only — no code changes.

## Why

`Plan.md` Phase 7 had agreed a **second Razor page per layout** (`IndexSp3l.cshtml` + companion CSS, chosen by a Settings dropdown) with Jacek SP3L on issue #48. Fabio then independently built the same pattern in PR #93 — `UiV2.cshtml`, 1,318 lines, plus `ui-v2.css`.

Three layouts — Classic, SP3L, Fabio's — means adding every control three times, fixing every bug three times, and writing every `data-a11y-key` three times. ADR 0003 predicted exactly this cost when it split the home page by receiver class. Accessibility makes it worse than tedious: labels bind strictly on `data-a11y-key`, and an omitted attribute fails silently, taking the control out of reach of voice control and screen readers with no visible sign.

## What changes

**Layouts become skins.** One set of markup shared by all of them; each control group a named CSS grid area declared once; each skin a stylesheet supplying its own `grid-template-areas` plus colour tokens. Hiding a group is CSS, not conditional Razor.

**No per-skin Razor partial.** The IWC design this is drawn from offered a grid template *and/or* a per-skin partial. The partial half is deleted explicitly — it is the loophole that reintroduces the duplication.

**Nothing changes for Jacek.** He was promised a "GUI Layout" dropdown in Settings with his option labelled SP3L, and that is still exactly what he gets. Only the mechanism behind it differs. The `feature/jacek-gui` dropdown skeleton stays useful.

**Phase 7 is unparked.** It was blocked on Jacek's unanswered *"where would the SDR spectrum displays go?"*. Fabio's screenshots answer it.

## Accepted costs, written down

- CSS can move a control anywhere on the page but **not into a different parent**. Skins constrain layout freedom.
- The `Index.cshtml` refactor (~4,500 lines) is the bulk of the work and is not a week.
- Most of the markup in PR #93 gets discarded. The design survives; the HTML does not. Fabio was told this before investing further.

## Sequencing

Build the mechanism in **IWC first** — the design already lives there, it has no contributors working in it, and YWC currently has three open PRs all touching `Index.cshtml`, `Settings.cshtml` and `site.js`. Keyboard shortcuts are layout-independent and can proceed here meanwhile.

## Files

- `docs/decisions/0004-skins-not-per-layout-pages.md` — new ADR
- `Plan.md` — Phase 7 rewritten, unparked, implementation order revised, summary table row updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
