### PR TITLE
Stop repeating the version in the Apps & features entry

### DIFF
--- a/installer.nsi
+++ b/installer.nsi
@@ -66,7 +66,9 @@ Section "Install"
 
     WriteUninstaller "$INSTDIR\Uninstall.exe"
 
-    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayName" "${APPNAME} ${VERSION}"
+    ; DisplayName is the name column only -- Apps & features renders DisplayVersion
+    ; in its own column beside it, so including the version here showed it twice.
+    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayName" "${APPNAME}"
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "UninstallString" "$INSTDIR\Uninstall.exe"
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "InstallLocation" "$INSTDIR"
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayIcon" "$INSTDIR\Yaesu_Web_Control.exe"


### PR DESCRIPTION
Cosmetic installer fix.

The uninstall registry entry set `DisplayName` to `"${APPNAME} ${VERSION}"` while also setting `DisplayVersion` separately, so Windows' **Apps & features** list showed the version twice — "Yaesu Web Control 2.4.3" in the Name column and "2.4.3" in the Version column beside it. `DisplayName` is now the name alone.

No version bump; nothing else in the installer changes. Spotted while doing the same fix in Icom Web Control, which inherited the line from here — that PR is [mm5agm/Icom_Web_Control#24](https://github.com/mm5agm/Icom_Web_Control/pull/24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)