### PR TITLE
Fix the Docker build after the shared-core subtree

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,14 @@ FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS
 ARG TARGETARCH
 WORKDIR /src
 
+# Only the project files, so the restore layer stays cached across source edits.
+# core/ is the Radio_Web_Control_Core git subtree and is a ProjectReference from
+# the csproj above, so its .csproj has to be here too — restore does NOT fail on
+# a missing referenced project, it prints "Skipping project ... because it was
+# not found" and carries on, and the damage only surfaces at the publish below
+# as "NETSDK1004: Assets file '/src/core/obj/project.assets.json' not found".
 COPY Yaesu_Web_Control.csproj ./
+COPY core/RadioWebControl.Core.csproj core/
 RUN arch="$TARGETARCH"; \
     if [ "$arch" = "amd64" ]; then arch=x64; fi; \
     dotnet restore Yaesu_Web_Control.csproj -r "linux-$arch"


### PR DESCRIPTION
Follow-up to #99. Thanks @fabiojvalente for triggering the multi-platform build — that caught it.

## What broke

`build-docker` only. `build-windows` passed and `build-macos` was still running; both of those build from the whole checkout, so they picked `core/` up for free. The Dockerfile does not:

```dockerfile
COPY Yaesu_Web_Control.csproj ./
RUN dotnet restore Yaesu_Web_Control.csproj -r "linux-$arch"
COPY . .
```

That is the usual restore-layer cache trick — project files first, so editing a `.cs` does not invalidate the restore. #99 added `<ProjectReference Include="core\RadioWebControl.Core.csproj" />` without the matching `COPY`.

## Why the log is misleading

Not a checkout problem — `Checkout` succeeded in all three jobs. `dotnet restore` does not treat a missing referenced project as an error:

```
#13  Skipping project "/src/core/RadioWebControl.Core.csproj" because it was not found.
```

and exits 0. The failure lands two steps later, in a different phase, naming a file rather than the cause:

```
#16  error NETSDK1004: Assets file '/src/core/obj/project.assets.json' not found.
```

Worth knowing that the same `Skipping` line already appears for `Workers/Yaesu_Sdr_Worker` on every Linux build and is harmless — that reference is `Condition="'$(TargetFramework)' == 'net10.0-windows'"` and the image publishes `net10.0`. The core reference is deliberately unconditioned (YWC multi-targets and the Linux host needs it), so for that one the skip is fatal. The comment added to the Dockerfile says this, because whoever hits it next will be reading the publish error, not the restore.

## The fix

One line, plus the comment:

```dockerfile
COPY Yaesu_Web_Control.csproj ./
COPY core/RadioWebControl.Core.csproj core/
```

`.dockerignore` needed no change, and `COPY . .` was already bringing the core sources in for the publish itself.

## Verification

Reproduced the restore layer in isolation with only the two `.csproj` files present, which is exactly what the image sees at that point:

```
Restored .../core/RadioWebControl.Core.csproj (in 2.41 sec)
Restored .../Yaesu_Web_Control.csproj (in 2.59 sec)
core/obj/project.assets.json — exists
```

I have no Docker daemon here, so **the multi-arch image build itself is unverified locally** — I will dispatch the workflow on this branch and report back rather than claim it works.

Icom Web Control is unaffected: it is `WinExe`/`net10.0-windows` and has no Dockerfile.