### PR TITLE
Build pull requests, not just releases and dispatches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,22 @@ on:
   release:
     types: [created]
 
+  # Build every pull request into develop, so a PR arrives with a real signal
+  # instead of "no checks". Added after shared-core phase 1 (#99) merged clean
+  # and broke build-docker: nothing had run, because until now the only ways in
+  # were a release and a manual dispatch, and the manual one happened after the
+  # merge. build-docker is exactly the job that would have caught it.
+  #
+  # Nothing is published on this path. Every upload step is guarded by event
+  # name, and the docker job's push flag falls into its `else` branch on any
+  # event that is neither a release nor a dispatch carrying a tag — so a PR run
+  # gets version=smoke, push=false, the GHCR login skips and the image is built
+  # and discarded.
+  #
+  # build-macos is deliberately excluded (see its `if:`).
+  pull_request:
+    branches: [develop]
+
   workflow_dispatch:
     inputs:
       tag:
@@ -109,7 +125,16 @@ jobs:
 
   # Unsigned CAT-only .app DMGs (arm64 + x64). No Apple Developer ID / notarization.
   # workflow_dispatch with empty tag → artifacts only (safe branch smoke test).
+  #
+  # Skipped on pull requests, on wall-clock grounds rather than cost — both
+  # repos are public, so Actions minutes are free. This job builds two DMGs and
+  # routinely runs well over twenty minutes, which would leave every PR sitting
+  # "in progress" long after the answer was known. build-windows and
+  # build-docker cover the same compile in a fraction of the time, and macOS
+  # still runs on dispatch and on release. If a change is macOS-specific, hit
+  # "Run workflow" on the branch.
   build-macos:
+    if: github.event_name != 'pull_request'
     runs-on: macos-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Why

#99 merged clean and left `develop` with a broken Docker image. It was not a review miss — the PR genuinely had **no checks**, because until now the only ways into this workflow were `release: [created]` and a manual `workflow_dispatch`. GitHub presents "no checks" as nothing to look at rather than as a gap.

Thanks @fabiojvalente for dispatching the build that found it. The point of this change is that nobody should have to remember to, and that it should happen *before* the merge rather than after. `build-docker` fails on that fault in about forty seconds.

## What changed

The trigger:

```yaml
  pull_request:
    branches: [develop]
```

and one job guard:

```yaml
  build-macos:
    if: github.event_name != 'pull_request'
```

## Nothing gets published on this path

| Step | Guard | On a PR |
|---|---|---|
| Upload installer as workflow artifact | `github.event_name == 'workflow_dispatch'` | skipped |
| Upload installer / DMGs to GitHub Release | release, or dispatch with a tag | skipped |
| Log in to GHCR | `steps.prep.outputs.push == 'true'` | skipped |

That last one is worth spelling out. `Resolve version and push flag` ends with:

```bash
else
  echo "version=smoke" >> "$GITHUB_OUTPUT"
  echo "push=false" >> "$GITHUB_OUTPUT"
fi
```

A `pull_request` event is neither a release nor a dispatch carrying a tag, so it lands in that `else` — `push=false`, no GHCR login, `:latest` untouched, image built and discarded. No job needed changing to make this safe; the guards were already right.

## Why macOS is excluded

Wall-clock, not cost — the repo is public, so Actions minutes are free. `build-macos` builds two DMGs and routinely runs well over twenty minutes (the run on #100 was still going long after windows and docker had both finished). Leaving it on would mean every PR sits "in progress" long after the answer is known, which is how required checks end up being ignored. `build-windows` and `build-docker` cover the same compile far sooner.

macOS still runs on dispatch and on release, so a macOS-specific change is one "Run workflow" on the branch away. If that trade turns out wrong in practice, deleting the `if:` line puts it back.

## What this does not do

It makes the checks **visible, not mandatory**. A red X will not stop the merge button. Blocking needs a branch protection rule on `develop` marking the checks required — a repo setting rather than anything in this file, and a separate decision, since it also changes how you merge under time pressure during a release.

## Verification

YAML parses and resolves as intended:

```
triggers: ['release', 'pull_request', 'workflow_dispatch']
pull_request branches: ['develop']
  build-windows: runs-on=windows-latest  if=(none)
  build-macos:   runs-on=macos-latest    if=github.event_name != 'pull_request'
  build-docker:  runs-on=ubuntu-latest   if=(none)
```

**This PR is its own test** — `pull_request` runs use the workflow file from the PR. If it works, `build-windows` and `build-docker` appear below and `build-macos` does not.

Companion PR in Icom Web Control (single Windows job, no macOS exclusion needed).