### PR TITLE
Fail the macOS job fast when the runner stalls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,15 +127,29 @@ jobs:
   # workflow_dispatch with empty tag → artifacts only (safe branch smoke test).
   #
   # Skipped on pull requests, on wall-clock grounds rather than cost — both
-  # repos are public, so Actions minutes are free. This job builds two DMGs and
-  # routinely runs well over twenty minutes, which would leave every PR sitting
-  # "in progress" long after the answer was known. build-windows and
-  # build-docker cover the same compile in a fraction of the time, and macOS
-  # still runs on dispatch and on release. If a change is macOS-specific, hit
-  # "Run workflow" on the branch.
+  # repos are public, so Actions minutes are free. build-windows and
+  # build-docker cover the same compile, and macOS still runs on dispatch and
+  # on release. If a change is macOS-specific, hit "Run workflow" on the branch.
+  #
+  # timeout-minutes exists because this job can stall indefinitely. Observed
+  # three times on 2026-08-13: build-dmg.sh runs two sequential publishes, and
+  # the FIRST RID finished in under a minute while the SECOND stopped dead
+  # straight after restore and never recovered — 36, 38 and 54 minutes before
+  # being cancelled, with an orphaned dotnet/VBCSCompiler killed at cleanup.
+  # Not our code: it reproduced on tag v2.4.3-pre6, which has no core/ subtree
+  # in it at all and had built both DMGs in 1m50s three days earlier. Hosted
+  # arm64 macOS runners, nothing in this repo.
+  #
+  # Why a timeout and not a retry: these jobs are independent — no `needs:` —
+  # so a stalled macOS job does not hold up build-windows or build-docker, and
+  # on a release that is the trap. The tag ships with the Windows installer and
+  # the Docker image while the DMGs never upload, and the release looks
+  # finished. Failing at 20 minutes (~10x the 1m50s normal, so a merely slow
+  # runner won't trip it) makes that visible instead of silent.
   build-macos:
     if: github.event_name != 'pull_request'
     runs-on: macos-latest
+    timeout-minutes: 20
     permissions:
       contents: write
 


### PR DESCRIPTION
Adds `timeout-minutes: 20` to `build-macos`, and corrects a comment I got wrong in #101.

### The problem

`build-macos` had no `timeout-minutes`, so it inherits the **6-hour** default. That matters more than it looks, because the three jobs are **independent** — there is no `needs:` between them, so `build-windows` and `build-docker` complete regardless of what macOS is doing.

On a release that is the trap: the tag goes out with the Windows installer and the Docker image, the DMGs never upload, and **the release looks finished**. Nothing turns red until six hours later.

### What was actually happening

`build-dmg.sh all` publishes two RIDs in sequence. Three runs on 2026-08-13, all identical: the **first** RID finished in under a minute, and the **second** stopped dead immediately after restore and never recovered.

```
17:29:54  ==> Publishing self-contained osx-arm64
17:30:44    created: ..._macos-arm64.dmg
17:30:45  OK                                  <- 51 seconds, fine

17:30:45  ==> Publishing self-contained osx-x64
17:30:48    Restored Yaesu_Web_Control.csproj (in 1.76 sec)
          -- nothing at all, 36 minutes --
18:06:38  ##[error]The operation was canceled.
          Terminate orphan process: pid (2543) (dotnet)
```

Stalls were 36, 38 and 54 minutes before I cancelled them; one also left an orphaned `VBCSCompiler` to be killed at cleanup. Restore is consistently instant (1.3–1.8 s) — it is the compile that never progresses.

### It is not the `core/` subtree

Worth stating plainly, since the shared core landed the same morning and the timing looked damning. It is not the cause:

- It reproduced on tag **`v2.4.3-pre6`**, which has **no `core/` in it at all** — `git cat-file -e v2.4.3-pre6:core` fails, and that run's log shows only two `Restored` lines, no `RadioWebControl.Core`.
- That same tag built **both** DMGs in **1m50s on 2026-08-10**.
- The identical two-pass sequence (arm64 then x64, same tree, reusing `core/bin`) runs in **11s + 8s** on Windows.

Same workflow, same script, same commit that worked three days earlier. The only variable left is the runner, so this is hosted arm64 macOS being unwell and there is nothing in this repo to fix.

### Why a timeout rather than a retry or a `needs:`

A retry would just stall twice. Adding `needs:` so macOS gates the others would make every release slower and would trade a silent partial release for a fully blocked one — worse, not better, when the underlying fault is transient infrastructure. A timeout leaves the parallelism alone and only changes how a stall *presents*: a red X at 20 minutes instead of silence for six hours.

### Also in here

The comment I added above this job in #101 said the job *"routinely runs well over twenty minutes"*. That was written from the stalled runs and is wrong — it normally takes **1m50s for both DMGs**. Corrected, with the real numbers and the evidence recorded inline so the next person to see a stall doesn't re-investigate it from scratch.

### @fabiojvalente — one thing for you

**Is 20 minutes the right number?** I picked it as roughly 10× the 1m50s normal, so a merely slow runner won't trip it while a genuine stall fails fast. You know the macOS build better than I do, and you build DMGs locally where I don't — if you've seen legitimate runs take materially longer (a cold NuGet cache, a slower runner class, `hdiutil` on a big image), say so and I'll raise it. Happy to go to 30 or 40 if that's a safer margin; I'd rather not go far beyond that, since the whole point is that it fires well before six hours.

Also worth knowing for your own debugging: Actions serves **no logs at all for an in-progress job** (`BlobNotFound`, HTTP 404), so a hung job has to be cancelled before you can see where it stopped. A cancelled job's log is complete up to the moment of cancellation, which is how the trace above was obtained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
