### PR TITLE
Fail a release that is missing an asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,3 +253,71 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # The three build jobs above are independent on purpose — no `needs:` between
+  # them, so they run in parallel and a release is not held up by the slowest.
+  # The cost of that is nobody notices when one of them does not finish: the
+  # release event fires when the tag is created, each job uploads its own assets
+  # to a release that already exists, and if one never gets there the tag simply
+  # ends up short an asset. The release page looks finished. That is exactly what
+  # a stalled build-macos produced on 2026-08-13 — installer and image present,
+  # both DMGs missing, nothing red for six hours.
+  #
+  # This job is the only thing that actually checks. It runs last and in parallel
+  # with nothing, so it costs the release no wall-clock time.
+  verify-release-assets:
+    # always() matters: without it a failed or cancelled `needs` would SKIP this
+    # job, so the check would go silent in precisely the case it exists for.
+    # The event guard stays inside the same expression — a dispatch or a PR has
+    # no release to inspect.
+    if: ${{ always() && github.event_name == 'release' }}
+    needs: [build-windows, build-macos, build-docker]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check every build job succeeded
+        run: |
+          fail=0
+          for pair in "build-windows:${{ needs.build-windows.result }}" \
+                      "build-macos:${{ needs.build-macos.result }}" \
+                      "build-docker:${{ needs.build-docker.result }}"; do
+            name="${pair%%:*}"; result="${pair##*:}"
+            if [ "$result" = "success" ]; then
+              echo "OK       $name"
+            else
+              echo "::error::$name did not succeed (result: $result)"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      - name: Check the release carries every expected asset
+        # always() again, so a failed job above does not hide which assets are
+        # actually missing — both answers are more useful than either alone.
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          names="$(gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')"
+          echo "Assets on $tag:"
+          echo "$names" | sed 's/^/  /'
+          echo
+          fail=0
+          # Matched on a suffix rather than a full filename: the DMGs carry
+          # AppVersion.Current (2.4.3), which is deliberately NOT the tag on a
+          # pre-release (v2.4.3-pre6), so building the name from the tag would
+          # fail every pre-release for the wrong reason.
+          for want in 'Yaesu_Web_Control_Setup.exe' 'macos-arm64.dmg' 'macos-x64.dmg'; do
+            if printf '%s\n' "$names" | grep -q -- "$want"; then
+              echo "OK       $want"
+            else
+              echo "::error::missing from release $tag: $want"
+              fail=1
+            fi
+          done
+          # The Docker image is not a release asset — it goes to GHCR — so it is
+          # covered by build-docker's job result in the step above, not here.
+          exit $fail


### PR DESCRIPTION
Follow-up to #102. That one makes a stalled macOS job **fail** instead of hanging for six hours; this one makes a release that is **missing an asset** fail instead of looking finished.

### The gap

The three build jobs are independent on purpose — there is no `needs:` between them, so they run in parallel and a release is not held up by the slowest. The cost of that is that nothing notices when one of them doesn't finish.

The `release` event fires when the tag is **created**, so the release object already exists; each job then uploads its own assets to it with `gh release upload`. A job that never gets there just leaves the tag short an asset. There is no step anywhere that looks at the finished release and asks whether it is complete.

On 2026-08-13 that produced exactly the bad outcome in a dispatch run: `build-windows` and `build-docker` both green, `build-macos` stalled for two hours, and nothing red. Had that been a real release, the tag would carry the installer and the GHCR image with **both DMGs silently absent**.

### What this adds

```yaml
verify-release-assets:
  if: ${{ always() && github.event_name == 'release' }}
  needs: [build-windows, build-macos, build-docker]
```

Two checks, and it reports both rather than stopping at the first:

1. **Every job reported `success`** — this is what covers the Docker image, which is not a release asset at all (it goes to GHCR), so there is nothing to look up on the release page.
2. **The release actually carries** `Yaesu_Web_Control_Setup.exe`, `…macos-arm64.dmg` and `…macos-x64.dmg`.

It runs last, in parallel with nothing, so it adds no wall-clock time to a release. Only on a `release` event — a dispatch or a PR has no release to inspect.

### Two implementation details that are easy to get wrong

**`always()` is load-bearing.** A job with `needs:` is skipped by default when any of its needs fails. Without `always()`, `verify-release-assets` would be *skipped* whenever a build failed — going silent in precisely the situation it exists for, which is the worst possible failure mode for a check. The event guard is kept inside the same expression so the two conditions can't drift apart.

**Asset names are matched on a suffix, not composed from the tag.** On a pre-release the DMG carries `AppVersion.Current` while the tag does not. `v2.4.3-pre6` really shipped:

```
Yaesu_Web_Control_CAT_2.4.3_macos-arm64.dmg
Yaesu_Web_Control_CAT_2.4.3_macos-x64.dmg
Yaesu_Web_Control_Setup.exe
```

Building the expected filename from `GITHUB_REF_NAME` would look for `…CAT_v2.4.3-pre6_macos-arm64.dmg` and fail **every** pre-release for the wrong reason. Matching `macos-arm64.dmg` sidesteps the version-vs-tag question entirely.

### Verification

The YAML parses and the job graph is as intended. Both shell blocks were run locally against representative inputs:

- one failing job among three → correct `::error::`, exit 1
- pre-release asset names, all three present → exit 0 (this is the case that proves the suffix matching)
- installer present, both DMGs missing → two errors, exit 1

Checked against the real releases too. `v2.4.3-pre6` carries all three assets and parses correctly. `v2.4.3-pre5` and `-pre4` carry only the installer, but that is **not** a historical instance of this bug — both predate #90, which added the macOS job on 2026-08-10, so there were no DMGs to miss.

This PR won't exercise the new job in its own checks: it is gated to `release` events, so a PR run sees `build-windows` and `build-docker` only. It first runs for real on the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
