### PR TITLE
ATU: visible Tune button + tuner voice commands

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -609,9 +609,23 @@
                                onchange="setProcLevel(this.value);">
                         <button id="atuBtn"
                                 class="btn btn-sm ms-2 @(Model.AtuEnabled ? "btn-success" : "btn-outline-secondary")"
+                                data-a11y-key="controls.atu"
                                 aria-label="Antenna tuner — short tap toggles on/off, long press starts auto-tune"
                                 title="Tap to toggle ATU on/off; press and hold to start auto-tune"
                                 style="touch-action: manipulation; user-select: none;">@(Model.AtuEnabled ? "ATU On" : "ATU Off")</button>
+                        @* Explicit auto-tune button. The ATU button above also
+                           starts a tune on press-and-hold, but a long press can't
+                           be announced by a screen reader or performed by voice —
+                           this gives keyboard/AT/voice users a real control. It
+                           becomes a red "Stop" while a tune cycle is running. *@
+                        <button id="atuTuneBtn"
+                                type="button"
+                                class="btn btn-sm ms-1 btn-outline-secondary"
+                                data-a11y-key="controls.atuTune"
+                                aria-label="Start antenna auto-tune"
+                                title="Start antenna auto-tune"
+                                onclick="atuTuneButtonClick()"
+                                style="touch-action: manipulation;">Tune</button>
                         <button id="monitorOnBtn"
                                 class="btn btn-sm ms-2 @(Model.MonitorOn ? "btn-warning" : "btn-outline-secondary")"
                                 aria-label="TX monitor — currently @(Model.MonitorOn ? "on" : "off")"
@@ -3312,6 +3326,45 @@
                 const onNow = btn.dataset.atuEnabled === 'true';
                 updateAtuButton(onNow);
             }
+            // Mirror the state on the dedicated Tune button: it becomes a red
+            // "Stop" while a cycle runs so the button never silently means
+            // something other than what it says. aria-label / title follow,
+            // and the idle label is preserved so a customised or translated
+            // accessible label (data-a11y-key="controls.atuTune") survives a
+            // tune cycle rather than being overwritten with a hard-coded string.
+            const tuneBtn = document.getElementById('atuTuneBtn');
+            if (tuneBtn) {
+                if (tuning) {
+                    if (!tuneBtn.dataset.idleLabel)
+                        tuneBtn.dataset.idleLabel = tuneBtn.getAttribute('aria-label') || 'Start antenna auto-tune';
+                    tuneBtn.classList.remove('btn-outline-secondary');
+                    tuneBtn.classList.add('btn-danger');
+                    tuneBtn.textContent = 'Stop';
+                    tuneBtn.setAttribute('aria-label', 'Stop antenna tuning');
+                    tuneBtn.setAttribute('title', 'Stop antenna tuning');
+                } else {
+                    const idle = tuneBtn.dataset.idleLabel || 'Start antenna auto-tune';
+                    tuneBtn.classList.remove('btn-danger');
+                    tuneBtn.classList.add('btn-outline-secondary');
+                    tuneBtn.textContent = 'Tune';
+                    tuneBtn.setAttribute('aria-label', idle);
+                    tuneBtn.setAttribute('title', idle);
+                    delete tuneBtn.dataset.idleLabel;
+                }
+            }
+        }
+
+        // Dedicated Tune button: start a tune when idle, stop the running
+        // cycle when one's in progress. Mirrors the ATU button's short-tap
+        // behaviour but as an explicit, announceable, keyboard-reachable
+        // control (the press-and-hold gesture is neither).
+        function atuTuneButtonClick() {
+            const atuBtn = document.getElementById('atuBtn');
+            if (atuBtn && atuBtn.dataset.tuning === 'true') {
+                stopAtuTune();
+            } else {
+                startAtuTune();
+            }
         }
         // Wire short-tap vs long-press behaviour. Using pointer events
         // covers mouse, touch, and pen with one code path.
@@ -4515,6 +4568,7 @@
         window.toggleAtu        = toggleAtu;
         window.startAtuTune     = startAtuTune;
         window.stopAtuTune      = stopAtuTune;
+        window.atuTuneButtonClick = atuTuneButtonClick;
         window.updateAtuButton  = updateAtuButton;
         window.updateAtuTuningState = updateAtuTuningState;
         window.toggleMonitor    = toggleMonitor;

--- a/Services/Voice/IntentDispatcher.cs
+++ b/Services/Voice/IntentDispatcher.cs
@@ -106,6 +106,9 @@ namespace Yaesu_Web_Control.Services.Voice
                     case "TxOff":             return await TxOffAsync(cancellationToken);
                     case "SplitOn":           return await SplitAsync(true, cancellationToken);
                     case "SplitOff":          return await SplitAsync(false, cancellationToken);
+                    case "AtuOn":             return await AtuAsync(true, cancellationToken);
+                    case "AtuOff":            return await AtuAsync(false, cancellationToken);
+                    case "AtuTune":           return await AtuTuneAsync(cancellationToken);
                     case "Help":              return Help();
                     case "NudgeIfWidth":      return await NudgeIfWidthAsync(parameters, cancellationToken);
                     case "SetAfGain":          return await SetAfGainAsync(parameters, cancellationToken);
@@ -420,6 +423,42 @@ namespace Yaesu_Web_Control.Services.Voice
             _state.SplitMode = on ? 1 : 0;
             _logger.LogInformation("[Voice] Split {State}", on ? "on" : "off");
             return new DispatchResult(true, on ? "Split on" : "Split off");
+        }
+
+        // -- ATU (antenna tuner) -------------------------------------------
+        // AC{P1}{P2}{P3}; per the FTdx10 / FTdx101MP CAT manual:
+        //   P3 = 0 tuner off (bypass), 1 tuner on (in line), 2 start/stop
+        //   the auto-tune cycle. Same command set across FTdx101MP / FTdx10 /
+        //   FT-710; the tuner is radio-wide, not per-VFO, so there's no VfoP1.
+        // Setting _state.AtuEnabled directly gives immediate UI feedback and
+        // broadcasts over SignalR, exactly as the HTTP /api/cat/atu endpoint
+        // does — the radio's own AC echo confirms it afterwards.
+        //
+        // The whole reason these exist: on the web UI the auto-tune was only
+        // reachable by a press-and-hold on the ATU button, which a screen
+        // reader can't announce and voice can't perform — so voice/keyboard
+        // operators had no route to the tuner at all.
+        private async Task<DispatchResult> AtuAsync(bool on, CancellationToken ct)
+        {
+            await SendCommand(on ? "AC001;" : "AC000;", ct);
+            _state.AtuEnabled = on;
+            _logger.LogInformation("[Voice] Atu {State}", on ? "on" : "off");
+            return new DispatchResult(true, on ? "Tuner on" : "Tuner off");
+        }
+
+        // AC002; toggles the auto-tune cycle (a second AC002; aborts a run).
+        // Yaesu's CAT spec fixes AC's tuning-in-progress field at 0 (unlike
+        // Icom's tuner readback), so we genuinely can't tell start from stop
+        // here — the spoken confirmation is deliberately neutral. We also
+        // don't drive the "Tuning…" button state from the voice path: nothing
+        // server-side would clear it (the page's own startAtuTune() owns the
+        // 8 s auto-clear), so a voice-started tune would otherwise leave the
+        // button stuck. The spoken confirmation is what the operator relies on.
+        private async Task<DispatchResult> AtuTuneAsync(CancellationToken ct)
+        {
+            await SendCommand("AC002;", ct);
+            _logger.LogInformation("[Voice] AtuTune (AC002;)");
+            return new DispatchResult(true, "Antenna tuning");
         }
 
         // -- IF width / AF gain nudges (query → adjust → set) --------------

--- a/Services/Voice/VoiceHelpBuilder.cs
+++ b/Services/Voice/VoiceHelpBuilder.cs
@@ -42,6 +42,9 @@ namespace Yaesu_Web_Control.Services.Voice
             ["TxOff"]            = "Stop transmitting (back to receive)",
             ["SplitOn"]          = "Turn split on",
             ["SplitOff"]         = "Turn split off",
+            ["AtuOn"]            = "Turn the antenna tuner on",
+            ["AtuOff"]           = "Turn the antenna tuner off",
+            ["AtuTune"]          = "Start an antenna auto-tune",
             ["Help"]             = "Speak a short help summary",
             ["NudgeIfWidthUp"]   = "Widen the filter",
             ["NudgeIfWidthDown"] = "Narrow the filter",
@@ -90,7 +93,10 @@ namespace Yaesu_Web_Control.Services.Voice
                 Simple("TxOn", cfg),
                 Simple("TxOff", cfg),
                 Simple("SplitOn", cfg),
-                Simple("SplitOff", cfg));
+                Simple("SplitOff", cfg),
+                Simple("AtuOn", cfg),
+                Simple("AtuOff", cfg),
+                Simple("AtuTune", cfg));
 
             Group("Status & help",
                 Simple("StatusFrequency", cfg),

--- a/Services/Voice/VoicePhraseStore.cs
+++ b/Services/Voice/VoicePhraseStore.cs
@@ -91,6 +91,10 @@ namespace Yaesu_Web_Control.Services.Voice
                 // Older files are reset to defaults rather than partially migrated.
                 if (config == null || config.Version < 7)
                     return BuildDefaults();
+                // v7 → v8+ is additive (ATU commands), so don't reset — just
+                // fill in any core command keys the older pack is missing,
+                // leaving the user's own phrases and translations untouched.
+                BackfillMissingCommands(config);
                 return config;
             }
             catch
@@ -319,9 +323,34 @@ namespace Yaesu_Web_Control.Services.Voice
             }
         }
 
+        /// <summary>
+        /// Additive upgrade for packs saved by an older build: fill in only the
+        /// SimpleCommands keys that are entirely absent (e.g. the ATU tuner
+        /// commands added in v8), using the built-in defaults. Keys the user
+        /// already has — even if they've edited or translated the phrases — are
+        /// left exactly as they are, so this never overwrites customisation.
+        /// The in-memory Version is advanced so a subsequent Save persists the
+        /// upgraded pack; the file on disk is untouched until then.
+        /// </summary>
+        private static void BackfillMissingCommands(VoicePhrasesConfig config)
+        {
+            var defaults = BuildDefaults();
+            config.SimpleCommands ??= new();
+            foreach (var (key, phrases) in defaults.SimpleCommands)
+            {
+                if (!config.SimpleCommands.ContainsKey(key))
+                    config.SimpleCommands[key] = new List<string>(phrases);
+            }
+            if (config.Version < defaults.Version)
+                config.Version = defaults.Version;
+        }
+
         public static VoicePhrasesConfig BuildDefaults() => new()
         {
-            Version = 7,
+            // v8 added the ATU tuner commands (AtuOn / AtuOff / AtuTune).
+            // Existing v7 packs aren't reset — BackfillMissingCommands adds
+            // just the new keys on load so a user's customisations survive.
+            Version = 8,
             SimpleCommands = new()
             {
                 ["SwapVFO"]          = ["swap v f o", "swap v f os", "swap a and b", "swap a b", "switch v f o", "switch a and b"],
@@ -336,6 +365,11 @@ namespace Yaesu_Web_Control.Services.Voice
                 ["TxOff"]            = ["stop transmitting", "go to receive", "transmit off"],
                 ["SplitOn"]          = ["split on", "enable split", "split transmit"],
                 ["SplitOff"]         = ["split off", "disable split", "simplex"],
+                // ATU. No bare "tune" — it would collide with the "tune up" /
+                // "tune down" nudges above.
+                ["AtuOn"]            = ["tuner on", "antenna tuner on", "a t u on"],
+                ["AtuOff"]           = ["tuner off", "antenna tuner off", "a t u off"],
+                ["AtuTune"]          = ["tune antenna", "tune the antenna", "start tuner", "auto tune"],
                 ["Help"]             = ["help", "command help", "what can I say", "list commands"],
                 ["NudgeIfWidthUp"]   = ["filter wider", "wider filter", "increase bandwidth", "i f width up"],
                 ["NudgeIfWidthDown"] = ["filter narrower", "narrower filter", "decrease bandwidth", "i f width down"],

--- a/wwwroot/i18n/labels.default.json
+++ b/wwwroot/i18n/labels.default.json
@@ -96,6 +96,8 @@
     "manualNotchA": "Manual notch, VFO A",
     "manualNotchB": "Manual notch, VFO B",
     "roofingA":     "Roofing filter, VFO A",
-    "roofingB":     "Roofing filter, VFO B"
+    "roofingB":     "Roofing filter, VFO B",
+    "atu":          "Antenna tuner on or off — tap to toggle, press and hold to auto-tune",
+    "atuTune":      "Start antenna auto-tune"
   }
 }


### PR DESCRIPTION
## Summary
Ports the ATU improvements from IWC to YWC: a visible **Tune** button and voice commands for the antenna tuner.

- **Index page** - a visible **Tune** button beside the existing ATU On/Off, which flips to a red **Stop** while a tune cycle runs (aria-label and title follow via a cached idle label). Both ATU buttons get `data-a11y-key` for keyboard accessibility.
- **Voice intents** - three new commands wired to CAT: `AtuOn` -> `AC001;`, `AtuOff` -> `AC000;`, `AtuTune` -> `AC002;`.
- **Phrases** - "tuner on/off" and "tune antenna" (deliberately no bare "tune", which would collide with the tune-up/down frequency nudges). Phrase store version 7 -> 8 with an additive `BackfillMissingCommands` so existing users keep their customisations and translations.
- **Help + labels** - ATU entries added to the voice help builder and `labels.default.json`.

5 files, +138/-3.

## Design notes
- Yaesu `AC` P2 is "Fixed at 0" - the radio does **not** report a tune cycle in progress (unlike Icom's `1C 01`). So the Tuning/Stop UI is client-side/timer-driven only, and the voice path deliberately does not set any server-side tuning state (nothing server-side would ever clear a stuck "Tuning...").
- YWC has no `IRadioController` seam, so this uses the dispatcher's own `SendCommand` CAT path directly.

## Test plan
- [x] Both TFMs build clean (`net10.0-windows` and `net10.0`), 0 warnings / 0 errors.
- [ ] Bench: ATU On / Off / Tune from the button on a real 101MP.
- [ ] Bench: same three via voice.
- [ ] Confirm the new intents surface correctly in the Settings voice editor.
- [ ] Mid-cycle **Stop** path - untested on a low-SWR antenna (cycles complete almost instantly); needs a stubborn band to exercise.

## Still to do (not in this PR)
- USER_MANUAL / VOICE_CONTROL ATU sections.
