### PR TITLE
Release the FTdx101 front-panel meters outside of transmit

### DIFF
--- a/Services/CatCommands.cs
+++ b/Services/CatCommands.cs
@@ -21,8 +21,14 @@
         // METER READING COMMANDS (RM)
         public const string MeterPower = "RM5";    // Power output meter (0-255)
         public const string MeterSWR = "RM6";      // SWR meter (0-255) — NOTE: RM6 returns stale/wrong values on FTdx101MP; use SetMetersSWR+MeterBoth instead
-        public const string SetMetersCompAndSWR = "MS13"; // Select Compression(left) + SWR(right) for RM0 read
-        public const string SetMeterPower       = "MS01"; // Restore the default Power meter on shutdown so the user's radio is left in a normal state
+        public const string SetMetersCompAndSWR = "MS13"; // FTdx101MP/D ONLY: Compression(left) + SWR(right) for the RM0 read
+        public const string SetMeterPower       = "MS01"; // FTdx101MP/D ONLY: POW(left) + ALC(right) — the radio's own default pair
+
+        // Fallback used when restoring the operator's meters and YWC never saw an
+        // MS answer (radio powered up mid-session, init answer lost, etc.). MS01 on
+        // the FTdx101 is POW + ALC, which is what the radio shows out of the box —
+        // the same value the pre-existing shutdown restore has always used.
+        public const string DefaultFtdx101MeterSelection = "01";
         public const string MeterBoth = "RM0";            // Read both currently-selected meters: RM0LLLRRR;
         public const string MeterALC = "RM4";      // ALC meter (0-255)
         public const string MeterComp = "RM3";     // Compression meter (0-255)

--- a/Services/CatCommands.cs
+++ b/Services/CatCommands.cs
@@ -22,13 +22,16 @@
         public const string MeterPower = "RM5";    // Power output meter (0-255)
         public const string MeterSWR = "RM6";      // SWR meter (0-255) — NOTE: RM6 returns stale/wrong values on FTdx101MP; use SetMetersSWR+MeterBoth instead
         public const string SetMetersCompAndSWR = "MS13"; // FTdx101MP/D ONLY: Compression(left) + SWR(right) for the RM0 read
-        public const string SetMeterPower       = "MS01"; // FTdx101MP/D ONLY: POW(left) + ALC(right) — the radio's own default pair
+        public const string SetMeterPower       = "MS00"; // FTdx101MP/D ONLY: POW(MAIN) + ALC(SUB) — the radio's own default pair
 
         // Fallback used when restoring the operator's meters and YWC never saw an
-        // MS answer (radio powered up mid-session, init answer lost, etc.). MS01 on
-        // the FTdx101 is POW + ALC, which is what the radio shows out of the box —
-        // the same value the pre-existing shutdown restore has always used.
-        public const string DefaultFtdx101MeterSelection = "01";
+        // MS answer (radio powered up mid-session, init answer lost, etc.). The MS
+        // digits are MAIN then SUB, not left then right: MAIN 0=POW 1=COMP 2=TEMP,
+        // SUB 0=ALC 1=VDD 2=ID 3=SWR. So POW + ALC is MS00, not MS01 (which is
+        // POW + VDD). Bench-confirmed on the FTdx101MP 2026-08-15: sending MS00;
+        // put the front panel back to PO and ALC. The pre-existing shutdown restore
+        // hard-coded MS01 and had been leaving the operator on POW + VDD.
+        public const string DefaultFtdx101MeterSelection = "00";
         public const string MeterBoth = "RM0";            // Read both currently-selected meters: RM0LLLRRR;
         public const string MeterALC = "RM4";      // ALC meter (0-255)
         public const string MeterComp = "RM3";     // Compression meter (0-255)

--- a/Services/CatMessageDispatcher.cs
+++ b/Services/CatMessageDispatcher.cs
@@ -597,6 +597,19 @@
                             });
                         }
                         break;
+                    case "MS":
+                        // MS{P1}; or MS{P1}{P2}; — front-panel METER SW selection.
+                        // Stored verbatim: the parameter encoding differs per model
+                        // (see RadioStateService.RadioMeterSelection) and YWC only
+                        // ever needs to replay it, never to understand it. Sent at
+                        // init by GetInitialValues and pushed by the radio's auto-
+                        // information whenever the operator changes meters.
+                        {
+                            var msDigits = message.Substring(2).TrimEnd(';');
+                            if (msDigits.Length is 1 or 2 && msDigits.All(char.IsDigit))
+                                _stateService.ReportMeterSelection(msDigits);
+                        }
+                        break;
                     case "MG":
                         // MG{NNN}; — MIC Gain 000-100
                         if (message.Length >= 6 && int.TryParse(message.Substring(2, 3), out int mgVal))

--- a/Services/CatMessageDispatcher.cs
+++ b/Services/CatMessageDispatcher.cs
@@ -602,8 +602,12 @@
                         // Stored verbatim: the parameter encoding differs per model
                         // (see RadioStateService.RadioMeterSelection) and YWC only
                         // ever needs to replay it, never to understand it. Sent at
-                        // init by GetInitialValues and pushed by the radio's auto-
-                        // information whenever the operator changes meters.
+                        // init from RadioInitializationService's readQueries, and
+                        // pushed by the radio's auto-information whenever the
+                        // operator changes meters. (It was NOT sent between
+                        // 2026-02-22 and 2026-08-15: the read sat in
+                        // CatMultiplexerService.GetInitialValues(), which lost its
+                        // only caller in 5d83175 and became dead code.)
                         {
                             var msDigits = message.Substring(2).TrimEnd(';');
                             if (msDigits.Length is 1 or 2 && msDigits.All(char.IsDigit))

--- a/Services/MeterPollingService.cs
+++ b/Services/MeterPollingService.cs
@@ -411,7 +411,7 @@ namespace Yaesu_Web_Control.Services
         // in RadioInitializationService.StopAsync, not here — the hosted-service
         // reverse-shutdown order means MeterPollingService stops AFTER
         // RadioInitializationService has already disconnected the multiplexer,
-        // so sending MS01 from this StopAsync would talk to a closed port (at
+        // so sending the MS restore from this StopAsync would talk to a closed port (at
         // best a no-op, at worst a hang that stalls host shutdown).
     }
 }

--- a/Services/MeterPollingService.cs
+++ b/Services/MeterPollingService.cs
@@ -70,6 +70,41 @@ namespace Yaesu_Web_Control.Services
         // doesn't hold the other's needle back.
         private int _sMeterBZeroCount = 0;
 
+        // --- FTdx101 meter borrowing ------------------------------------------
+        //
+        // Reading compression + SWR on the FTdx101 needs the radio's two front-
+        // panel meter slots pinned to MS13 so RM0 returns the pair (see the long
+        // comment at the RM0 branch below). Until now that MS13 went out on every
+        // 500 ms cycle, which meant the operator could never change the meters on
+        // the touchscreen — the poller stomped their choice twice a second, and it
+        // was the only thing Fabio's video stream could ever show.
+        //
+        // Both borrowed values are TX-only: SWRMeter and CompressionMeter are
+        // forced to 0 whenever the radio isn't transmitting, so during receive the
+        // poller was pinning the display to harvest readings it then threw away.
+        // So: borrow the meters when TX starts, hand them straight back once TX has
+        // been quiet for MeterReturnDelay. During receive the radio shows whatever
+        // the operator picked.
+        //
+        // The return delay is deliberately longer than a between-overs gap. Handing
+        // the meters back the instant TX drops would make the display flap once per
+        // over on SSB and strobe on QSK CW break-in, which is worse than leaving it
+        // pinned. 10 s means a normal QSO keeps the meters borrowed for its
+        // duration and they come back during genuine idle/listening time — which is
+        // when a video stream of the front panel is worth watching anyway.
+        private DateTime _lastTxSeenUtc = DateTime.MinValue;
+        private bool _metersBorrowed = false;
+        private static readonly TimeSpan MeterReturnDelay = TimeSpan.FromSeconds(10);
+
+        // Cycles to discard after switching the meter pair. The radio needs a
+        // moment to settle onto the newly-selected meters, so the first RM0 read
+        // after an MS13 write can carry a value belonging to the previous
+        // selection. Discarding one 500 ms cycle costs nothing (SWR at the very
+        // start of an over is not meaningful) and avoids a bogus spike. If bench
+        // testing shows SWR coming up a beat late, this is the knob.
+        private int _borrowSettleCycles = 0;
+        private const int BorrowSettleCycles = 1;
+
         public MeterPollingService(
             CatMultiplexerService multiplexer,
             RadioStateService stateService,
@@ -213,25 +248,71 @@ namespace Yaesu_Web_Control.Services
                     //  - FTdx101MP / FTdx101D: RM6 (the documented SWR read) returns
                     //    stale/wrong values, so we have to set both meter slots via
                     //    MS13 (compression-left, SWR-right) and then read both at once
-                    //    with RM0. Pre-existing workaround, do not regress.
+                    //    with RM0. Pre-existing workaround, do not regress. The MS13
+                    //    is now issued only while transmitting and handed back
+                    //    afterwards — see the meter-borrowing comment above.
                     //
                     //  - FTdx10 / FT-710 / FTDX3000: MS13+RM0 doesn't read SWR
                     //    correctly (reported by OE5HMR on FTdx10, 2026-06-01).
                     //    Reverting to the documented direct reads — RM3 for
                     //    compression, RM6 for SWR — which is what Yaesu's CAT
-                    //    manual specifies for these radios.
+                    //    manual specifies for these radios. These models never touch
+                    //    MS at all, so their front-panel meters were always free and
+                    //    nothing in the borrowing logic applies to them.
                     var settings = await _settingsService.GetSettingsAsync();
                     bool useRm0Pair = settings.RadioModel is "FTdx101MP" or "FTdx101D";
                     int compression;
                     int swr;
                     if (useRm0Pair)
                     {
-                        _logger.LogDebug("[MeterPolling][DEBUG] Polling Compression+SWR (MS13+RM0)... TX={IsTransmitting}", isTransmitting);
-                        await _multiplexer.SendCommandAsync(CatCommands.SetMetersCompAndSWR + ";", "MeterPoll", stoppingToken);
-                        var compSwrResponse = await _multiplexer.SendCommandAsync(CatCommands.MeterBoth + ";", "MeterPoll", stoppingToken);
-                        _logger.LogDebug("[MeterPolling][DEBUG] MS13+RM0 response: '{Raw}'", compSwrResponse);
-                        compression = CatCommands.ParseRm0LeftMeter(compSwrResponse ?? "");
-                        swr         = CatCommands.ParseRm0RightMeter(compSwrResponse ?? "");
+                        if (isTransmitting)
+                        {
+                            _lastTxSeenUtc = DateTime.UtcNow;
+                            if (!_metersBorrowed)
+                            {
+                                // Flag before the write: the radio echoes MS via auto-
+                                // information, and the dispatcher must not mistake our
+                                // own MS13 for an operator choice.
+                                _stateService.MetersBorrowed = true;
+                                _metersBorrowed = true;
+                                _borrowSettleCycles = BorrowSettleCycles;
+                                _logger.LogDebug("[MeterPolling] TX started — borrowing front-panel meters (MS13)");
+                                await _multiplexer.SendCommandAsync(CatCommands.SetMetersCompAndSWR + ";", "MeterPoll", stoppingToken);
+                            }
+
+                            var compSwrResponse = await _multiplexer.SendCommandAsync(CatCommands.MeterBoth + ";", "MeterPoll", stoppingToken);
+                            _logger.LogDebug("[MeterPolling][DEBUG] RM0 response: '{Raw}'", compSwrResponse);
+                            compression = CatCommands.ParseRm0LeftMeter(compSwrResponse ?? "");
+                            swr         = CatCommands.ParseRm0RightMeter(compSwrResponse ?? "");
+
+                            if (_borrowSettleCycles > 0)
+                            {
+                                // Meters have only just switched — this read may still
+                                // describe the operator's previous selection.
+                                _borrowSettleCycles--;
+                                compression = 0;
+                                swr         = 0;
+                            }
+                        }
+                        else
+                        {
+                            // Nothing to read: both values are discarded during RX
+                            // anyway (see the assignments below).
+                            compression = 0;
+                            swr         = 0;
+
+                            if (_metersBorrowed && DateTime.UtcNow - _lastTxSeenUtc > MeterReturnDelay)
+                            {
+                                var restore = _stateService.RadioMeterSelection
+                                              ?? CatCommands.DefaultFtdx101MeterSelection;
+                                _logger.LogInformation("[MeterPolling] TX idle — returning front-panel meters to MS{Restore}", restore);
+                                await _multiplexer.SendCommandAsync($"MS{restore};", "MeterPoll", stoppingToken);
+                                _metersBorrowed = false;
+                                // Cleared last: any MS echo of the restore carries the
+                                // operator's own value, so recording it is harmless.
+                                _stateService.MetersBorrowed = false;
+                            }
+                        }
                     }
                     else
                     {

--- a/Services/RadioInitializationService.cs
+++ b/Services/RadioInitializationService.cs
@@ -369,6 +369,24 @@ namespace Yaesu_Web_Control.Services
                     "PC;",                   // RF Power (Issue #35) — radio is
                                              //   source of truth on connect
                     "ML0;", "ML1;",          // Monitor on/off / level
+                    // Front-panel METER SW selection. Needed so the FTdx101
+                    // meter restores put back the operator's own pair rather
+                    // than falling back to the POW+ALC default. Note that is
+                    // both restores, not just this service's shutdown one:
+                    // MeterPollingService returns the panel 10 s after TX
+                    // goes idle using the same expression, so without this
+                    // read the operator's pair was overwritten after the
+                    // first over of every session. This
+                    // used to live in CatMultiplexerService.GetInitialValues(),
+                    // but that method's only call site was deleted on
+                    // 2026-02-22 (5d83175, "Fixed initialization hang") and it
+                    // has been dead code ever since — so MS; had not actually
+                    // been sent for months, and RadioMeterSelection was always
+                    // null on a fresh start. Harmless on the other models:
+                    // MS is a documented read on FTdx10 / FT-710 / FTDX3000,
+                    // the dispatcher stores it verbatim, and only the FTdx101
+                    // branch ever replays it.
+                    "MS;",                   // METER SW (front-panel meter pair)
                     // CW
                     "KP;",                   // CW Pitch
                     "KS;",                   // CW Speed

--- a/Services/RadioInitializationService.cs
+++ b/Services/RadioInitializationService.cs
@@ -601,32 +601,40 @@ namespace Yaesu_Web_Control.Services
                 logger?.LogWarning(ex, "[RadioInit] TX0; on shutdown failed — non-fatal");
             }
 
-            // FTdx101 power-meter restore (discussion #6, F1ubw). During normal
-            // operation MeterPollingService sets the radio's front-panel meter
-            // to MS13 (Comp + SWR) as the RM0 read workaround; without this
-            // restore, quitting YWC leaves the FTdx101's Power needle hidden
-            // until the operator power-cycles the radio or hits the METER button.
+            // FTdx101 meter restore (discussion #6, F1ubw). MeterPollingService
+            // borrows the radio's front-panel meter pair (MS13 = Comp + SWR) for
+            // the duration of each transmission as the RM0 read workaround; if YWC
+            // quits mid-borrow, without this restore the operator is left staring
+            // at Comp + SWR until they power-cycle the radio or hit METER.
+            //
+            // Restores the operator's own selection when YWC has seen one (from the
+            // MS; read at init or an auto-info push), falling back to the radio's
+            // default POW + ALC pair otherwise — which is what this always sent
+            // before the selection was tracked.
             //
             // Best-effort with a 1 s timeout so a hung send (e.g. radio
             // powered off, COM cable yanked) can't stall host shutdown.
-            // Only FTdx101MP/D set MS13; other radios don't touch the meter.
+            // Only FTdx101MP/D borrow the meters; other radios never touch MS.
             try
             {
                 var settingsService = scopeForLogger.ServiceProvider.GetRequiredService<ISettingsService>();
                 var settings = await settingsService.GetSettingsAsync();
                 if (settings.RadioModel is "FTdx101MP" or "FTdx101D")
                 {
-                    logger?.LogInformation("[RadioInit] Sending MS01 to restore FTdx101 power meter");
+                    var radioStateService = scopeForLogger.ServiceProvider.GetRequiredService<RadioStateService>();
+                    var restore = radioStateService.RadioMeterSelection
+                                  ?? CatCommands.DefaultFtdx101MeterSelection;
+                    logger?.LogInformation("[RadioInit] Sending MS{Restore} to restore FTdx101 front-panel meters", restore);
                     using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                     cts.CancelAfter(TimeSpan.FromSeconds(1));
                     await _multiplexer.SendCommandAsync(
-                        CatCommands.SetMeterPower + ";", "RadioInit-Shutdown", cts.Token);
-                    logger?.LogInformation("[RadioInit] MS01 send completed");
+                        $"MS{restore};", "RadioInit-Shutdown", cts.Token);
+                    logger?.LogInformation("[RadioInit] Meter restore send completed");
                 }
             }
             catch (Exception ex)
             {
-                logger?.LogWarning(ex, "[RadioInit] MS01 send failed — non-fatal");
+                logger?.LogWarning(ex, "[RadioInit] Meter restore send failed — non-fatal");
             }
 
             logger?.LogInformation("[RadioInit] Disconnecting multiplexer");

--- a/Services/RadioStateService.cs
+++ b/Services/RadioStateService.cs
@@ -423,6 +423,43 @@ namespace Yaesu_Web_Control.Services
         private int? _powerMeter;
         public int? PowerMeter { get => _powerMeter; set => SetField(ref _powerMeter, value); }
 
+        // --- Front-panel meter selection (MS) ---------------------------------
+        //
+        // The operator's own front-panel meter choice, stored as the RAW parameter
+        // digits from the radio's own MS answer — never interpreted. That matters,
+        // because MS's parameter encoding is model-specific:
+        //
+        //   FTdx101MP/D  MSP1P2;  P1 MAIN 0=POW 1=COMP 2=TEMP
+        //                         P2 SUB  0=ALC 1=VDD  2=ID   3=SWR
+        //   FTdx10/710   MSP1P2;  P1 0=PO 1=COMP 2=ALC 3=VDD 4=ID 5=SWR, P2 fixed 0
+        //   FTDX5000     MSP1;    0=COMP 1=ALC 2=PO 3=SWR 4=ID 5=VDD
+        //   FT-991A      MSP1;    0=COMP 1=ALC 2=PO 3=SWR 4=ID 5=VDD
+        //   FTDX3000     MSP1;    0=COMP 1=ALC 3=SWR 4=ID 5=VDD  (no PO)
+        //
+        // Keeping the digits opaque means capture-and-restore works on every model
+        // without a per-model table: we replay exactly what the radio told us it
+        // had. Only the *borrow* value (MS13 on the FTdx101) is model-specific, and
+        // that stays confined to the FTdx101 branch in MeterPollingService.
+        //
+        // Populated from the MS; read issued during init and from the unsolicited
+        // MS auto-info the radio pushes when the operator changes meters on the
+        // front panel (MS has AI in every supported model's CAT manual).
+        public string? RadioMeterSelection { get; private set; }
+
+        // True while MeterPollingService has commandeered the meter pair for the
+        // FTdx101 comp+SWR read. MS traffic seen during a borrow is our own write
+        // echoing back, so ReportMeterSelection drops it rather than recording
+        // MS13 as the operator's preference and "restoring" to it forever.
+        public bool MetersBorrowed { get; set; }
+
+        public void ReportMeterSelection(string digits)
+        {
+            if (MetersBorrowed || string.IsNullOrEmpty(digits)) return;
+            if (RadioMeterSelection == digits) return;
+            RadioMeterSelection = digits;
+            _logger.LogInformation("[Meters] Operator front-panel meter selection is MS{Digits}", digits);
+        }
+
         private int? _compressionMeter;
         public int? CompressionMeter
         {


### PR DESCRIPTION
## The problem

`MeterPollingService` sends `MS13;` (left = Compression, right = SWR) on **every 500 ms poll cycle**. That is what makes the FTdx101 touchscreen meters unchangeable - whatever the operator picks is stomped twice a second - and it is the only thing a video stream of the front panel can ever show.

## The key observation

Both borrowed values are **TX-only**. `MeterPollingService` already forces `SWRMeter = 0` and `CompressionMeter = 0` whenever the radio is not transmitting. So during receive the poller was pinning the display to harvest readings it then threw away.

Every other meter is read with a command that does not care what is on the screen: `RM5` power, `RM4` ALC, `RM7` IDD, `RM8` VDD, `RM9` temp, `SM0`/`SM1` S-meter. Only compression and SWR need the meter slots, and only during transmit.

So no duty-cycle sampling is needed. Borrow at TX, hand back afterwards, and the radio shows the operator's own meters for the whole of receive.

## What this PR does

1. **`MS13` only while transmitting.** On TX start, borrow the pair and read `RM0` as before. On TX end, hand them back.
2. **Return delay of 10 s.** Deliberately longer than a between-overs gap. Releasing the instant TX drops would flap the display once per over on SSB and strobe it on QSK CW break-in, which would be worse than leaving it pinned. A normal QSO keeps the meters borrowed for its duration; they come back during genuine idle time, which is when a front-panel video feed is worth watching anyway.
3. **Learn the operator's selection.** `MS` is Set/Read/Answer/**AI** on every supported model, and `GetInitialValues` already sends `MS;` - the answer was just dropped on the floor. Added an `MS` case to `CatMessageDispatcher` that records it, plus the auto-info the radio pushes when the operator changes meters on the front panel.
4. **One settle cycle discarded** after the switch (500 ms), so the first `RM0` after `MS13` cannot report a value still belonging to the previous selection.
5. **Shutdown restore** returns the operator's own selection instead of the hard-coded `MS01`.

## Compatibility with the other Yaesu models

I checked the `MS` definition in every CAT manual in `docs/manuals/`, and **the parameter encoding is different on almost every model**:

| Model | Format | Codes |
|---|---|---|
| FTdx101MP/D | `MSP1P2;` | MAIN 0=POW 1=COMP 2=TEMP / SUB 0=ALC 1=VDD 2=ID 3=SWR |
| FTdx10 | `MSP1P2;` | 0=PO 1=COMP 2=ALC 3=VDD 4=ID 5=SWR, P2 fixed 0 |
| FT-710 | `MSP1P2;` | 0=PO 1=COMP 2=ALC 3=VDD 4=ID 5=SWR, P2 fixed 0 |
| FTDX5000MP/D | `MSP1;` | 0=COMP 1=ALC 2=PO 3=SWR 4=ID 5=VDD |
| FT-991A | `MSP1;` | 0=COMP 1=ALC 2=PO 3=SWR 4=ID 5=VDD |
| FTDX3000 | `MSP1;` | 0=COMP 1=ALC 3=SWR 4=ID 5=VDD (no PO) |

`MS13` therefore means completely different things depending on the radio, and would be malformed on the single-parameter models.

Two things keep this safe:

- **Only FTdx101MP/D ever write `MS`.** That was already true (the `useRm0Pair` gate) and is unchanged. FTdx10 / FT-710 / FTDX3000 / FTDX5000 / FT-991A read compression and SWR with `RM3`/`RM6` directly and never touch `MS`, so **their front-panel meters were always free** and no CAT traffic changes for them at all.
- **The captured selection is stored as raw digits and never interpreted.** We replay exactly what the radio told us it had, which works on 1-digit and 2-digit models alike with no per-model table. The new dispatcher case is read-only and format-agnostic.

## For Fabio (@fabiojvalente) - video stream

This is the change that lets the front panel in the video feed show the operator's own meters instead of being permanently stuck on Compression + SWR. Worth testing together with the audio/video work to confirm:

- the meters visibly return to the operator's choice about 10 s after an over
- the flip at TX start is not distracting on the stream
- nothing in the stream pipeline is upset by the meter area changing

If 10 s is wrong for streaming, `MeterReturnDelay` in `MeterPollingService` is a one-line change and is the obvious candidate to promote to a Settings field.

## Bench testing needed (FTdx101MP)

- [ ] Change the meters on the touchscreen during receive - do they stay changed?
- [ ] Transmit - do they flip to Comp + SWR, and does SWR still read correctly in the web UI?
- [ ] Does SWR come up as fast as before, or is it a beat late? (If late, `BorrowSettleCycles` is the knob.)
- [ ] After ~10 s of receive, do the operator's meters come back?
- [ ] Quick CW / QSK overs - is the display stable rather than flapping?
- [ ] Quit YWC - are the operator's meters restored (not `MS01`)?
- [ ] Confirm the log shows `[Meters] Operator front-panel meter selection is MS..` at startup, which proves the `MS;` read is being captured.
- [ ] Any other model (FTdx10 in particular) - confirm compression and SWR are unchanged.

## Deliberately not in this PR

**Pre-arming.** When YWC itself initiates TX (web UI, voice, rigctld) we could borrow the meters before the radio keys, removing the settle delay for those paths. Hardware PTT (mic or foot switch) cannot be pre-armed, so it would only help some cases, and it adds cross-service coupling. Left as a follow-up if the settle cycle proves to be a problem in testing.

**Releasing the left meter slot.** We only strictly need SWR, which lives in the right slot. If `RM3` reads compression standalone on the FTdx101 (it does on every other model), we could borrow only the right slot and leave the operator's left meter alone even during transmit. That needs a bench measurement on real hardware before it can be relied on - happy to do it as a follow-up if you want to check whether `RM3` returns sane compression values on the MP.

No version bump or release notes in this PR.
