### PR TITLE
Experiment: show only the meters that are actually reading

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -228,6 +228,23 @@
         display: none !important;
     }
 
+    /* The mirror case, and a real defect in its own right: the radio FREEZES
+       both S-meters at key-down. Measured on the MP 2026-08-15 — 101 samples
+       across a 5 s over returned one value each (SM0=154, SM1=75), against 29
+       and 21 distinct values while receiving. The needles look alive but are
+       showing whatever the band was doing at the instant of key-down.
+
+       Dimmed rather than hidden because the S-meters are leftmost: hiding them
+       would shift the whole row left on every over, which is exactly the
+       movement the reorder removed. Dimmed rather than zeroed because a needle
+       dropping to S0 asserts "no signal", which is a different untruth. Grey
+       reads consistently across the row as "not telling you anything now". */
+    .meters-tx-dim [data-meter-scope="rx"] {
+        filter: grayscale(1);
+        opacity: 0.3;
+        transition: opacity 0.25s ease, filter 0.25s ease;
+    }
+
     /* Voice command help popup (right-click a mic button). */
     #voiceHelpBody .vh-intro   { color: #bbb; font-size: 0.85rem; margin-bottom: 0.75rem; }
     #voiceHelpBody .vh-group   { margin-bottom: 0.85rem; }
@@ -524,7 +541,7 @@
                         <!-- S-Meter A (MAIN) — moved from per-VFO panels to the top
                              row in v2.3.9. Always live (unlike SWR/Power/etc which
                              are TX-only). -->
-                        <div class="text-center" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
+                        <div class="text-center" data-meter-scope="rx" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
                             <div class="analog-meter-container">
                                 <canvas id="sMeterCanvas" role="img" aria-hidden="true" aria-label="S meter A" data-a11y-key="meters.smeterA"></canvas>
                             </div>
@@ -541,7 +558,7 @@
                                         data-a11y-key="meters.smeterHistoryB"
                                         style="display:block; width:100%; height:100%; border-radius:3px;"></canvas>
                             </div>
-                            <div class="text-center" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
+                            <div class="text-center" data-meter-scope="rx" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
                                 <div class="analog-meter-container">
                                     <canvas id="sMeterCanvasB" role="img" aria-hidden="true" aria-label="S meter B" data-a11y-key="meters.smeterB"></canvas>
                                 </div>

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -206,6 +206,28 @@
         display: none !important;
     }
 
+    /* EXPERIMENT (feat/meter-visibility-experiment) — de-emphasise the
+       transmit-only gauges while receiving. Two candidate behaviours, cycled
+       from the "Meters:" toolbar button; one gets deleted before this ships.
+       See wwwroot/js/ui/meter-visibility.js for which gauges are tagged and
+       why Temp and VDD are deliberately NOT among them.
+
+       dim: geometry untouched, so nothing reflows when TX/RX flips mid-QSO.
+       Costs nothing to the layout, buys no width back either. */
+    .meters-idle-dim [data-meter-scope="tx"] {
+        filter: grayscale(1);
+        opacity: 0.3;
+        transition: opacity 0.25s ease, filter 0.25s ease;
+    }
+
+    /* hide: reclaims the row, at the price of a reflow on every over. Note
+       this does NOT reliably fix the narrow-viewport wrap warning below —
+       transmit still needs room for the full set, so a row that wraps at
+       nine may well still wrap at seven. */
+    .meters-idle-hide [data-meter-scope="tx"] {
+        display: none !important;
+    }
+
     /* Voice command help popup (right-click a mic button). */
     #voiceHelpBody .vh-intro   { color: #bbb; font-size: 0.85rem; margin-bottom: 0.75rem; }
     #voiceHelpBody .vh-group   { margin-bottom: 0.85rem; }
@@ -401,6 +423,16 @@
                     aria-pressed="false">
                 S-hist
             </button>
+            @* EXPERIMENT (feat/meter-visibility-experiment) — cycles the
+               transmit-only gauges between always-shown, dimmed-on-receive and
+               hidden-on-receive so the two candidates can be compared at the
+               rig. Remove with the losing variant. *@
+            <button id="meterVisibilityBtn" class="btn btn-sm btn-outline-secondary"
+                    style="padding-top: 1px; padding-bottom: 1px;"
+                    title="Transmit-only gauges always shown (current behaviour)"
+                    aria-label="Cycle how transmit-only gauges appear while receiving">
+                Meters: all
+            </button>
             <button id="vfoBToggleBtn" class="btn btn-sm btn-outline-secondary"
                     style="padding-top: 1px; padding-bottom: 1px;" title="Show/Hide VFO-B"
                     aria-label="Show or hide VFO B panel">
@@ -470,7 +502,7 @@
             <div class="card border-secondary">
                 <div class="card-body py-2">
                     <!-- Gauges row -->
-                    <div class="d-flex justify-content-start align-items-start flex-wrap" style="margin-left: 0; gap: 0; margin-bottom: 0.2rem !important;">
+                    <div id="meterGaugesRow" class="d-flex justify-content-start align-items-start flex-wrap" style="margin-left: 0; gap: 0; margin-bottom: 0.2rem !important;">
                         <!-- S-Meter rolling history strip — leftmost so the live trace
                              reads left-to-right toward the S-meter needle. Hidden
                              until the toolbar's S-hist toggle is on. Sized to match
@@ -515,26 +547,27 @@
                                 </div>
                             </div>
                         }
-                        <!-- SWR Meter -->
-                        <div class="text-center" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
+                        <!-- SWR Meter — transmit-only (pinned to 0 on RX by
+                             MeterPollingService, see data-meter-scope above). -->
+                        <div class="text-center" data-meter-scope="tx" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
                             <div class="analog-meter-container">
                                 <canvas id="swrMeterCanvas" role="img" aria-hidden="true" aria-label="SWR meter" data-a11y-key="meters.swr"></canvas>
                             </div>
                         </div>
-                        <!-- Power Meter -->
-                        <div class="text-center power-meter-container" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
+                        <!-- Power Meter — transmit-only -->
+                        <div class="text-center power-meter-container" data-meter-scope="tx" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
                             <div class="analog-meter-container">
                                 <canvas id="powerMeterCanvas" role="img" aria-hidden="true" aria-label="Power output meter" data-a11y-key="meters.power"></canvas>
                             </div>
                         </div>
-                        <!-- Compression Meter -->
-                        <div class="text-center" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
+                        <!-- Compression Meter — transmit-only -->
+                        <div class="text-center" data-meter-scope="tx" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
                             <div class="analog-meter-container">
                                 <canvas id="compressionMeterCanvas" role="img" aria-hidden="true" aria-label="Compression meter" data-a11y-key="meters.compression"></canvas>
                             </div>
                         </div>
-                        <!-- ALC Meter -->
-                        <div class="text-center" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
+                        <!-- ALC Meter — transmit-only -->
+                        <div class="text-center" data-meter-scope="tx" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
                             <div class="analog-meter-container">
                                 <canvas id="alcMeterCanvas" role="img" aria-hidden="true" aria-label="ALC meter" data-a11y-key="meters.alc"></canvas>
                             </div>
@@ -547,8 +580,13 @@
                                 <canvas id="tempMeterCanvas" role="img" aria-hidden="true" aria-label="Amplifier temperature meter" data-a11y-key="meters.temp"></canvas>
                             </div>
                         </div>
-                        <!-- IDD Meter — FTdx101/FTDX3000 only -->
-                        <div class="text-center" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
+                        <!-- IDD Meter — FTdx101/FTDX3000 only. Transmit-only:
+                             drain current is ~0 with no carrier. Temp and VDD
+                             below are deliberately NOT tagged — both stay
+                             meaningful on receive (a hot PA after a long over,
+                             a sagging supply), and Temp is polled outside the
+                             isTransmitting branch in MeterPollingService. -->
+                        <div class="text-center" data-meter-scope="tx" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
                             <div class="analog-meter-container">
                                 <canvas id="iddMeterCanvas" role="img" aria-hidden="true" aria-label="Drain current meter" data-a11y-key="meters.idd"></canvas>
                             </div>
@@ -2346,6 +2384,7 @@
     <script type="module">
         import { MeterPanel }           from "/js/guages/meter-panel.js?v=1";
         import { SMeterHistoryPanel }   from "/js/guages/smeter-history-panel.js?v=1";
+        import { MeterVisibility }      from "/js/ui/meter-visibility.js?v=1";
         import { FTdx101Meters }        from "/js/orchestrators/FTdx101Meters.js?v=1";
         import { SdrSpectrumPipeline }  from "/js/sdr/sdr-spectrum-pipeline.js?v=4";
         import { SpectrumPanel }        from "/js/sdr/spectrum-panel.js?v=5";
@@ -2423,6 +2462,11 @@
                 vdd:         { canvasId: 'vddMeterCanvas' }
             });
             window.ftdx101Meters = new FTdx101Meters(window.meterPanel, window.calibrationEngine);
+
+            // ── Transmit-only gauge visibility (EXPERIMENT) ──────────────────
+            // Published on window so site.js's IsTransmitting handler can push
+            // TX state in, the same way it drives the other TX indicators.
+            window.meterVisibility = new MeterVisibility('meterGaugesRow', 'meterVisibilityBtn');
 
             // ── S-meter history strips ───────────────────────────────────────
             // Hidden by default. Toggle via the "S-hist" button in the top

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -547,8 +547,50 @@
                                 </div>
                             </div>
                         }
-                        <!-- SWR Meter — transmit-only (pinned to 0 on RX by
-                             MeterPollingService, see data-meter-scope above). -->
+                        @* EXPERIMENT (feat/meter-visibility-experiment) — row
+                           REORDERED so the always-meaningful gauges are
+                           contiguous on the left and every transmit-only gauge
+                           sits in one block on the right. Colin's call, and it
+                           improves both candidate behaviours: dim gives one
+                           bright group and one grey group instead of the two
+                           alternating, and hide removes a trailing block so
+                           nothing that survives changes position. Previously
+                           Temp and VDD were stranded at the far right with IDD
+                           between them.
+
+                           Cost to weigh before shipping: this changes gauge
+                           order for every existing user, which is muscle
+                           memory for 100+ people. Note Temp/IDD/VDD share one
+                           radio-capability gate, so it now appears twice. *@
+
+                        @* --- Always meaningful: receive and transmit alike --- *@
+                        @if (!isFtdx10 && !isFt710 && !isFtdx5000) {
+                        <!-- PA Temperature Meter — FTdx101/FTDX3000 only (high-voltage PA board).
+                             FTDX5000 excluded: no temperature read-code in its RM meter set.
+                             NOT transmit-only: polled outside the isTransmitting
+                             branch in MeterPollingService, and a hot PA after a
+                             long over is worth seeing while receiving. -->
+                        <div class="text-center" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
+                            <div class="analog-meter-container">
+                                <canvas id="tempMeterCanvas" role="img" aria-hidden="true" aria-label="Amplifier temperature meter" data-a11y-key="meters.temp"></canvas>
+                            </div>
+                        </div>
+                        <!-- VDD Meter — FTdx101/FTDX3000 only. NOT transmit-only:
+                             a sagging supply is worth seeing at any time. -->
+                        <div class="text-center" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
+                            <div class="analog-meter-container">
+                                <canvas id="vddMeterCanvas" role="img" aria-hidden="true" aria-label="Amplifier supply voltage meter" data-a11y-key="meters.vdd"></canvas>
+                            </div>
+                        </div>
+                        }
+
+                        @* --- Transmit-only block: dimmed or hidden on receive ---
+                           All five are pinned to zero during receive by
+                           MeterPollingService, so nothing live is being
+                           suppressed here. Keep this block last and contiguous
+                           — that is what stops the surviving gauges moving when
+                           the hide variant reflows the row. *@
+                        <!-- SWR Meter — transmit-only -->
                         <div class="text-center" data-meter-scope="tx" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
                             <div class="analog-meter-container">
                                 <canvas id="swrMeterCanvas" role="img" aria-hidden="true" aria-label="SWR meter" data-a11y-key="meters.swr"></canvas>
@@ -573,28 +615,11 @@
                             </div>
                         </div>
                         @if (!isFtdx10 && !isFt710 && !isFtdx5000) {
-                        <!-- PA Temperature Meter — FTdx101/FTDX3000 only (high-voltage PA board).
-                             FTDX5000 excluded: no temperature read-code in its RM meter set. -->
-                        <div class="text-center" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
-                            <div class="analog-meter-container">
-                                <canvas id="tempMeterCanvas" role="img" aria-hidden="true" aria-label="Amplifier temperature meter" data-a11y-key="meters.temp"></canvas>
-                            </div>
-                        </div>
                         <!-- IDD Meter — FTdx101/FTDX3000 only. Transmit-only:
-                             drain current is ~0 with no carrier. Temp and VDD
-                             below are deliberately NOT tagged — both stay
-                             meaningful on receive (a hot PA after a long over,
-                             a sagging supply), and Temp is polled outside the
-                             isTransmitting branch in MeterPollingService. -->
+                             drain current is ~0 with no carrier. -->
                         <div class="text-center" data-meter-scope="tx" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
                             <div class="analog-meter-container">
                                 <canvas id="iddMeterCanvas" role="img" aria-hidden="true" aria-label="Drain current meter" data-a11y-key="meters.idd"></canvas>
-                            </div>
-                        </div>
-                        <!-- VDD Meter — FTdx101/FTDX3000 only -->
-                        <div class="text-center" style="position: relative; height: 135px; min-width: 165px; margin: 0; padding: 0;">
-                            <div class="analog-meter-container">
-                                <canvas id="vddMeterCanvas" role="img" aria-hidden="true" aria-label="Amplifier supply voltage meter" data-a11y-key="meters.vdd"></canvas>
                             </div>
                         </div>
                         }

--- a/wwwroot/js/ui/meter-visibility.js
+++ b/wwwroot/js/ui/meter-visibility.js
@@ -1,0 +1,93 @@
+// meter-visibility.js — de-emphasise the transmit-only gauges while receiving.
+//
+// EXPERIMENT (feat/meter-visibility-experiment). Two candidate behaviours are
+// implemented side by side so they can be compared against a real rig mid-QSO;
+// one of them is meant to be deleted before this ever ships.
+//
+//   off   current behaviour — every gauge drawn at full strength always
+//   dim    transmit-only gauges greyed in place, geometry unchanged
+//   hide   transmit-only gauges removed from layout, row reflows
+//
+// Which gauges count as transmit-only is decided in the markup, not here: a
+// cell carries data-meter-scope="tx" if it means nothing while receiving.
+// S-meters are obviously excluded. So are Temp and VDD, which are NOT
+// transmit-only despite sitting among the transmit gauges — MeterPollingService
+// polls temperature outside the isTransmitting branch, and a hot PA or a sagging
+// supply is worth seeing on receive, which is exactly when you would look.
+//
+// SWR/Power/ALC/Compression are already pinned to zero during receive by
+// MeterPollingService, so nothing here is hiding live data — it is choosing
+// whether to draw a gauge that is deliberately reading nothing.
+
+const MODES = ['off', 'dim', 'hide'];
+const KEY = 'ywc.meterIdleMode';
+
+const LABEL = {
+    off:  'Meters: all',
+    dim:  'Meters: dim',
+    hide: 'Meters: hide'
+};
+
+const TITLE = {
+    off:  'Transmit-only gauges always shown (current behaviour)',
+    dim:  'Transmit-only gauges greyed while receiving — nothing moves',
+    hide: 'Transmit-only gauges hidden while receiving — the row reflows'
+};
+
+export class MeterVisibility {
+    /**
+     * @param {string} rowId    id of the gauges row container
+     * @param {string} btnId    id of the toolbar cycle button (optional)
+     */
+    constructor(rowId, btnId) {
+        this._row = document.getElementById(rowId);
+        this._btn = btnId ? document.getElementById(btnId) : null;
+        this._transmitting = false;
+
+        this._mode = 'off';
+        try {
+            const stored = localStorage.getItem(KEY);
+            if (MODES.includes(stored)) this._mode = stored;
+        } catch { /* private browsing — fall back to the default */ }
+
+        if (this._btn) {
+            this._btn.addEventListener('click', () => {
+                this.setMode(MODES[(MODES.indexOf(this._mode) + 1) % MODES.length]);
+            });
+        }
+        this._apply();
+    }
+
+    /** Called from the IsTransmitting handler in site.js. */
+    setTransmitting(transmitting) {
+        const next = !!transmitting;
+        if (next === this._transmitting) return;
+        this._transmitting = next;
+        this._apply();
+    }
+
+    setMode(mode) {
+        if (!MODES.includes(mode)) return;
+        this._mode = mode;
+        try { localStorage.setItem(KEY, mode); } catch { /* ignore */ }
+        this._apply();
+    }
+
+    get mode() { return this._mode; }
+
+    _apply() {
+        if (!this._row) return;
+
+        // Receive-idle styling only bites while receiving; on transmit every
+        // gauge is live and the row always looks exactly as it does today.
+        const idle = !this._transmitting && this._mode !== 'off';
+        this._row.classList.toggle('meters-idle-dim',  idle && this._mode === 'dim');
+        this._row.classList.toggle('meters-idle-hide', idle && this._mode === 'hide');
+
+        if (this._btn) {
+            this._btn.textContent = LABEL[this._mode];
+            this._btn.title = TITLE[this._mode];
+            this._btn.classList.toggle('active', this._mode !== 'off');
+        }
+    }
+}

--- a/wwwroot/js/ui/meter-visibility.js
+++ b/wwwroot/js/ui/meter-visibility.js
@@ -8,10 +8,11 @@
 //   dim    transmit-only gauges greyed in place, geometry unchanged
 //   hide   transmit-only gauges removed from layout, row reflows
 //
-// Both active modes also grey the S-meters while transmitting, which is the
-// mirror of the same problem: the radio freezes SM0/SM1 at key-down, so those
-// needles are stale for the whole over. See the CSS comment in Index.cshtml
-// for the measurement.
+// Both active modes also grey the S-meters while transmitting AND make them
+// read zero, which is the mirror of the same problem: the radio freezes
+// SM0/SM1 at key-down, so those needles are stale for the whole over. See the
+// CSS comment in Index.cshtml for the measurement, and `suppressSMeters`
+// below for why zeroing is only safe in company with the greying.
 //
 // Which gauges count as transmit-only is decided in the markup, not here: a
 // cell carries data-meter-scope="tx" if it means nothing while receiving.
@@ -79,6 +80,21 @@ export class MeterVisibility {
     }
 
     get mode() { return this._mode; }
+
+    /**
+     * True while the S-meters are being drawn as inactive (greyed).
+     *
+     * The radio freezes SM0/SM1 at key-down, so every reading taken during an
+     * over is a stale snapshot of the moment you keyed. site.js checks this in
+     * updateSMeter() and substitutes 0, so the greyed gauges read zero rather
+     * than sitting at whatever the band happened to be doing when you started
+     * talking. Safe to zero only because the gauge is greyed at the same time:
+     * on its own a zeroed needle would claim "no signal", but dimmed it reads
+     * as "not measuring", which is the truth.
+     */
+    get suppressSMeters() {
+        return this._mode !== 'off' && this._transmitting;
+    }
 
     _apply() {
         if (!this._row) return;

--- a/wwwroot/js/ui/meter-visibility.js
+++ b/wwwroot/js/ui/meter-visibility.js
@@ -8,6 +8,11 @@
 //   dim    transmit-only gauges greyed in place, geometry unchanged
 //   hide   transmit-only gauges removed from layout, row reflows
 //
+// Both active modes also grey the S-meters while transmitting, which is the
+// mirror of the same problem: the radio freezes SM0/SM1 at key-down, so those
+// needles are stale for the whole over. See the CSS comment in Index.cshtml
+// for the measurement.
+//
 // Which gauges count as transmit-only is decided in the markup, not here: a
 // cell carries data-meter-scope="tx" if it means nothing while receiving.
 // S-meters are obviously excluded. So are Temp and VDD, which are NOT
@@ -78,11 +83,18 @@ export class MeterVisibility {
     _apply() {
         if (!this._row) return;
 
-        // Receive-idle styling only bites while receiving; on transmit every
-        // gauge is live and the row always looks exactly as it does today.
-        const idle = !this._transmitting && this._mode !== 'off';
+        const active = this._mode !== 'off';
+
+        // Receiving: the transmit-only gauges are the ones reading nothing.
+        const idle = active && !this._transmitting;
         this._row.classList.toggle('meters-idle-dim',  idle && this._mode === 'dim');
         this._row.classList.toggle('meters-idle-hide', idle && this._mode === 'hide');
+
+        // Transmitting: the S-meters are the ones reading nothing — the radio
+        // freezes both at key-down (measured, see the CSS comment). Always
+        // dimmed, never hidden, in BOTH modes: they sit at the left of the row,
+        // so removing them would shift everything else across on every over.
+        this._row.classList.toggle('meters-tx-dim', active && this._transmitting);
 
         if (this._btn) {
             this._btn.textContent = LABEL[this._mode];

--- a/wwwroot/js/ui/site.js
+++ b/wwwroot/js/ui/site.js
@@ -1338,6 +1338,10 @@ connection.on("RadioStateUpdate", function (update) {
         }
         updateTxButton();
         updateTxIndicators(update.value);
+        // EXPERIMENT (feat/meter-visibility-experiment): de-emphasise the
+        // transmit-only gauges while receiving. No-op unless the operator has
+        // picked dim or hide from the "Meters:" toolbar button.
+        if (window.meterVisibility) window.meterVisibility.setTransmitting(update.value);
         publishTxState();
         if (typeof window.handleTxStateForTimeout === 'function') {
             window.handleTxStateForTimeout(!!update.value);

--- a/wwwroot/js/ui/site.js
+++ b/wwwroot/js/ui/site.js
@@ -3268,6 +3268,21 @@ document.addEventListener('DOMContentLoaded', function() {
         // window.meterPanel has no 'smeterB' gauge (canvas doesn't exist —
         // MeterPanel._createGauges skipped it) and sMeterHistoryB.push() is
         // a no-op (canvas doesn't exist).
+        // EXPERIMENT (feat/meter-visibility-experiment): the radio freezes both
+        // S-meters at key-down and holds them for the whole over — measured on
+        // an FTdx101MP, 101 consecutive transmit samples returned one unchanged
+        // value each. So the raw figure arriving here during transmit is a
+        // stale snapshot, not a reading. Zero it, but only while the gauges are
+        // also greyed (see MeterVisibility.suppressSMeters): greyed-and-zero
+        // reads as "not measuring", whereas zero on its own would claim "no
+        // signal". No-op in the default "all" mode.
+        //
+        // Deliberately placed before everything below, so the gauge, the S-unit
+        // label, the raw readout and the history strip all agree. In particular
+        // the strip now records a floor across each over rather than a flat
+        // line at the frozen value, which was the same lie drawn sideways.
+        if (window.meterVisibility?.suppressSMeters) value = 0;
+
         const gaugeKey   = receiver === 'B' ? 'smeterB' : 'smeter';
         const history     = receiver === 'B' ? window.sMeterHistoryB : window.sMeterHistory;
         const canvasId    = receiver === 'B' ? 'sMeterCanvasB' : 'sMeterCanvas';


### PR DESCRIPTION
> **Scope narrowed since this was opened.** The S-meter transmit fix that was
> originally part of this branch has been split out and merged to `develop` on
> its own (`264e108`), because it is a defect fix rather than a preference and
> should not wait on the question below. It is described under "Related" at the
> end - worth reading, because one of the test questions still concerns it.
> This PR is now **only** the dim-vs-hide experiment and the row reorder.

## What this is

Two separable changes to the meter row.

An experimental toolbar button, "Meters:", cycles three modes. It is there so
the two candidate behaviours can be compared against a real rig. **One of the
two is meant to be deleted before this ships.**

| Mode | Behaviour |
|---|---|
| `all` | Current behaviour, unchanged. The default. |
| `dim` | Transmit-only gauges greyed in place while receiving. Nothing moves. |
| `hide` | Transmit-only gauges removed from layout while receiving. The row reflows. |

The mode persists in `localStorage` under `ywc.meterIdleMode`.

Which gauges count as transmit-only is declared in the markup, not in the JS: a
cell carries `data-meter-scope="tx"` if it means nothing while receiving. That
is SWR, Power, Compression, ALC and IDD - all five are already pinned to zero
during receive by `MeterPollingService`, so nothing live is being suppressed.
Temp and VDD are deliberately NOT tagged: temperature is polled outside the
`isTransmitting` branch, and a hot PA or a sagging supply is worth seeing on
receive, which is exactly when you would look.

The second change reorders the row so the always-meaningful gauges are
contiguous on the left and the transmit-only block sits last:

```
S-A  S-B  Temp  VDD  |  SWR  Power  Comp  ALC  IDD
```

That matters to the `hide` variant specifically: with the transmit-only gauges
last and contiguous, hiding them removes a trailing block, so nothing that
survives changes position.

## Testing on an FTdx10 (@fabiojvalente)

Worth knowing before you look: the FTdx10 renders a much smaller meter row than
the FTdx101MP, because Temp, VDD and IDD are FTdx101/FTDX3000-only and there is
no SUB receiver.

|  | FTdx101MP | FTdx10 |
|---|---|---|
| Receive gauges | S-A, S-B, Temp, VDD | S-A only |
| Transmit gauges | SWR, Power, Comp, ALC, IDD | SWR, Power, Comp, ALC |

So in `hide` mode on receive your row collapses from five gauges to one, where
mine goes from nine to four. That is the most extreme case this change
produces, which is exactly why your opinion is the useful one.

What would help:

1. **Does `hide` look right or look broken on receive?** One gauge on an
   otherwise empty row is a big change. Blunt reaction is what is wanted.
2. **Does `dim` read better than `hide` on your rig?** On the FTdx101MP the
   preference was hide, but that was with four gauges surviving, not one.
3. **Does the FTdx10 freeze its S-meter during transmit too?** See "Related"
   below for what the FTdx101MP does. On develop the S-meter is now greyed and
   zeroed for the duration of an over. If the FTdx10 genuinely keeps measuring
   while transmitting, that would be wrong for your radio and I would want to
   know - the measurement is from one radio and I would not assume it
   generalises.
4. **Anything ugly in the reflow** when switching RX to TX repeatedly in
   `hide` mode - flicker, gauges redrawing at the wrong size, layout jumping.
   `hide` uses `display:none`, which collapses each gauge and makes its
   `ResizeObserver` rebuild it on reappearance. That happens every over, and
   it is a known cost of the hide variant that `dim` does not have.

No need to review the row reorder - it only moves Temp and VDD, which your
radio does not render, so it is invisible on an FTdx10. It does need review
from an FTdx101MP or FTDX3000 user before it ships, since it changes gauge
order for everyone.

## Related: the S-meter transmit fix (already on develop, `264e108`)

While checking whether the S-meters should also be suppressed on transmit, I
measured what the radio actually reports. With YWC stopped, I sampled `TX;`,
`SM0;` and `SM1;` together at about 21 Hz over the serial port on an FTdx101MP:

```
RECEIVE   n=375   SM0 mean 154.2, 29 distinct   SM1 mean 72.8, 21 distinct
TRANSMIT  n=101   SM0 mean 153.3,  2 distinct   SM1 mean 74.3,  2 distinct
```

101 consecutive transmit samples returned `SM0=154 SM1=75` unchanged. The "2
distinct" is the single unkey-transition sample. The last receive value before
key-down latches, and both resume within about 200 ms of release.

`MeterPollingService` polls SM0/SM1 with no transmit gate, unlike SWR which is
forced to zero on receive. So **released YWC drew two plausible-looking needles
throughout every over that were a snapshot from key-down.** On develop they are
now greyed and zeroed for the duration. The two go together: a zeroed needle on
its own would claim "no signal", a different untruth, but greyed-and-zero reads
as "not measuring". Zeroing is applied at the top of `updateSMeter`, so the
gauge, the S-unit label, the raw readout and the 30-second history strip all
agree.

Incidental finding worth recording: **TUNE registers as `TX2`**, so it is a
valid way to drive transmit tests without putting out a signal.

## Open questions before any of this ships

- **Whether to ship the visibility modes at all.**
- **Whether the row reorder ships independently.** It stands on its own, but it
  changes gauge order for 100+ existing users, which is muscle memory.
- When a variant wins, the losing variant and the "Meters:" toolbar button come
  out together. The `data-meter-scope` tagging is the part worth keeping, and
  is a candidate for the shared core so IWC gets it too.
