### PR TITLE
Design note: drive the radio's own scope and meters over CAT

### DIFF
--- a/Controllers/ScopeController.cs
+++ b/Controllers/ScopeController.cs
@@ -1,0 +1,356 @@
+using Microsoft.AspNetCore.Mvc;
+using Yaesu_Web_Control.Services;
+
+namespace Yaesu_Web_Control.Controllers;
+
+/// <summary>
+/// Drives the radio's OWN spectrum scope over CAT (the SS command).
+///
+/// This is not YWC's SDR spectrum panel — that is separate hardware fed by an
+/// RSP1 on the rear-panel IF output, and nothing here touches it. What these
+/// endpoints change is what the operator sees on the radio's front-panel TFT,
+/// which is useful when operating remotely, and useful again when that TFT is
+/// being captured to the browser as video. See
+/// docs/design/scope-control-via-cat.md for why this beats drawing clickable
+/// overlays on top of the captured picture.
+///
+/// Deliberately a separate controller rather than more endpoints bolted onto
+/// CatController (which is already 3000 lines): this feature is new, is gated
+/// per model, and may not survive contact with users. Keeping it in one file
+/// means it can be judged — or deleted — on its own.
+///
+/// Every write is followed by a read-back, and the read-back is what the API
+/// returns. The radio, not our optimism, is the source of truth for what the
+/// scope is now showing; that matters here more than usual because the operator
+/// may be sitting in front of the radio changing the same settings by hand.
+/// </summary>
+[ApiController]
+[Route("api/scope")]
+public class ScopeController : ControllerBase
+{
+    private readonly ICatClient _catClient;
+    private readonly ISettingsService _settingsService;
+    private readonly RadioStateService _radioState;
+    private readonly ILogger<ScopeController> _logger;
+
+    // SS frames are short and the radio answers them promptly, but they share
+    // the port with the ~10 Hz meter poll. One at a time, same as CatController.
+    private static readonly SemaphoreSlim _gate = new(1, 1);
+
+    // How long to let the radio redraw before reading a setting back after a
+    // write. Measured on an FTdx101MP: without it, roughly one read in three
+    // following a mode change goes unanswered.
+    private const int SettleAfterWriteMs = 150;
+
+    // Gap before a retried read. Deliberately shorter than the settle delay —
+    // by this point the radio has already had the settle window.
+    private const int RetryDelayMs = 80;
+
+    public ScopeController(
+        ICatClient catClient,
+        ISettingsService settingsService,
+        RadioStateService radioState,
+        ILogger<ScopeController> logger)
+    {
+        _catClient       = catClient;
+        _settingsService = settingsService;
+        _radioState      = radioState;
+        _logger          = logger;
+    }
+
+    // ── Endpoints ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// GET /api/scope/main | /api/scope/sub
+    /// Reads the scope settings the UI exposes, straight from the radio.
+    /// </summary>
+    [HttpGet("{band}")]
+    public async Task<IActionResult> GetState(string band)
+    {
+        if (!TryBand(band, out var p1, out var bandError))
+            return BadRequest(new { error = bandError });
+
+        if (!Supported(out var model))
+            return NotSupported(model);
+
+        if (!await _gate.WaitAsync(2000))
+            return StatusCode(503, new { error = "Radio busy" });
+        try
+        {
+            await EnsureConnectedAsync();
+            return Ok(await ReadStateAsync(p1, model));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error reading scope state for {Band}", band);
+            return StatusCode(500, new { error = "Failed to read scope state" });
+        }
+        finally { _gate.Release(); }
+    }
+
+    /// <summary>
+    /// POST /api/scope/{main|sub}/{setting}   body: { "value": "..." }
+    ///
+    /// setting is one of: span, mode, hold, marker, peak, speed, level.
+    /// Returns the re-read state, so the caller can see what the radio actually
+    /// did rather than what it was asked to do.
+    ///
+    /// Route token is {setting}, NOT {action}: "action" is a reserved ASP.NET
+    /// Core routing token and an attribute route using it silently fails to
+    /// register, 404ing every request. That already cost a debugging session
+    /// once on the QMB endpoints — see CatController.Qmb.
+    /// </summary>
+    [HttpPost("{band}/{setting}")]
+    public async Task<IActionResult> Set(string band, string setting, [FromBody] ScopeSetRequest? request)
+    {
+        if (!TryBand(band, out var p1, out var bandError))
+            return BadRequest(new { error = bandError });
+
+        if (!Supported(out var model))
+            return NotSupported(model);
+
+        var value = request?.Value?.Trim() ?? "";
+        if (value.Length == 0)
+            return BadRequest(new { error = "value is required" });
+
+        string frame;
+        switch (setting.ToLowerInvariant())
+        {
+            case "span":
+                if (!TryDigit(value, 0, 9, out var span))
+                    return BadRequest(new { error = "span must be 0-9 (0 = 1 kHz … 9 = 1 MHz)" });
+                frame = ScopeCommands.Set(p1, ScopeCommands.Span, span);
+                break;
+
+            case "mode":
+                // The UI sends the composed P3 character rather than the three
+                // axes, so the composition rule lives in exactly one place
+                // (ScopeCommands.ModeValue, which the browser mirrors). Validate
+                // the size against the model here anyway: the FT-710 has no
+                // third size, and sending a value its manual prints as "-" is a
+                // guess, not a feature.
+                if (value.Length != 1 || !IsModeChar(value[0]))
+                    return BadRequest(new { error = "mode must be a single character 0-9 or A-B" });
+                var (is3dss, _, size) = ScopeCommands.ParseMode(value[0]);
+                var sizes = RadioCapabilities.ScopeSizeLabels(model);
+                if (!is3dss && size >= sizes.Length)
+                    return BadRequest(new
+                    {
+                        error = $"{model} has {sizes.Length} scope size options ({string.Join(" / ", sizes)}); size index {size} does not exist on this radio"
+                    });
+                frame = ScopeCommands.Set(p1, ScopeCommands.Mode, char.ToUpperInvariant(value[0]));
+                break;
+
+            case "hold":
+                if (!RadioCapabilities.SupportsScopeHold(model))
+                    return BadRequest(new { error = $"{model} has no scope HOLD — its SS sub-commands stop at 7" });
+                if (!TryDigit(value, 0, 1, out var hold))
+                    return BadRequest(new { error = "hold must be 0 (off) or 1 (on)" });
+                frame = ScopeCommands.Set(p1, ScopeCommands.Hold, hold);
+                break;
+
+            case "marker":
+                if (!TryDigit(value, 0, 1, out var marker))
+                    return BadRequest(new { error = "marker must be 0 (off) or 1 (on)" });
+                frame = ScopeCommands.Set(p1, ScopeCommands.Marker, marker);
+                break;
+
+            case "peak":
+                if (!TryDigit(value, 0, 4, out var peak))
+                    return BadRequest(new { error = "peak must be 0-4 (LV1-LV5)" });
+                frame = ScopeCommands.Set(p1, ScopeCommands.Peak, peak);
+                break;
+
+            case "speed":
+                // The FT-710 adds a sixth setting, STOP (5); the others stop at
+                // FAST3 (4).
+                var maxSpeed = model == "FT-710" ? 5 : 4;
+                if (!TryDigit(value, 0, maxSpeed, out var speed))
+                    return BadRequest(new { error = $"speed must be 0-{maxSpeed} for {model}" });
+                frame = ScopeCommands.Set(p1, ScopeCommands.Speed, speed);
+                break;
+
+            case "level":
+                if (!double.TryParse(value, System.Globalization.NumberStyles.Float,
+                                     System.Globalization.CultureInfo.InvariantCulture, out var db))
+                    return BadRequest(new { error = "level must be a number of dB, -30.0 to +30.0" });
+                frame = ScopeCommands.SetLevel(p1, db);
+                break;
+
+            default:
+                return BadRequest(new
+                {
+                    error = $"Unknown scope setting '{setting}'. Expected span, mode, hold, marker, peak, speed or level."
+                });
+        }
+
+        if (!await _gate.WaitAsync(2000))
+            return StatusCode(503, new { error = "Radio busy" });
+        try
+        {
+            await EnsureConnectedAsync();
+            await _catClient.SendCommandAsync(frame, "WebUI", CancellationToken.None);
+            _logger.LogInformation("Scope {Band} {Setting} -> {Frame}", band, setting, frame);
+
+            // Let the radio finish redrawing before reading back. A mode change
+            // rebuilds the whole scope display, and reads issued into that
+            // window are simply not answered — measured at roughly one in three
+            // on an FTdx101MP with the meter poll running. ReadValueAsync
+            // retries once on top of this, but the delay is what stops most of
+            // them happening at all.
+            await Task.Delay(SettleAfterWriteMs);
+
+            var state = await ReadStateAsync(p1, model);
+            return Ok(state);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error setting scope {Setting} on {Band}", setting, band);
+            return StatusCode(500, new { error = $"Failed to set scope {setting}" });
+        }
+        finally { _gate.Release(); }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Reads the sub-commands the UI shows. HOLD is skipped entirely on models
+    /// without it rather than read and discarded — an unanswered read costs a
+    /// timeout on a port shared with the meter poll.
+    /// </summary>
+    private async Task<object> ReadStateAsync(char p1, string model)
+    {
+        var span   = await ReadValueAsync(p1, ScopeCommands.Span);
+        var mode   = await ReadValueAsync(p1, ScopeCommands.Mode);
+        var marker = await ReadValueAsync(p1, ScopeCommands.Marker);
+        var peak   = await ReadValueAsync(p1, ScopeCommands.Peak);
+        var speed  = await ReadValueAsync(p1, ScopeCommands.Speed);
+        var level  = await ReadFieldAsync(p1, ScopeCommands.Level);
+
+        char? hold = null;
+        if (RadioCapabilities.SupportsScopeHold(model))
+            hold = await ReadValueAsync(p1, ScopeCommands.Hold);
+
+        var (is3dss, placement, size) = mode is { } m
+            ? ScopeCommands.ParseMode(m)
+            : (false, 0, 0);
+
+        return new
+        {
+            band      = p1 == '1' ? "sub" : "main",
+            span      = span?.ToString(),
+            mode      = mode?.ToString(),
+            is3dss,
+            placement,
+            size,
+            hold      = hold?.ToString(),
+            marker    = marker?.ToString(),
+            peak      = peak?.ToString(),
+            speed     = speed?.ToString(),
+            // Sent as the raw five-character field ("+05.0") — the browser
+            // displays it as-is, so there is no float round-trip to disagree
+            // about.
+            level,
+        };
+    }
+
+    private async Task<char?> ReadValueAsync(char p1, char subCommand) =>
+        (await ReadFieldAsync(p1, subCommand)) is { Length: > 0 } f ? f[0] : null;
+
+    /// <summary>
+    /// Reads one SS sub-command, retrying once if the radio does not answer.
+    ///
+    /// Unanswered reads are real and expected rather than a fault: the radio
+    /// stops answering while it redraws its scope, so the read that follows a
+    /// mode change is the one that gets dropped. One retry clears it. Anything
+    /// still unanswered after that is reported as null and shown as "unknown"
+    /// rather than guessed at — a scope control that displays a stale value as
+    /// though it were current is worse than one that admits it does not know.
+    /// </summary>
+    private async Task<string?> ReadFieldAsync(char p1, char subCommand)
+    {
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            if (attempt > 0) await Task.Delay(RetryDelayMs);
+
+            var answer = await _catClient.SendCommandAsync(
+                ScopeCommands.Read(p1, subCommand), "WebUI", CancellationToken.None);
+
+            var field = ScopeCommands.ValueField(answer, p1, subCommand);
+            if (field is not null) return field;
+        }
+
+        _logger.LogDebug("Scope read SS{P1}{P2} unanswered after retry", p1, subCommand);
+        return null;
+    }
+
+    private async Task EnsureConnectedAsync()
+    {
+        if (_catClient.IsConnected) return;
+        var settings = await _settingsService.GetSettingsAsync();
+        await _catClient.ConnectAsync(settings.SerialPort, settings.BaudRate);
+    }
+
+    private bool Supported(out string model)
+    {
+        model = _radioState.RadioModel ?? "";
+        return RadioCapabilities.SupportsSpectrumScopeCat(model);
+    }
+
+    private IActionResult NotSupported(string model) => BadRequest(new
+    {
+        error = string.IsNullOrEmpty(model)
+            ? "No radio model is configured, so scope control is unavailable."
+            : $"{model} cannot have its scope driven over CAT."
+    });
+
+    /// <summary>
+    /// Maps the route's band segment to SS P1. Accepts A/B as well as main/sub
+    /// because the rest of YWC's API speaks in VFO letters; the scope command
+    /// speaks in MAIN/SUB, and they are the same two things.
+    ///
+    /// On single-receiver radios P1 is documented as "0: (Fixed)", so "sub" is
+    /// rejected rather than quietly rewritten to MAIN — a UI asking for a SUB
+    /// scope on a radio that has one receiver is a bug worth hearing about.
+    /// </summary>
+    private bool TryBand(string band, out char p1, out string error)
+    {
+        p1 = '0';
+        error = "";
+        var b = band.ToLowerInvariant();
+        var wantsSub = b is "sub" or "b";
+        if (!wantsSub && b is not ("main" or "a"))
+        {
+            error = "band must be 'main' or 'sub' (or 'a' / 'b')";
+            return false;
+        }
+
+        if (wantsSub && !RadioCapabilities.HasPerReceiverScopes(_radioState.RadioModel ?? ""))
+        {
+            error = $"{_radioState.RadioModel} has a single scope; SS P1 is fixed at 0 on this radio";
+            return false;
+        }
+
+        p1 = ScopeCommands.BandDigit(wantsSub);
+        return true;
+    }
+
+    private static bool TryDigit(string value, int min, int max, out char digit)
+    {
+        digit = '0';
+        if (value.Length != 1 || value[0] < '0' || value[0] > '9') return false;
+        var n = value[0] - '0';
+        if (n < min || n > max) return false;
+        digit = value[0];
+        return true;
+    }
+
+    private static bool IsModeChar(char c) =>
+        (c >= '0' && c <= '9') || (c is >= 'A' and <= 'B') || (c is >= 'a' and <= 'b');
+}
+
+/// <summary>Request body for a scope setting change.</summary>
+public sealed class ScopeSetRequest
+{
+    public string? Value { get; set; }
+}

--- a/Controllers/ScopeController.cs
+++ b/Controllers/ScopeController.cs
@@ -78,6 +78,13 @@ public class ScopeController : ControllerBase
         try
         {
             await EnsureConnectedAsync();
+            // Logged at Information alongside the writes. A read changes nothing
+            // on the radio, so it is invisible from the operating position — and
+            // when someone reports "pressing the buttons does nothing", the first
+            // question is whether the request arrived at all. Without this line a
+            // scope panel whose JS never wired up and one that is working
+            // normally produce byte-identical logs.
+            _logger.LogInformation("Scope {Band} read", band);
             return Ok(await ReadStateAsync(p1, model));
         }
         catch (Exception ex)

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -784,6 +784,18 @@
         </div>
     </div>
 
+    @* Controls for the RADIO's own scope, sent over CAT (SS command). Renders
+       only on models that have the command; collapsed by default so the page
+       gains one header row, not a wall of controls.
+
+       Placement is not settled. It sits above YWC's own spectrum panels here
+       because both concern "what am I looking at on which band", but it could
+       equally live beside the meters or behind a toolbar button. It is a
+       partial precisely so that argument can be had by moving one line.
+
+       See docs/design/scope-control-via-cat.md. *@
+    <partial name="_RadioScopePartial" model="@Model.RadioModel" />
+
     <!-- Spectrum Display — dual-VFO layout (v2.3.0+).
          Each panel has its own canvas. Mono A / Mono B / Multi toggle below
          hides/shows individual panels. Outer container hides itself when no
@@ -2404,6 +2416,7 @@
         import { initMemoriesPanel }   from "/js/ui/memories.js?v=@Yaesu_Web_Control.AppVersion.Current";
         import { DxSpotsPanel }         from "/js/ui/dx-spots-panel.js?v=@Yaesu_Web_Control.AppVersion.Current";
         import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=@Yaesu_Web_Control.AppVersion.Current";
+        import { RadioScopeControl }    from "/js/ui/radio-scope.js?v=@Yaesu_Web_Control.AppVersion.Current";
         window.bandPlanData = BAND_PLANS;
         window.getBandSegments = getSegments;
         window.getBandSegmentForHz = segmentForHz;
@@ -2438,6 +2451,11 @@
         document.addEventListener('DOMContentLoaded', function () {
             initFreqKeyboard();
             initMemoriesPanel();
+
+            // Radio-scope CAT controls. The constructor no-ops when the card is
+            // absent, which is the case on every model without the SS command,
+            // so there is no capability check to keep in sync here.
+            window.radioScopeControl = new RadioScopeControl();
 
             // ── UTC clock in the top bar ──────────────────────────────────────
             const utcClockEl = document.getElementById('utcClock');

--- a/Pages/Shared/_RadioScopePartial.cshtml
+++ b/Pages/Shared/_RadioScopePartial.cshtml
@@ -1,4 +1,5 @@
 @model string
+@inject Yaesu_Web_Control.Services.RadioStateService RadioState
 @{
     // Controls for the RADIO's own spectrum scope, driven over CAT with the SS
     // command. Nothing here touches YWC's SDR spectrum panel — that is separate
@@ -16,6 +17,13 @@
     var hasHold    = Yaesu_Web_Control.Services.RadioCapabilities.SupportsScopeHold(radioModel);
     var hasSub     = Yaesu_Web_Control.Services.RadioCapabilities.HasPerReceiverScopes(radioModel);
     var sizeLabels = Yaesu_Web_Control.Services.RadioCapabilities.ScopeSizeLabels(radioModel);
+
+    // Start pointed at whichever band the radio is actually operating on, so the
+    // panel opens aimed at the scope on screen. Rendered server-side rather than
+    // left to the first SignalR ActiveVfo broadcast: the panel can be expanded
+    // and read from before any broadcast arrives, and being aimed at the wrong
+    // scope for even one interaction is exactly the confusion this avoids.
+    var initialBand = (hasSub && RadioState.ActiveVfo == 1) ? "sub" : "main";
 
     // SS P2=5 span table — identical across every model that has the command.
     var spans = new (string Value, string Label)[]
@@ -37,7 +45,7 @@
 
 @if (hasScope)
 {
-    <div id="radioScopeCard" class="card border-dark mt-3">
+    <div id="radioScopeCard" class="card border-dark mt-3" data-initial-band="@initialBand">
         <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center py-1"
              role="button" tabindex="0" id="radioScopeToggle"
              aria-expanded="false" aria-controls="radioScopeBody"
@@ -54,16 +62,30 @@
         <div id="radioScopeBody" class="card-body py-2" style="display:none;">
             @if (hasSub)
             {
-                <div class="d-flex align-items-center gap-2 mb-2">
-                    <span class="small text-muted" style="min-width:5.5em;">Scope</span>
-                    <div class="btn-group btn-group-sm" role="group" aria-label="Which scope to control">
-                        <button type="button" class="btn btn-outline-secondary active scope-band-btn"
+                @* These SWITCH THE RADIO's band, via the same VS command and the
+                   same endpoint as clicking a VFO panel header. The radio shows
+                   the scope of whichever band is operating, so "show me the SUB
+                   scope" and "make SUB the operating band" are the same request —
+                   there is no way to display one band's scope while operating the
+                   other, and pretending otherwise is what made the first version
+                   of this row so confusing. The controls below then follow the
+                   band automatically (see setActiveBand in radio-scope.js). *@
+                <div class="d-flex align-items-center gap-2 mb-1">
+                    <span class="small text-muted" style="min-width:5.5em;">Band</span>
+                    <div class="btn-group btn-group-sm" role="group" aria-label="Which band's scope to show and adjust">
+                        <button type="button" class="btn btn-outline-secondary scope-band-btn @(initialBand == "main" ? "active" : "")"
                                 data-band="main" data-a11y-key="radioScope.bandMain"
-                                title="Control the MAIN band scope">MAIN</button>
-                        <button type="button" class="btn btn-outline-secondary scope-band-btn"
+                                title="Switch the radio to MAIN — the screen shows the MAIN scope and the controls below follow">MAIN</button>
+                        <button type="button" class="btn btn-outline-secondary scope-band-btn @(initialBand == "sub" ? "active" : "")"
                                 data-band="sub" data-a11y-key="radioScope.bandSub"
-                                title="Control the SUB band scope — the FTdx101 keeps the two entirely separate">SUB</button>
+                                title="Switch the radio to SUB — the screen shows the SUB scope and the controls below follow">SUB</button>
                     </div>
+                </div>
+                <div class="form-text mb-2">
+                    Switches the radio's band, exactly as clicking the VFO A or VFO B panel header
+                    does. The radio displays the scope of whichever band is operating, so this is
+                    also how you choose which scope you are looking at &mdash; the controls below
+                    follow it automatically.
                 </div>
             }
 

--- a/Pages/Shared/_RadioScopePartial.cshtml
+++ b/Pages/Shared/_RadioScopePartial.cshtml
@@ -1,0 +1,157 @@
+@model string
+@{
+    // Controls for the RADIO's own spectrum scope, driven over CAT with the SS
+    // command. Nothing here touches YWC's SDR spectrum panel — that is separate
+    // hardware fed from the rear-panel IF output. The two are easy to confuse,
+    // which is why the header says "the radio's own display" out loud.
+    //
+    // Deliberately a partial taking only the model name: placement on the page
+    // is still an open question, so relocating this is a matter of moving one
+    // <partial> line rather than a block of markup. Do not inline it back into
+    // Index.cshtml until that question is settled.
+    //
+    // See docs/design/scope-control-via-cat.md.
+    var radioModel = Model ?? "";
+    var hasScope   = Yaesu_Web_Control.Services.RadioCapabilities.SupportsSpectrumScopeCat(radioModel);
+    var hasHold    = Yaesu_Web_Control.Services.RadioCapabilities.SupportsScopeHold(radioModel);
+    var hasSub     = Yaesu_Web_Control.Services.RadioCapabilities.HasPerReceiverScopes(radioModel);
+    var sizeLabels = Yaesu_Web_Control.Services.RadioCapabilities.ScopeSizeLabels(radioModel);
+
+    // SS P2=5 span table — identical across every model that has the command.
+    var spans = new (string Value, string Label)[]
+    {
+        ("0", "1k"), ("1", "2k"), ("2", "5k"), ("3", "10k"), ("4", "20k"),
+        ("5", "50k"), ("6", "100k"), ("7", "200k"), ("8", "500k"), ("9", "1M")
+    };
+
+    // Long-form size names for the tooltips. The FT-710's two-entry vocabulary
+    // is genuinely different, not an abbreviation of the other radios' three.
+    string SizeTitle(string s) => s switch
+    {
+        "L"      => "Large",
+        "N"      => "Normal",
+        "S"      => "Small",
+        _        => s
+    };
+}
+
+@if (hasScope)
+{
+    <div id="radioScopeCard" class="card border-dark mt-3">
+        <div class="card-header bg-dark text-white d-flex justify-content-between align-items-center py-1"
+             role="button" tabindex="0" id="radioScopeToggle"
+             aria-expanded="false" aria-controls="radioScopeBody"
+             title="Change what the radio's own screen is showing. Collapsed by default — these controls drive the radio, not the spectrum panel below.">
+            <span class="small fw-bold">
+                <i class="bi bi-display me-1" aria-hidden="true"></i>Radio Scope &mdash; the radio's own display
+            </span>
+            <span class="d-flex align-items-center gap-2">
+                <span id="radioScopeStatus" class="badge bg-secondary small">&mdash;</span>
+                <i id="radioScopeChevron" class="bi bi-chevron-down" aria-hidden="true"></i>
+            </span>
+        </div>
+
+        <div id="radioScopeBody" class="card-body py-2" style="display:none;">
+            @if (hasSub)
+            {
+                <div class="d-flex align-items-center gap-2 mb-2">
+                    <span class="small text-muted" style="min-width:5.5em;">Scope</span>
+                    <div class="btn-group btn-group-sm" role="group" aria-label="Which scope to control">
+                        <button type="button" class="btn btn-outline-secondary active scope-band-btn"
+                                data-band="main" data-a11y-key="radioScope.bandMain"
+                                title="Control the MAIN band scope">MAIN</button>
+                        <button type="button" class="btn btn-outline-secondary scope-band-btn"
+                                data-band="sub" data-a11y-key="radioScope.bandSub"
+                                title="Control the SUB band scope — the FTdx101 keeps the two entirely separate">SUB</button>
+                    </div>
+                </div>
+            }
+
+            <div class="d-flex align-items-center gap-2 mb-2 flex-wrap">
+                <span class="small text-muted" style="min-width:5.5em;">Span</span>
+                <div class="btn-group btn-group-sm flex-wrap" role="group" aria-label="Radio scope span">
+                    @foreach (var (value, label) in spans)
+                    {
+                        <button type="button" class="btn btn-outline-secondary scope-span-btn"
+                                data-value="@value" data-a11y-key="radioScope.span@(label)"
+                                aria-label="Radio scope span @label" title="Radio scope span @label">@label</button>
+                    }
+                </div>
+            </div>
+
+            <div class="d-flex align-items-center gap-2 mb-2 flex-wrap">
+                <span class="small text-muted" style="min-width:5.5em;">Display</span>
+                <div class="btn-group btn-group-sm" role="group" aria-label="Radio scope display type">
+                    <button type="button" class="btn btn-outline-secondary scope-type-btn"
+                            data-value="wf" data-a11y-key="radioScope.typeWf"
+                            title="Waterfall display">W/F</button>
+                    <button type="button" class="btn btn-outline-secondary scope-type-btn"
+                            data-value="3dss" data-a11y-key="radioScope.type3dss"
+                            title="3DSS — the radio's three-dimensional spectrum stream display">3DSS</button>
+                </div>
+
+                <div class="btn-group btn-group-sm ms-2" role="group" aria-label="Radio scope placement">
+                    <button type="button" class="btn btn-outline-secondary scope-place-btn"
+                            data-value="0" data-a11y-key="radioScope.placeCenter"
+                            title="Centre — the scope stays centred on the operating frequency">Center</button>
+                    <button type="button" class="btn btn-outline-secondary scope-place-btn"
+                            data-value="1" data-a11y-key="radioScope.placeCursor"
+                            title="Cursor — the marker moves within a fixed window">Cursor</button>
+                    <button type="button" class="btn btn-outline-secondary scope-place-btn"
+                            data-value="2" data-a11y-key="radioScope.placeFix"
+                            title="Fix — the window stays put on the band regardless of where you tune">Fix</button>
+                </div>
+
+                @* Size applies to the waterfall modes only — 3DSS has no size
+                   variants at all, so the group is disabled rather than hidden
+                   when 3DSS is selected. Hiding it would reflow the row every
+                   time the operator switched display type. *@
+                <div id="scopeSizeGroup" class="btn-group btn-group-sm ms-2" role="group" aria-label="Radio scope size">
+                    @for (var i = 0; i < sizeLabels.Length; i++)
+                    {
+                        <button type="button" class="btn btn-outline-secondary scope-size-btn"
+                                data-value="@i" data-a11y-key="radioScope.size@(sizeLabels[i])"
+                                title="@SizeTitle(sizeLabels[i]) — waterfall modes only">@sizeLabels[i]</button>
+                    }
+                </div>
+            </div>
+
+            <div class="d-flex align-items-center gap-2 flex-wrap">
+                <span class="small text-muted" style="min-width:5.5em;">Options</span>
+                @if (hasHold)
+                {
+                    <button type="button" class="btn btn-outline-secondary btn-sm scope-toggle-btn"
+                            data-setting="hold" data-a11y-key="radioScope.hold"
+                            title="Freeze the radio's scope trace so you can study it. Click again to resume.">Hold</button>
+                }
+                <button type="button" class="btn btn-outline-secondary btn-sm scope-toggle-btn"
+                        data-setting="marker" data-a11y-key="radioScope.marker"
+                        title="Show or hide the frequency marker on the radio's scope">Marker</button>
+
+                <span class="small text-muted ms-2">Level</span>
+                <input type="range" class="form-range" id="scopeLevelSlider"
+                       min="-30" max="30" step="0.5" value="0"
+                       aria-label="Radio scope reference level in dB"
+                       title="Reference level of the radio's scope, -30 to +30 dB in 0.5 dB steps"
+                       style="flex:0 1 140px; min-width:90px;">
+                <span id="scopeLevelLabel" class="text-monospace small" style="min-width:4em;">&mdash;</span>
+            </div>
+
+            @if (!hasHold)
+            {
+                <div class="form-text mt-2">
+                    The @radioModel has no scope Hold — its SS command genuinely stops one
+                    sub-command short of the FTdx101 and FTdx10, so there is nothing to send.
+                </div>
+            }
+            <div class="form-text mt-1">
+                The radio keeps a separate span for each display mode, so the highlighted span
+                may change when you switch between W/F and 3DSS. That is the radio doing it, not YWC.
+            </div>
+            <div class="form-text mt-1">
+                Mono / Multi cannot be changed from here: Yaesu exposes no CAT command for it
+                on any supported model. It stays a front-panel control.
+            </div>
+        </div>
+    </div>
+}

--- a/Services/CatCommands.cs
+++ b/Services/CatCommands.cs
@@ -321,6 +321,152 @@
         };
     }
 
+    /// <summary>
+    /// Frame construction for SS (SPECTRUM SCOPE) — the radio's OWN display,
+    /// not YWC's SDR spectrum panel. See docs/design/scope-control-via-cat.md.
+    ///
+    /// Frame shape, confirmed against a real FTdx101MP rather than inferred from
+    /// the CAT manual (whose table is mangled by the PDF layout):
+    ///
+    ///     Set / Answer   SS P1 P2 P3P4P5P6P7 ;    10 characters
+    ///     Read           SS P1 P2 ;                5 characters
+    ///
+    /// P3-P7 is ONE five-character value field, not five one-character fields.
+    /// LEVEL uses all five ("+05.0"); every other sub-command uses the first
+    /// character and pads the rest with zeros. Reading SS04; on the bench
+    /// answered SS04+05.0; which is what settles it.
+    ///
+    /// Everything here builds the padded field in one place on purpose. Writing
+    /// the pad at each call site is exactly the kind of detail that gets
+    /// miscounted, and the radio is tolerant enough of a malformed tail to hide
+    /// the mistake — the write probe accidentally sent a NUL in the pad and the
+    /// radio still applied the value.
+    /// </summary>
+    public static class ScopeCommands
+    {
+        public const string Opcode = "SS";
+
+        // P2 sub-command selectors.
+        public const char Speed  = '0';
+        public const char Peak   = '1';
+        public const char Marker = '2';
+        public const char Color  = '3';
+        public const char Level  = '4';
+        public const char Span   = '5';
+        public const char Mode   = '6';
+        public const char AfFft  = '7';
+        public const char Hold   = '8';   // absent on FT-710
+
+        /// <summary>P1: 0 = MAIN scope, 1 = SUB scope. Fixed at 0 on every
+        /// model except the FTdx101 family.</summary>
+        public static char BandDigit(bool isSub) => isSub ? '1' : '0';
+
+        /// <summary>Read frame, e.g. Read('0', Span) => "SS05;".</summary>
+        public static string Read(char band, char subCommand) =>
+            $"{Opcode}{band}{subCommand};";
+
+        /// <summary>
+        /// Set frame for the single-character sub-commands (everything except
+        /// LEVEL), e.g. Set('0', Span, '4') => "SS0540000;".
+        /// </summary>
+        public static string Set(char band, char subCommand, char value) =>
+            $"{Opcode}{band}{subCommand}{value}0000;";
+
+        /// <summary>
+        /// Set frame for LEVEL, which is the one sub-command that uses the whole
+        /// five-character field: -30.0 to +30.0 in 0.5 dB steps, always signed
+        /// and always zero-padded to two integer digits ("+05.0", "-30.0").
+        /// </summary>
+        public static string SetLevel(char band, double db)
+        {
+            // Clamp then snap to the radio's 0.5 dB grid; a value off the grid
+            // is not a rounding nicety, the radio rejects the frame.
+            var clamped = Math.Clamp(db, -30.0, 30.0);
+            var snapped = Math.Round(clamped * 2, MidpointRounding.AwayFromZero) / 2;
+            var sign    = snapped < 0 ? '-' : '+';
+            var field   = $"{sign}{Math.Abs(snapped):00.0}";
+            return $"{Opcode}{band}{Level}{field};";
+        }
+
+        /// <summary>
+        /// Extracts the five-character value field from an SS answer, or null if
+        /// the answer is not the expected shape. "SS0540000;" => "40000".
+        ///
+        /// The terminator is optional on the way in. On the wire the radio always
+        /// sends it, but CatMultiplexerService strips it before handing the
+        /// answer back, so a parser that insists on it works perfectly against a
+        /// raw serial probe and then returns null for everything in the actual
+        /// app. It did exactly that once already.
+        /// </summary>
+        public static string? ValueField(string? answer, char band, char subCommand)
+        {
+            if (string.IsNullOrEmpty(answer)) return null;
+            var a = answer.TrimEnd();
+            if (a.EndsWith(';')) a = a[..^1];
+            if (a.Length != 9) return null;
+            if (a[0] != 'S' || a[1] != 'S') return null;
+            if (a[2] != band || a[3] != subCommand) return null;
+            return a.Substring(4, 5);
+        }
+
+        /// <summary>
+        /// The P3 character of an SS answer — the value for every sub-command
+        /// except LEVEL. Returns null if the answer did not parse.
+        /// </summary>
+        public static char? Value(string? answer, char band, char subCommand) =>
+            ValueField(answer, band, subCommand) is { Length: > 0 } f ? f[0] : null;
+
+        // ── MODE (P2=6) composition ──────────────────────────────────────────
+        //
+        // The twelve mode values are not an arbitrary list, they are a 2x3x3
+        // grid, which is why the UI offers three small selectors rather than one
+        // twelve-entry dropdown:
+        //
+        //   0,1,2  3DSS      CENTER / CURSOR / FIX          (no size variants)
+        //   3,4,5  W/F       CENTER  x  L / N / S
+        //   6,7,8  W/F       CURSOR  x  L / N / S
+        //   9,A,B  W/F       FIX     x  L / N / S
+        //
+        // The FT-710 uses the same positions with only two sizes
+        // (EXPAND / NORMAL) and documents the third slot of each group as "-",
+        // i.e. it does not exist. Callers must therefore range-check `size`
+        // against RadioCapabilities.ScopeSizeLabels for the model.
+
+        public const int PlacementCenter = 0;
+        public const int PlacementCursor = 1;
+        public const int PlacementFix    = 2;
+
+        /// <summary>
+        /// Composes the P3 mode character from the three axes the UI exposes.
+        /// 3DSS has no size variants, so <paramref name="size"/> is ignored when
+        /// <paramref name="is3dss"/> is true.
+        /// </summary>
+        public static char ModeValue(bool is3dss, int placement, int size)
+        {
+            placement = Math.Clamp(placement, 0, 2);
+            if (is3dss) return (char)('0' + placement);
+
+            var index = 3 + placement * 3 + Math.Clamp(size, 0, 2);
+            // 10 and 11 are 'A' and 'B', not '10' and '11'.
+            return index < 10 ? (char)('0' + index) : (char)('A' + index - 10);
+        }
+
+        /// <summary>Decomposes a P3 mode character back into the three axes.</summary>
+        public static (bool Is3dss, int Placement, int Size) ParseMode(char value)
+        {
+            var index = value switch
+            {
+                >= '0' and <= '9' => value - '0',
+                >= 'A' and <= 'B' => value - 'A' + 10,
+                >= 'a' and <= 'b' => value - 'a' + 10,
+                _                 => 0
+            };
+            if (index < 3) return (true, index, 0);
+            var offset = index - 3;
+            return (false, offset / 3, offset % 3);
+        }
+    }
+
     public static class IFCommandParser
     {
         public static (long frequency, string mode) ParseIFResponse(string response)

--- a/Services/CatMessageDispatcher.cs
+++ b/Services/CatMessageDispatcher.cs
@@ -480,6 +480,38 @@
                         if (message.Length >= 4 && int.TryParse(message.Substring(2, 1), out int txVfo))
                             _stateService.TxVfo = txVfo;
                         break;
+                    case "SS":
+                        // SS P1 P2 {5-char field}; — SPECTRUM SCOPE. The radio
+                        // announces scope changes made at its own front panel,
+                        // one message per sub-command, tagged with the band.
+                        //
+                        // Measured on an FTdx101MP, 2026-08-15: SPAN (P2=5),
+                        // MODE (6) and HOLD (8) all report. A mode change
+                        // arrives as TWO messages a few ms apart — the new mode
+                        // and the span that mode carries, because the radio
+                        // stores span per display mode. MARKER and LEVEL were
+                        // never observed, which may mean they do not report or
+                        // may only mean they were not touched during the test;
+                        // routing on P2 instead of listing sub-commands means it
+                        // costs nothing to be wrong about that.
+                        //
+                        // Deliberately not stored: the scope panel holds this
+                        // state in the browser and re-reads it on every expand,
+                        // and it is the only consumer. See BroadcastTransient.
+                        if (message.Length >= 10)
+                        {
+                            var ss = message.TrimEnd(';');
+                            if (ss.Length == 9)
+                            {
+                                _stateService.BroadcastTransient("ScopeSetting", new
+                                {
+                                    band    = ss[2] == '1' ? "sub" : "main",
+                                    setting = ss[3].ToString(),
+                                    field   = ss.Substring(4, 5)
+                                });
+                            }
+                        }
+                        break;
                     case "VS":
                         // VS{n}; — VFO SELECT: 0=VFO-A active (operating/RX),
                         // 1=VFO-B active. On single-receiver radios this is

--- a/Services/RadioCapabilities.cs
+++ b/Services/RadioCapabilities.cs
@@ -123,8 +123,18 @@ public static class RadioCapabilities
     /// Confirmed on FTdx101MP (Colin MM5AGM, 2026-08-15): all nine SS
     /// sub-commands answered a Read, and Set frames for SPAN, HOLD and MARKER
     /// were written and read back on both MAIN and SUB
-    /// (scripts/probe/ss-probe.ps1 and ss-write-probe.ps1). FTdx10 and FT-710
-    /// are from their CAT manuals only and are not yet hardware-verified.
+    /// (scripts/probe/ss-probe.ps1 and ss-write-probe.ps1).
+    ///
+    /// Only the FTdx101 pair is enabled, and that is the whole point of this
+    /// switch. The FTdx10 and FT-710 also document SS, and the tables below
+    /// (hold, size labels) carry their values — but nobody has yet sent a Set
+    /// frame to either radio. These are writes: they change what appears on
+    /// somebody's front panel, and the bench run turned up two behaviours the
+    /// manuals do not mention (span is stored per display mode, and a Read
+    /// straight after a Write can come back stale). Shipping manual-derived
+    /// writes to an untested model would find that out on an operator's rig.
+    /// Enabling a model here is a one-line change once someone has run
+    /// scripts/probe/ss-write-probe.ps1 against it and reported the result.
     ///
     /// Excluded, and not by oversight: the FTDX3000 has no SS command at all —
     /// its scope lives in EX menu items 124-148, which is writing configuration
@@ -133,7 +143,7 @@ public static class RadioCapabilities
     /// </summary>
     public static bool SupportsSpectrumScopeCat(string radioModel) => radioModel switch
     {
-        "FTdx101MP" or "FTdx101D" or "FTdx10" or "FT-710" => true,
+        "FTdx101MP" or "FTdx101D" => true,
         _ => false
     };
 
@@ -142,6 +152,11 @@ public static class RadioCapabilities
     /// The FT-710's SS sub-command list genuinely stops at 7 — it has fewer
     /// functions, not a gap in its manual — so the Hold button is hidden there
     /// rather than sent and silently ignored.
+    ///
+    /// The FTdx10 stays listed here even though SupportsSpectrumScopeCat gates
+    /// it off today. That is not an inconsistency to tidy up: this table is
+    /// manual-derived knowledge worth keeping, and it is never consulted unless
+    /// the gate above lets the model through.
     /// </summary>
     public static bool SupportsScopeHold(string radioModel) => radioModel switch
     {
@@ -171,6 +186,9 @@ public static class RadioCapabilities
     /// does not exist, and sending it would be a guess.
     ///
     /// Returns an empty array for models with no CAT scope control.
+    /// Like the hold table above, the FTdx10 and FT-710 rows are retained
+    /// while SupportsSpectrumScopeCat gates those models off — see the note
+    /// there before deleting them.
     /// </summary>
     public static string[] ScopeSizeLabels(string radioModel) => radioModel switch
     {

--- a/Services/RadioCapabilities.cs
+++ b/Services/RadioCapabilities.cs
@@ -112,6 +112,74 @@ public static class RadioCapabilities
         !string.IsNullOrEmpty(hardwareId) && !_vcTuneCatBlockedIds.Contains(hardwareId);
 
     /// <summary>
+    /// True when the radio's own spectrum scope can be driven over CAT with the
+    /// SS command, so YWC can change what the radio's front-panel display shows
+    /// (span, 3DSS vs waterfall, fix/centre/cursor, hold, marker).
+    ///
+    /// This is deliberately not the same question as "does YWC show a spectrum
+    /// for this radio" — that is YWC's own SDR panel, which is unrelated
+    /// hardware. See docs/design/scope-control-via-cat.md.
+    ///
+    /// Confirmed on FTdx101MP (Colin MM5AGM, 2026-08-15): all nine SS
+    /// sub-commands answered a Read, and Set frames for SPAN, HOLD and MARKER
+    /// were written and read back on both MAIN and SUB
+    /// (scripts/probe/ss-probe.ps1 and ss-write-probe.ps1). FTdx10 and FT-710
+    /// are from their CAT manuals only and are not yet hardware-verified.
+    ///
+    /// Excluded, and not by oversight: the FTDX3000 has no SS command at all —
+    /// its scope lives in EX menu items 124-148, which is writing configuration
+    /// rather than operating a control — and the FTDX5000 has only a DP
+    /// display-page selector.
+    /// </summary>
+    public static bool SupportsSpectrumScopeCat(string radioModel) => radioModel switch
+    {
+        "FTdx101MP" or "FTdx101D" or "FTdx10" or "FT-710" => true,
+        _ => false
+    };
+
+    /// <summary>
+    /// True when the scope supports HOLD (freeze the trace) via SS P2=8.
+    /// The FT-710's SS sub-command list genuinely stops at 7 — it has fewer
+    /// functions, not a gap in its manual — so the Hold button is hidden there
+    /// rather than sent and silently ignored.
+    /// </summary>
+    public static bool SupportsScopeHold(string radioModel) => radioModel switch
+    {
+        "FTdx101MP" or "FTdx101D" or "FTdx10" => true,
+        _ => false
+    };
+
+    /// <summary>
+    /// True when the radio has two independently-configurable scopes addressed
+    /// by SS P1 (0 = MAIN, 1 = SUB), so the UI needs a MAIN/SUB selector.
+    /// Proven on the FTdx101MP by reading both at once: MAIN answered span=1 MHz
+    /// mode=W/F CURSOR (L) while SUB answered span=500 kHz mode=3DSS FIX.
+    /// On every other model SS P1 is documented as "0: (Fixed)".
+    /// </summary>
+    public static bool HasPerReceiverScopes(string radioModel) =>
+        radioModel is "FTdx101MP" or "FTdx101D";
+
+    /// <summary>
+    /// The size variants of the waterfall scope modes, in SS P2=6 value order.
+    ///
+    /// The FTdx101 and FTdx10 offer three (Large / Normal / Small); the FT-710
+    /// offers two, and calls them something else entirely (Expand / Normal).
+    /// Same command, same value positions, different vocabulary and different
+    /// length — so this must stay a per-model list. Do not be tempted to
+    /// collapse it into one shared enum: on the FT-710 the third slot of each
+    /// group (values 5, 8 and the one after B) is documented as "-", i.e. it
+    /// does not exist, and sending it would be a guess.
+    ///
+    /// Returns an empty array for models with no CAT scope control.
+    /// </summary>
+    public static string[] ScopeSizeLabels(string radioModel) => radioModel switch
+    {
+        "FTdx101MP" or "FTdx101D" or "FTdx10" => ["L", "N", "S"],
+        "FT-710"                              => ["Expand", "Normal"],
+        _                                     => []
+    };
+
+    /// <summary>
     /// Returns the P1 character for a per-VFO CAT command, given the
     /// user's (or voice command's) targeted receiver ("A" or "B"). On
     /// single-receiver radios always "0" -- the firmware hard-codes that

--- a/Services/RadioStateService.cs
+++ b/Services/RadioStateService.cs
@@ -168,6 +168,23 @@ namespace Yaesu_Web_Control.Services
             }
         }
 
+        /// <summary>
+        /// Pushes a one-off update down the normal RadioStateUpdate envelope for
+        /// something that has no stored property here.
+        ///
+        /// Used by the scope panel, whose eleven SS sub-commands are read on
+        /// demand and held in the browser. Mirroring them as fields on this
+        /// service would mean eleven more properties, eleven more snapshot
+        /// entries and a persistence round-trip, all so that one collapsible
+        /// panel could learn something it re-reads whenever it opens anyway.
+        ///
+        /// Not a general escape hatch: anything the rest of the UI depends on,
+        /// or that a late-joining client needs replayed, belongs in a property
+        /// and in GetClientStateSnapshot instead.
+        /// </summary>
+        public void BroadcastTransient(string property, object value) =>
+            BroadcastUpdate(property, value);
+
         // --- Properties for all CAT commands in GetInitialValues() ---
 
         private string _id = "";

--- a/docs/design/scope-control-via-cat.md
+++ b/docs/design/scope-control-via-cat.md
@@ -1,7 +1,11 @@
 # Driving the radio's own display over CAT
 
-**Status:** IMPLEMENTED for FTdx101 / FTdx10 / FT-710, bench-tested on an
-FTdx101MP. Raised by Colin MM5AGM 2026-08-15.
+**Status:** IMPLEMENTED, and **enabled for the FTdx101MP/D only**. The FTdx10
+and FT-710 tables below are written and kept, but gated off in
+`RadioCapabilities.SupportsSpectrumScopeCat` until someone has run the write
+probe on one — these are commands that change what appears on an operator's
+front panel, so manual-derived writes do not ship unverified. Bench-tested on
+an FTdx101MP. Raised by Colin MM5AGM 2026-08-15.
 **Bench evidence:** `SS` read-probe and write-probe run against a real
 FTdx101MP (ID0682) on COM4, 2026-08-15, plus end-to-end testing through the
 app's own endpoints. Results in §2; what the implementation turned up in §6.
@@ -302,9 +306,12 @@ here; `ScopeCommands.ValueField` now treats the terminator as optional.
    frame arrives unbidden. Only worth answering if the read-back approach turns
    out to feel stale in use.
 2. **The FTdx10 and FT-710 are manual-only** — nothing on either has been
-   hardware-verified. Fabio (FTdx10) can confirm his. Nobody currently runs an
-   FT-710 actively enough to confirm that one, so it either ships unverified or
-   is gated off until someone steps up.
+   hardware-verified, so both are **gated off** (decided 2026-08-16; see the
+   Status note at the top). Re-enabling either is one line in
+   `RadioCapabilities.SupportsSpectrumScopeCat` plus a probe run. Fabio
+   (FTdx10) can confirm his whenever video-tx frees him; nobody currently runs
+   an FT-710 actively enough to confirm that one, so it stays gated until
+   someone steps up.
 3. **The meter selector is not built**, and the reason is in §4: it has to
    cooperate with the borrow-and-restore in `MeterPollingService` or it will
    appear to randomly revert. That is a design decision to take deliberately,

--- a/docs/design/scope-control-via-cat.md
+++ b/docs/design/scope-control-via-cat.md
@@ -1,10 +1,10 @@
 # Driving the radio's own display over CAT
 
-**Status:** DESIGN NOTE — nothing implemented. Raised by Colin MM5AGM
-2026-08-15.
-**Bench evidence:** `SS` read-probe run against a real FTdx101MP (ID0682) on
-COM4, 2026-08-15. Read frames only; no `Set` frame was sent. Results are in
-§2.
+**Status:** IMPLEMENTED for FTdx101 / FTdx10 / FT-710, bench-tested on an
+FTdx101MP. Raised by Colin MM5AGM 2026-08-15.
+**Bench evidence:** `SS` read-probe and write-probe run against a real
+FTdx101MP (ID0682) on COM4, 2026-08-15, plus end-to-end testing through the
+app's own endpoints. Results in §2; what the implementation turned up in §6.
 **Related:** PR #97 (USB video capture of the radio's screen), and the
 overlay idea this note replaces.
 
@@ -78,8 +78,24 @@ Three things this establishes that the manual alone did not:
 3. **Every sub-command answered, including `HOLD` (P2=8).** No CAT errors, no
    timeouts.
 
-**Not yet verified: writes.** Every frame above is a Read. No `Set` frame has
-been sent to any radio. See §6.
+### Writes, verified separately
+
+`scripts/probe/ss-write-probe.ps1` then confirmed that Set frames land. For
+each sub-command it reads the current value, writes a different one, reads
+back, and writes the original back, so the radio is left as it was found:
+
+```
+MAIN SPAN    was '90000' -> wrote '40000' -> reads 'SS0540000;'   WRITE OK
+MAIN HOLD    was '00000' -> wrote '10000' -> reads 'SS0810000;'   WRITE OK
+MAIN MARKER  was '10000' -> wrote '00000' -> reads 'SS0200000;'   WRITE OK
+SUB SPAN     was '80000' -> wrote '40000' -> reads 'SS1540000;'   WRITE OK
+```
+
+One warning from writing that probe, because the radio hides the mistake: in a
+double-quoted PowerShell string `` `0 `` is a NUL character, not a zero. The
+first run therefore sent `SS054<NUL>000;` — and **the radio applied it anyway**
+and read back cleanly. The table above is from the corrected run. A malformed
+pad will not announce itself.
 
 ---
 
@@ -179,8 +195,7 @@ normally one significant character followed by `0000`.
 | A | W/F FIX (N) | W/F FIX (NORMAL) |
 | B | W/F FIX (S) | — |
 
-Worked examples (FTdx101, derived from the confirmed frame shape — **not yet
-written to a radio**):
+Worked examples (FTdx101, all of these written to a real radio and read back):
 
 ```
 SS0540000;   MAIN span -> 20 kHz
@@ -188,7 +203,14 @@ SS1540000;   SUB  span -> 20 kHz
 SS0620000;   MAIN mode -> 3DSS FIX
 SS0810000;   MAIN HOLD -> ON
 SS0800000;   MAIN HOLD -> OFF
+SS04+02.5;   MAIN LEVEL -> +2.5 dB
 ```
+
+Note that the twelve mode values are a 2×3×3 grid, not an arbitrary list —
+display type × placement × size. `ScopeCommands.ModeValue` composes them from
+those three axes, which is why the UI offers three small selectors instead of
+one twelve-entry dropdown. The browser mirrors the same rule in
+`radio-scope.js`; the two must agree.
 
 ### `MS` — METER SW
 
@@ -207,55 +229,90 @@ feature.
 
 ---
 
-## 5. Implementation shape
+## 5. What was built
 
-Nothing here is built. This is the seam list, not a schedule.
+| File | Role |
+|---|---|
+| `Services/RadioCapabilities.cs` | `SupportsSpectrumScopeCat`, `SupportsScopeHold`, `HasPerReceiverScopes`, `ScopeSizeLabels` |
+| `Services/CatCommands.cs` | `ScopeCommands` — frame construction, answer parsing, mode composition |
+| `Controllers/ScopeController.cs` | `GET /api/scope/{main\|sub}`, `POST /api/scope/{band}/{setting}` |
+| `Pages/Shared/_RadioScopePartial.cshtml` | the control panel markup, gated per model |
+| `wwwroot/js/ui/radio-scope.js` | wiring; repaints from the radio's read-back |
+| `scripts/probe/ss-probe.ps1`, `ss-write-probe.ps1` | the read and write probes |
 
-**`Services/RadioCapabilities.cs`** — add capability predicates alongside the
-existing ones. The file already documents itself as the place per-model
-variation hangs off, and it already has the right shape (`SupportsQmb`,
-`SupportsVCTuneMain`). Wanted:
+Three decisions worth knowing about, because none of them is obvious from the
+code alone:
 
-- `SupportsSpectrumScopeCat(model)` — FTdx101MP/D, FTdx10, FT-710.
-- `SupportsScopeHold(model)` — the above minus FT-710.
-- `ScopeHasPerReceiverScopes(model)` — FTdx101MP/D only, drives `P1`.
-- A mode-table accessor returning the model's `P2=6` value list, because the
-  FT-710's differs and must not be unified.
+**Every write is followed by a read-back, and the read-back is what repaints
+the UI.** The radio is the source of truth, never our optimism. That matters
+more here than elsewhere because the operator may be standing at the rig
+changing the same settings by hand, and because a radio that quietly refuses a
+value should look refused rather than accepted.
 
-**`Services/CatCommands.cs`** — `SS` opcode plus builders. Keep the frame
-construction in one place; the 5-character pad field is exactly the kind of
-detail that gets miscounted at each call site.
+**The panel is collapsed by default and reads its state lazily, on first
+expand.** Six `SS` reads on a port shared with the ~10 Hz meter poll is not a
+cost worth paying for a panel most users will never open. The collapsed state
+persists in `localStorage` as `ywc.radioScopeOpen`.
 
-**`Services/CatMessageDispatcher.cs`** — parse `SS` answers into state. The
-FTdx101 marks `SS` as auto-information reported, so front-panel changes should
-arrive unprompted and the UI can stay in sync when the operator touches the
-radio. **[VERIFY]** that AI actually emits `SS` frames in practice — the
-manual's flag column and reality have diverged before.
+**It is a partial view, not inline markup.** Placement on the page is not
+settled — it currently sits above YWC's own spectrum panels — so moving it is a
+matter of moving one `<partial>` line. Do not inline it until that argument is
+had. Note the conceptual trap it is guarding against: YWC's SDR spectrum
+display and the radio's internal scope are entirely different things, which is
+why the card header says "the radio's own display" out loud.
 
-**UI** — a scope-control strip, gated per model. Natural home is beside the
-existing spectrum panels, but note the conceptual split: YWC's own SDR spectrum
-display and the radio's internal scope are two different things, and putting
-controls for the radio's scope next to YWC's spectrum will confuse people
-unless it is labelled clearly.
+`CatMessageDispatcher` was deliberately **not** touched. Read-back after write
+covers the cases the UI actually has, and adding `SS` to the dispatcher only
+pays off if the radio really does report scope changes over auto-information —
+which is still unverified (§6).
 
 ---
 
-## 6. Open questions and bench gates
+## 6. What the implementation turned up
 
-1. **No write has been attempted.** Everything in §2 is a Read. Before any
-   code, send one `Set` by hand — `SS0540000;` to move MAIN span to 20 kHz —
-   confirm the radio's display changes and that a subsequent `SS05;` reads back
-   `4`. Read-back-after-write is the honest test.
-2. **Does `SS` come back over auto-information?** Change the span on the radio's
-   own touchscreen with a CAT monitor running and see whether an `SS` frame
-   arrives unbidden. Determines whether the UI can stay in sync or must poll.
-3. **The FTdx10 and FT-710 columns are manual-only.** Fabio (FTdx10) can
-   confirm his; nobody currently runs an FT-710 actively enough to confirm
-   that one, so it ships unverified or not at all.
-4. **How does this interact with the meter borrow?** See §4. Needs deciding
-   before a meter selector is exposed, not after.
-5. **Is remote Mono/Multi actually wanted?** If yes, it needs the overlay this
+Two findings that were not in any manual, both measured on an FTdx101MP through
+the app's own endpoints.
+
+**Span is stored per display mode.** Setting the span to 20 kHz and then
+switching mode appeared at first to "revert" it. It does not: the radio keeps a
+separate span for each mode. Over ten consecutive mode changes, W/F CURSOR (L)
+held 20 kHz and 3DSS FIX held 1 MHz, each returning reliably. So the
+highlighted span button moving on its own after a mode change is correct
+behaviour, and re-sending the previous span to "fix" it would overwrite a
+setting the operator deliberately chose. Repainting everything from the
+read-back is what keeps this honest. The UI says so in a hint line, because it
+otherwise looks like a bug.
+
+**Reads issued immediately after a write go unanswered while the radio
+redraws** — roughly one in three following a mode change, which is the most
+expensive redraw. Fixed with a 150 ms settle delay before the read-back plus
+one retry; ten consecutive mode changes then produced zero dropped reads.
+Anything still unanswered after the retry is reported as null and shown as
+unknown rather than guessed at.
+
+One trap for the next person: **`CatMultiplexerService` strips the trailing
+`;`** from answers. A parser that requires it works perfectly against a raw
+serial probe and then returns null for everything inside the app. That happened
+here; `ScopeCommands.ValueField` now treats the terminator as optional.
+
+### Still open
+
+1. **Does `SS` come back over auto-information?** Change the span on the
+   radio's own touchscreen with a CAT monitor running and see whether an `SS`
+   frame arrives unbidden. Only worth answering if the read-back approach turns
+   out to feel stale in use.
+2. **The FTdx10 and FT-710 are manual-only** — nothing on either has been
+   hardware-verified. Fabio (FTdx10) can confirm his. Nobody currently runs an
+   FT-710 actively enough to confirm that one, so it either ships unverified or
+   is gated off until someone steps up.
+3. **The meter selector is not built**, and the reason is in §4: it has to
+   cooperate with the borrow-and-restore in `MeterPollingService` or it will
+   appear to randomly revert. That is a design decision to take deliberately,
+   not a control to bolt on.
+4. **Is remote Mono/Multi actually wanted?** If yes it needs the overlay this
    note was written to avoid — but only for that one control.
+5. **Placement.** Above the spectrum panels is a starting position, not a
+   verdict.
 
 ---
 

--- a/docs/design/scope-control-via-cat.md
+++ b/docs/design/scope-control-via-cat.md
@@ -1,0 +1,271 @@
+# Driving the radio's own display over CAT
+
+**Status:** DESIGN NOTE — nothing implemented. Raised by Colin MM5AGM
+2026-08-15.
+**Bench evidence:** `SS` read-probe run against a real FTdx101MP (ID0682) on
+COM4, 2026-08-15. Read frames only; no `Set` frame was sent. Results are in
+§2.
+**Related:** PR #97 (USB video capture of the radio's screen), and the
+overlay idea this note replaces.
+
+---
+
+## 1. The idea, and why it beats overlays
+
+The problem this started from: with USB video capture we can *see* the radio's
+own TFT in the browser, but we cannot *touch* it. The obvious fix was to draw
+YWC controls as an overlay on top of the video — clickable regions positioned
+over the radio's on-screen buttons.
+
+That approach has a nasty long tail. The overlay has to know where every
+button sits in the captured frame, which varies by radio model, by firmware
+screen layout, by capture resolution, and by whatever the operator has the
+radio currently displaying. It is pixel geometry pretending to be a UI.
+
+**The alternative: don't touch the radio's screen, command the radio.** Yaesu
+exposes the scope and meter controls over CAT. Send the command, the radio
+changes its own display, and the video capture shows the result because it is
+showing the radio's actual screen. No compositing, no coordinates, no
+per-model pixel maps.
+
+Two things follow that are worth stating plainly:
+
+- **This does not replace the video work.** You still need the capture to see
+  the screen. What it removes is the overlay layer specifically, which was
+  always going to be the fragile part.
+- **This is worth having without video at all.** Remote scope and meter
+  control stands on its own for anyone operating the rig from another room.
+  That is a better justification than the video framing, and it reaches more
+  people — every user with a supported radio, not only those with a capture
+  dongle.
+
+---
+
+## 2. What the radio actually answered
+
+Probe script: `scripts/probe/ss-probe.ps1` (read-only). Radio: FTdx101MP,
+firmware ID `0682`, 38400 8-N-2 on COM4, YWC stopped.
+
+```
+--- SS P1=0 (MAIN) ---
+  SS00;   SPEED        -> 'SS0020000;'     2 = FAST1
+  SS01;   PEAK         -> 'SS0100000;'     0 = LV1
+  SS02;   MARKER       -> 'SS0210000;'     1 = ON
+  SS03;   COLOR        -> 'SS0341100;'     P3=4, P4=1, P5=1
+  SS04;   LEVEL        -> 'SS04+05.0;'     +5.0 dB
+  SS05;   SPAN         -> 'SS0590000;'     9 = 1 MHz
+  SS06;   MODE         -> 'SS0660000;'     6 = W/F CURSOR (L)
+  SS07;   AF-FFT/OSC   -> 'SS0711200;'
+  SS08;   HOLD         -> 'SS0800000;'     0 = OFF
+
+--- SS P1=1 (SUB) ---
+  SS15;   SPAN         -> 'SS1580000;'     8 = 500 kHz
+  SS16;   MODE         -> 'SS1620000;'     2 = 3DSS FIX
+  (remaining sub-commands answered identically in shape)
+```
+
+Three things this establishes that the manual alone did not:
+
+1. **The frame is `SS` P1 P2 P3P4P5P6P7 `;` — 10 characters.** The CAT manual's
+   table is mangled by the PDF layout and it was not obvious whether P3–P7 were
+   five separate one-character fields or one five-character field. `SS04+05.0;`
+   settles it: they are **one 5-character field**, of which most sub-commands
+   use only the first character and pad the rest with `0`.
+2. **`P1` really does address MAIN and SUB independently.** MAIN was on 1 MHz
+   W/F CURSOR while SUB was on 500 kHz 3DSS FIX at the same moment. This is a
+   genuine per-receiver control on the FTdx101, not a documented-but-ignored
+   parameter.
+3. **Every sub-command answered, including `HOLD` (P2=8).** No CAT errors, no
+   timeouts.
+
+**Not yet verified: writes.** Every frame above is a Read. No `Set` frame has
+been sent to any radio. See §6.
+
+---
+
+## 3. Per-radio capability matrix
+
+Derived from the CAT manuals in `docs/manuals/`. Only the FTdx101MP column is
+hardware-confirmed.
+
+| Function | FTdx101MP/D | FTdx10 | FT-710 | FTDX3000 | FTDX5000 |
+|---|---|---|---|---|---|
+| Meter pair (`MS`) | yes | yes | yes | yes | yes |
+| Span (`SS` P2=5) | yes | yes | yes | menu only | no |
+| Scope mode / 3DSS (`SS` P2=6) | yes | yes | yes | no | no |
+| Fix / Center / Cursor (`SS` P2=6) | yes | yes | yes | menu only | no |
+| Expand | L/N/S | L/N/S | EXPAND/NORMAL | no | no |
+| Hold (`SS` P2=8) | yes | yes | **no** | no | no |
+| Marker (`SS` P2=2) | yes | yes | yes | no | no |
+| Peak / Level / Colour / Speed | yes | yes | yes | no | no |
+| MAIN vs SUB scope | `P1`=0/1 | n/a | n/a | n/a | n/a |
+| **Mono / Multi** | **no** | **no** | **no** | **no** | **no** |
+
+### The four differences that matter
+
+**Mono/Multi is not in CAT on any radio.** Searched all seven CAT manuals for
+the term; there is no command and no menu entry. This is the one item on the
+original wish-list that stays front-panel-only. If remote Mono/Multi is
+essential, an overlay click-target over the video is the only route, and that
+is a much smaller overlay than the original proposal.
+
+**The FT-710 has no HOLD.** Its `SS` P2 list stops at 7; the FTdx101 and FTdx10
+go to 8. Same command, genuinely fewer functions — not an omission in the
+manual.
+
+**The FT-710 spells Expand differently.** FTdx101/FTdx10 offer W/F CENTER
+(L)/(N)/(S) — three sizes. The FT-710 offers W/F CENTER (NORMAL)/(EXPAND) — two.
+Same concept, incompatible value tables, so the mode selector needs a per-model
+map rather than one shared enum. Do not try to unify these into one list.
+
+**FTDX3000 and FTDX5000 are effectively out of scope.** The FTDX3000 has no
+`SS` command at all; its scope lives in menu items 124–148 reachable via `EX`,
+which is writing configuration rather than operating a control. The FTDX5000
+has only a `DP` display-page selector. Neither has an engaged reporter (see
+`.claude/rules.md` on focusing effort on actively-reported radios), so neither
+should gate this work.
+
+> **Caution on the FTDX3000 menu numbers.** The 124–148 range is legible in the
+> extracted text, but the value columns beside them are visibly bleeding in from
+> an adjacent table in the PDF (a "SCOPE FIX 3.5MHz SPAN" row showing
+> "0: NARROW 1: WIDE" is not credible). If FTDX3000 support is ever attempted,
+> re-read those menu entries from the PDF directly rather than trusting any
+> extraction.
+
+---
+
+## 4. Command reference
+
+### `SS` — SPECTRUM SCOPE
+
+```
+Set     SS P1 P2 P3P4P5P6P7 ;      (10 chars)
+Read    SS P1 P2 ;                 (5 chars)
+Answer  SS P1 P2 P3P4P5P6P7 ;      (10 chars)
+```
+
+`P1` — `0` = MAIN band, `1` = SUB band on the FTdx101. Fixed `0` on FTdx10 and
+FT-710.
+
+`P2` selects the sub-command; `P3`–`P7` is a single 5-character value field,
+normally one significant character followed by `0000`.
+
+| P2 | Sub-command | P3 values |
+|---|---|---|
+| 0 | SPEED | 0 SLOW1, 1 SLOW2, 2 FAST1, 3 FAST2, 4 FAST3 (FT-710 adds 5 STOP) |
+| 1 | PEAK | 0 LV1 … 4 LV5 |
+| 2 | MARKER | 0 OFF, 1 ON |
+| 3 | COLOR | P3 0–A colour 1–11; P4 0–6 narrow-band colour; P5 0/1 narrow-band colour on |
+| 4 | LEVEL | five chars, `-30.0` … `+30.0`, 0.5 dB steps |
+| 5 | SPAN | 0 1 kHz, 1 2 kHz, 2 5 kHz, 3 10 kHz, 4 20 kHz, 5 50 kHz, 6 100 kHz, 7 200 kHz, 8 500 kHz, 9 1 MHz |
+| 6 | MODE | see below |
+| 7 | AF-FFT / OSCILLOSCOPE | P3 FFT att, P4 osc level att, P5 osc timebase |
+| 8 | HOLD | 0 OFF, 1 ON — **absent on FT-710** |
+
+`P2=6` (MODE) — **the value table differs by model:**
+
+| P3 | FTdx101 / FTdx10 | FT-710 |
+|---|---|---|
+| 0 | 3DSS CENTER | 3DSS CENTER |
+| 1 | 3DSS CURSOR | 3DSS CURSOR |
+| 2 | 3DSS FIX | 3DSS FIX |
+| 3 | W/F CENTER (L) | W/F CENTER (EXPAND) |
+| 4 | W/F CENTER (N) | W/F CENTER (NORMAL) |
+| 5 | W/F CENTER (S) | — |
+| 6 | W/F CURSOR (L) | W/F CURSOR (EXPAND) |
+| 7 | W/F CURSOR (N) | W/F CURSOR (NORMAL) |
+| 8 | W/F CURSOR (S) | — |
+| 9 | W/F FIX (L) | W/F FIX (EXPAND) |
+| A | W/F FIX (N) | W/F FIX (NORMAL) |
+| B | W/F FIX (S) | — |
+
+Worked examples (FTdx101, derived from the confirmed frame shape — **not yet
+written to a radio**):
+
+```
+SS0540000;   MAIN span -> 20 kHz
+SS1540000;   SUB  span -> 20 kHz
+SS0620000;   MAIN mode -> 3DSS FIX
+SS0810000;   MAIN HOLD -> ON
+SS0800000;   MAIN HOLD -> OFF
+```
+
+### `MS` — METER SW
+
+Already implemented and understood; see `Services/CatCommands.cs` and
+`docs/decisions/` for the FTdx101 meter-borrow design. The relevant point here
+is that YWC **already changes the radio's front-panel meter pair** during
+transmit and restores it afterwards, so the "command the radio's own display"
+pattern is not new — it is already shipping. This note generalises it.
+
+Note the interaction: any UI that lets the operator pick the displayed meter
+pair has to cooperate with the existing borrow-and-restore in
+`MeterPollingService`, which overwrites the pair on transmit and puts it back
+10 s after TX goes idle. A user-facing meter selector that fights that will
+appear to randomly revert. This is the single most likely bug in the whole
+feature.
+
+---
+
+## 5. Implementation shape
+
+Nothing here is built. This is the seam list, not a schedule.
+
+**`Services/RadioCapabilities.cs`** — add capability predicates alongside the
+existing ones. The file already documents itself as the place per-model
+variation hangs off, and it already has the right shape (`SupportsQmb`,
+`SupportsVCTuneMain`). Wanted:
+
+- `SupportsSpectrumScopeCat(model)` — FTdx101MP/D, FTdx10, FT-710.
+- `SupportsScopeHold(model)` — the above minus FT-710.
+- `ScopeHasPerReceiverScopes(model)` — FTdx101MP/D only, drives `P1`.
+- A mode-table accessor returning the model's `P2=6` value list, because the
+  FT-710's differs and must not be unified.
+
+**`Services/CatCommands.cs`** — `SS` opcode plus builders. Keep the frame
+construction in one place; the 5-character pad field is exactly the kind of
+detail that gets miscounted at each call site.
+
+**`Services/CatMessageDispatcher.cs`** — parse `SS` answers into state. The
+FTdx101 marks `SS` as auto-information reported, so front-panel changes should
+arrive unprompted and the UI can stay in sync when the operator touches the
+radio. **[VERIFY]** that AI actually emits `SS` frames in practice — the
+manual's flag column and reality have diverged before.
+
+**UI** — a scope-control strip, gated per model. Natural home is beside the
+existing spectrum panels, but note the conceptual split: YWC's own SDR spectrum
+display and the radio's internal scope are two different things, and putting
+controls for the radio's scope next to YWC's spectrum will confuse people
+unless it is labelled clearly.
+
+---
+
+## 6. Open questions and bench gates
+
+1. **No write has been attempted.** Everything in §2 is a Read. Before any
+   code, send one `Set` by hand — `SS0540000;` to move MAIN span to 20 kHz —
+   confirm the radio's display changes and that a subsequent `SS05;` reads back
+   `4`. Read-back-after-write is the honest test.
+2. **Does `SS` come back over auto-information?** Change the span on the radio's
+   own touchscreen with a CAT monitor running and see whether an `SS` frame
+   arrives unbidden. Determines whether the UI can stay in sync or must poll.
+3. **The FTdx10 and FT-710 columns are manual-only.** Fabio (FTdx10) can
+   confirm his; nobody currently runs an FT-710 actively enough to confirm
+   that one, so it ships unverified or not at all.
+4. **How does this interact with the meter borrow?** See §4. Needs deciding
+   before a meter selector is exposed, not after.
+5. **Is remote Mono/Multi actually wanted?** If yes, it needs the overlay this
+   note was written to avoid — but only for that one control.
+
+---
+
+## 7. Relevance to IWC
+
+The pattern transfers; the commands do not. The IC-7300 MkII exposes its scope
+over CI-V (`27 00`), which is how IWC gets spectrum data in the first place, but
+that is *reading* the scope. Whether the MkII's own display settings — span,
+fix/centre, hold — are CI-V-writable is a separate question that needs the CI-V
+reference checked, not an assumption carried over from Yaesu. See
+`core/docs/design/shared-core-plan.md`: any shared piece would be the UI concept,
+and UI touching the radio sits below the seam until `IRadioController` is
+back-ported into YWC.

--- a/scripts/probe/cdp-probe.mjs
+++ b/scripts/probe/cdp-probe.mjs
@@ -1,0 +1,113 @@
+// Drives the real Index page in headless Chrome over CDP and reports:
+//   - every uncaught exception / console error during load
+//   - whether window.radioScopeControl exists
+//   - whether the span buttons have click handlers that actually fire
+// Node 24 has a global WebSocket, so this needs no dependencies.
+
+const PORT = 9333;
+const URL_ = 'http://localhost:8080/';
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function pageTarget() {
+    for (let i = 0; i < 40; i++) {
+        try {
+            const r = await fetch(`http://127.0.0.1:${PORT}/json/list`);
+            const list = await r.json();
+            const p = list.find(t => t.type === 'page' && t.webSocketDebuggerUrl);
+            if (p) return p;
+        } catch { /* chrome not up yet */ }
+        await sleep(250);
+    }
+    throw new Error('no page target');
+}
+
+const target = await pageTarget();
+const ws = new WebSocket(target.webSocketDebuggerUrl);
+await new Promise(r => ws.addEventListener('open', r, { once: true }));
+
+let id = 0;
+const pending = new Map();
+const events = [];
+
+ws.addEventListener('message', ev => {
+    const msg = JSON.parse(ev.data);
+    if (msg.id && pending.has(msg.id)) {
+        pending.get(msg.id)(msg);
+        pending.delete(msg.id);
+    } else if (msg.method) {
+        events.push(msg);
+    }
+});
+
+const send = (method, params = {}) => new Promise(res => {
+    const n = ++id;
+    pending.set(n, res);
+    ws.send(JSON.stringify({ id: n, method, params }));
+});
+
+const evaluate = async expr => {
+    const r = await send('Runtime.evaluate', {
+        expression: expr, awaitPromise: true, returnByValue: true
+    });
+    if (r.result?.exceptionDetails) return { error: r.result.exceptionDetails.text };
+    return r.result?.result?.value;
+};
+
+await send('Runtime.enable');
+await send('Log.enable');
+await send('Page.enable');
+await send('Network.enable');
+
+await send('Page.navigate', { url: URL_ });
+await sleep(6000);
+
+console.log('══ uncaught exceptions / console errors during load ══');
+const bad = events.filter(e =>
+    e.method === 'Runtime.exceptionThrown' ||
+    (e.method === 'Runtime.consoleAPICalled' && ['error', 'warning'].includes(e.params.type)) ||
+    (e.method === 'Log.entryAdded' && ['error'].includes(e.params.entry.level)));
+if (!bad.length) console.log('  (none)');
+for (const e of bad) {
+    if (e.method === 'Runtime.exceptionThrown') {
+        const d = e.params.exceptionDetails;
+        console.log('  EXCEPTION:', d.text, d.exception?.description?.split('\n')[0] ?? '');
+    } else if (e.method === 'Log.entryAdded') {
+        console.log(`  LOG[${e.params.entry.level}]:`, e.params.entry.text, e.params.entry.url ?? '');
+    } else {
+        console.log(`  CONSOLE[${e.params.type}]:`,
+            e.params.args.map(a => a.value ?? a.description ?? a.type).join(' '));
+    }
+}
+
+console.log('\n══ module / instance state ══');
+console.log('  window.radioScopeControl exists :', await evaluate('typeof window.radioScopeControl'));
+console.log('  card in DOM                     :', await evaluate('!!document.getElementById("radioScopeCard")'));
+console.log('  body display                    :', await evaluate('document.getElementById("radioScopeBody")?.style.display'));
+console.log('  span buttons found              :', await evaluate('document.querySelectorAll(".scope-span-btn").length'));
+console.log('  control .band                   :', await evaluate('window.radioScopeControl?.band'));
+console.log('  control .busy                   :', await evaluate('window.radioScopeControl?.busy'));
+console.log('  control .loaded                 :', await evaluate('window.radioScopeControl?.loaded'));
+
+console.log('\n══ simulating a real click on the header, then a span button ══');
+console.log('  header click ->', await evaluate('document.getElementById("radioScopeToggle").click(), "clicked"'));
+await sleep(2500);
+console.log('  body display now :', await evaluate('document.getElementById("radioScopeBody")?.style.display'));
+console.log('  status badge     :', await evaluate('document.getElementById("radioScopeStatus")?.textContent'));
+console.log('  loaded           :', await evaluate('window.radioScopeControl?.loaded'));
+
+console.log('  span "20k" click ->',
+    await evaluate('[...document.querySelectorAll(".scope-span-btn")].find(b=>b.textContent.trim()==="20k").click(), "clicked"'));
+await sleep(2500);
+console.log('  status badge after span click :', await evaluate('document.getElementById("radioScopeStatus")?.textContent'));
+
+console.log('\n══ network requests to /api/scope ══');
+const reqs = events.filter(e => e.method === 'Network.requestWillBeSent' && e.params.request.url.includes('/api/scope'));
+if (!reqs.length) console.log('  (none — the browser never issued one)');
+for (const r of reqs) console.log(' ', r.params.request.method, r.params.request.url);
+
+ws.close();
+// Let the socket finish closing before exiting: process.exit() racing an
+// in-flight WebSocket teardown trips a libuv assertion on Windows.
+await sleep(200);
+process.exit(0);

--- a/scripts/probe/cdp-scope-follow.mjs
+++ b/scripts/probe/cdp-scope-follow.mjs
@@ -1,0 +1,128 @@
+// Verifies the CAT scope panel's band selector in BOTH directions:
+//
+//   inbound   VFO header clicked -> radio changes band -> ActiveVfo broadcast ->
+//             scope controls re-aim themselves
+//   outbound  panel's own MAIN/SUB button clicked -> VS sent -> radio actually
+//             changes band (checked against the radio, not just the UI)
+//
+// Drives the real page in headless Chrome over CDP, clicking exactly what an
+// operator would click. Restores the radio to MAIN before exiting.
+//
+// Usage:  node scripts/probe/cdp-scope-follow.mjs
+// Needs a headless Chrome already listening on --remote-debugging-port=9333.
+// Node 24's global WebSocket means no npm dependencies.
+
+const PORT = 9333;
+const URL_ = 'http://localhost:8080/';
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function pageTarget() {
+    for (let i = 0; i < 40; i++) {
+        try {
+            const list = await (await fetch(`http://127.0.0.1:${PORT}/json/list`)).json();
+            const p = list.find(t => t.type === 'page' && t.webSocketDebuggerUrl);
+            if (p) return p;
+        } catch { /* chrome not up yet */ }
+        await sleep(250);
+    }
+    throw new Error('no page target');
+}
+
+const target = await pageTarget();
+const ws = new WebSocket(target.webSocketDebuggerUrl);
+await new Promise(r => ws.addEventListener('open', r, { once: true }));
+
+let id = 0;
+const pending = new Map();
+ws.addEventListener('message', ev => {
+    const m = JSON.parse(ev.data);
+    if (m.id && pending.has(m.id)) { pending.get(m.id)(m); pending.delete(m.id); }
+});
+const send = (method, params = {}) => new Promise(res => {
+    const n = ++id; pending.set(n, res);
+    ws.send(JSON.stringify({ id: n, method, params }));
+});
+const evaluate = async expr => {
+    const r = await send('Runtime.evaluate', { expression: expr, awaitPromise: true, returnByValue: true });
+    if (r.result?.exceptionDetails) return `ERROR: ${r.result.exceptionDetails.text}`;
+    return r.result?.result?.value;
+};
+
+await send('Runtime.enable');
+await send('Page.enable');
+await send('Page.navigate', { url: URL_ });
+await sleep(6000);
+
+const band       = () => evaluate('window.radioScopeControl?.band');
+const activeBtn  = () => evaluate(
+    '[...document.querySelectorAll(".scope-band-btn")].filter(b=>b.classList.contains("active")).map(b=>b.dataset.band).join(",")');
+const badge      = () => evaluate('document.getElementById("radioScopeStatus")?.textContent');
+const clickVfo   = col => evaluate(`document.querySelector("#${col} .card-header").click(), "clicked"`);
+
+const report = async label => console.log(
+    `  ${label.padEnd(28)} band=${await band()}  activeBtn=${await activeBtn()}  badge="${await badge()}"`);
+
+console.log('══ initial (radio on MAIN) ══');
+await report('on load');
+
+console.log('\n══ ensure the panel is expanded ══');
+// NOT an unconditional click. The panel restores its expand state from
+// localStorage, so a blind toggle closes it about half the time and every
+// subsequent reading is the collapsed behaviour instead of the one under test.
+// That cost a debugging cycle once already.
+console.log('  ', await evaluate(`(() => {
+    const body = document.getElementById('radioScopeBody');
+    if (body.style.display === 'none') {
+        document.getElementById('radioScopeToggle').click();
+        return 'was collapsed - expanded it';
+    }
+    return 'already expanded';
+})()`));
+await sleep(2500);
+await report('after expand');
+
+console.log('\n══ click VFO B header -> radio to SUB ══');
+console.log('  ', await clickVfo('vfoBCol'));
+await sleep(3000);
+await report('after VFO B');
+
+console.log('\n══ click VFO A header -> radio back to MAIN ══');
+console.log('  ', await clickVfo('vfoACol'));
+await sleep(3000);
+await report('after VFO A');
+
+// ── outbound: the panel's own buttons must move the radio ────────────────────
+// This is the half that was missing at first. The buttons re-aimed the controls
+// and left the radio where it was, so "SUB scope" adjusted a scope the operator
+// could not see. Read VS off the radio after each click — the button highlight
+// agreeing with itself proves nothing.
+
+const readVs = async () => (await (await fetch(
+    'http://localhost:8080/api/vctune/diag?cmd=VS%3B')).json()).response;
+const clickBand = b => evaluate(
+    `document.querySelector('.scope-band-btn[data-band="${b}"]').click(), "clicked"`);
+
+console.log('\n══ click the panel\'s SUB button -> radio must go to SUB ══');
+console.log('  ', await clickBand('sub'));
+await sleep(3000);
+await report('after SUB button');
+const vsSub = await readVs();
+console.log('  VS on radio:', vsSub, vsSub === 'VS1' ? '✓ SUB' : '✗ radio did NOT move');
+
+console.log('\n══ click the panel\'s MAIN button -> radio must go back to MAIN ══');
+console.log('  ', await clickBand('main'));
+await sleep(3000);
+await report('after MAIN button');
+const vsMain = await readVs();
+console.log('  VS on radio:', vsMain, vsMain === 'VS0' ? '✓ MAIN' : '✗ radio did NOT move');
+
+console.log('\n══ radio state ══');
+const vs = { response: vsMain };
+console.log('  VS now:', vs.response, vs.response === 'VS0' ? '(MAIN — restored)' : '(NOT restored!)');
+
+ws.close();
+// Let the socket finish closing before exiting: process.exit() racing an
+// in-flight WebSocket teardown trips a libuv assertion on Windows.
+await sleep(200);
+process.exit(0);

--- a/scripts/probe/cdp-scope-remote.mjs
+++ b/scripts/probe/cdp-scope-remote.mjs
@@ -1,0 +1,129 @@
+// Verifies that scope changes made AT THE RADIO reach the panel.
+//
+// Two halves, checked separately because they fail for different reasons:
+//
+//   browser  applyRemote() patches the one sub-command it was told about and
+//            repaints, without re-reading anything
+//   server   an SS message off the wire becomes a ScopeSetting envelope and
+//            arrives at applyRemote
+//
+// The server half needs the radio to actually send an SS, so the probe wraps
+// applyRemote to record every call and then reports what turned up. Clicking a
+// control in the panel is a CAT-originated change; whether the radio also
+// announces those is the question this answers.
+//
+// Usage:  node scripts/probe/cdp-scope-remote.mjs
+// Needs headless Chrome on --remote-debugging-port=9333. No npm dependencies.
+
+const PORT = 9333;
+const URL_ = 'http://localhost:8080/';
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function pageTarget() {
+    for (let i = 0; i < 40; i++) {
+        try {
+            const list = await (await fetch(`http://127.0.0.1:${PORT}/json/list`)).json();
+            const p = list.find(t => t.type === 'page' && t.webSocketDebuggerUrl);
+            if (p) return p;
+        } catch { /* chrome not up yet */ }
+        await sleep(250);
+    }
+    throw new Error('no page target');
+}
+
+const target = await pageTarget();
+const ws = new WebSocket(target.webSocketDebuggerUrl);
+await new Promise(r => ws.addEventListener('open', r, { once: true }));
+
+let id = 0;
+const pending = new Map();
+ws.addEventListener('message', ev => {
+    const m = JSON.parse(ev.data);
+    if (m.id && pending.has(m.id)) { pending.get(m.id)(m); pending.delete(m.id); }
+});
+const send = (method, params = {}) => new Promise(res => {
+    const n = ++id; pending.set(n, res);
+    ws.send(JSON.stringify({ id: n, method, params }));
+});
+const evaluate = async expr => {
+    const r = await send('Runtime.evaluate', { expression: expr, awaitPromise: true, returnByValue: true });
+    if (r.result?.exceptionDetails) return `ERROR: ${r.result.exceptionDetails.text}`;
+    return r.result?.result?.value;
+};
+
+await send('Runtime.enable');
+await send('Page.enable');
+await send('Page.navigate', { url: URL_ });
+await sleep(6000);
+
+// Conditional, never a blind toggle: the panel restores its open/closed state
+// from localStorage, so a toggle closes it half the time and everything after
+// silently measures the collapsed path instead.
+await evaluate(`(() => {
+    const b = document.getElementById('radioScopeBody');
+    if (b.style.display === 'none') document.getElementById('radioScopeToggle').click();
+    return 'ok';
+})()`);
+await sleep(2500);
+
+// Record every ScopeSetting that reaches the panel from the server.
+await evaluate(`(() => {
+    const c = window.radioScopeControl;
+    window.__remoteCalls = [];
+    const original = c.applyRemote.bind(c);
+    c.applyRemote = m => { window.__remoteCalls.push(m); return original(m); };
+    return 'wrapped';
+})()`);
+
+const shown = () => evaluate(`(() => {
+    const on = sel => [...document.querySelectorAll(sel)]
+        .filter(b => b.classList.contains('active')).map(b => b.dataset.value).join(',');
+    return {
+        span:  on('.scope-span-btn'),
+        type:  on('.scope-type-btn'),
+        place: on('.scope-place-btn'),
+        size:  on('.scope-size-btn'),
+        badge: document.getElementById('radioScopeStatus').textContent
+    };
+})()`);
+
+console.log('══ browser half: applyRemote patches and repaints ══');
+console.log('  before        :', JSON.stringify(await shown()));
+
+// Pretend the radio announced a span change, then a mode change. Values are
+// chosen to be visibly different from whatever the radio is on.
+const band = await evaluate('window.radioScopeControl.band');
+await evaluate(`window.radioScopeControl.applyRemote({ band: '${band}', setting: '5', field: '30000' }), 'x'`);
+await sleep(300);
+console.log('  after span=3  :', JSON.stringify(await shown()));
+
+await evaluate(`window.radioScopeControl.applyRemote({ band: '${band}', setting: '6', field: '70000' }), 'x'`);
+await sleep(300);
+console.log('  after mode=7  :', JSON.stringify(await shown()), ' (7 = W/F Cursor, size N)');
+
+// The other band must be ignored outright — patching this panel from the scope
+// it is not showing is the same class of bug as the original band mismatch.
+const other = band === 'sub' ? 'main' : 'sub';
+const beforeOther = await shown();
+await evaluate(`window.radioScopeControl.applyRemote({ band: '${other}', setting: '5', field: '00000' }), 'x'`);
+await sleep(300);
+const afterOther = await shown();
+console.log(`  ${other} ignored  :`,
+    JSON.stringify(beforeOther) === JSON.stringify(afterOther) ? 'yes' : 'NO - it repainted!');
+
+console.log('\n══ server half: does an SS off the wire arrive? ══');
+console.log('  Clicking span 20k in the panel (a CAT-originated change).');
+await evaluate(`document.querySelector('.scope-span-btn[data-value="4"]').click(), 'x'`);
+await sleep(3000);
+const calls = await evaluate('JSON.stringify(window.__remoteCalls)');
+console.log('  ScopeSetting envelopes received:', calls);
+console.log('  final                          :', JSON.stringify(await shown()));
+console.log('\n  An empty list here does NOT mean the plumbing is broken - it may');
+console.log('  only mean the radio does not announce changes it was asked to make');
+console.log('  over CAT. Front-panel changes are the case that matters; turn the');
+console.log('  knob on the rig while this page is open to confirm those.');
+
+ws.close();
+await sleep(200);
+process.exit(0);

--- a/scripts/probe/ss-probe.ps1
+++ b/scripts/probe/ss-probe.ps1
@@ -1,0 +1,57 @@
+# ss-probe.ps1 - READ-ONLY probe of the SS (SPECTRUM SCOPE) command.
+#
+# Sends only Read frames (SS P1 P2 ;). Sends NO Set frames, so nothing on the
+# radio changes. Purpose is to confirm the answer format inferred from the
+# layout-mangled CAT manual PDF before any of it is written into code.
+#
+# Run with YWC STOPPED (it holds COM4 exclusively).
+# ASCII output only.
+
+$port = New-Object System.IO.Ports.SerialPort 'COM4',38400,'None',8,'one'
+$port.ReadTimeout = 60
+try { $port.Open() } catch {
+    Write-Output "OPEN FAILED (is YWC running and holding COM4?): $($_.Exception.Message)"
+    exit 1
+}
+Start-Sleep -Milliseconds 250
+$port.DiscardInBuffer()
+
+function Ask([string]$cmd, [int]$budgetMs = 300) {
+    $port.DiscardInBuffer()
+    $port.Write($cmd)
+    $sw  = [System.Diagnostics.Stopwatch]::StartNew()
+    $buf = ''
+    while ($sw.ElapsedMilliseconds -lt $budgetMs) {
+        try { $buf += $port.ReadExisting() } catch {}
+        if ($buf -match ';') { break }
+        Start-Sleep -Milliseconds 5
+    }
+    return $buf.Trim()
+}
+
+Write-Output "Sanity check first - ID and the meter selection we already understand:"
+Write-Output ("  ID;  -> '{0}'" -f (Ask 'ID;'))
+Write-Output ("  MS;  -> '{0}'" -f (Ask 'MS;'))
+Write-Output ''
+
+$names = @{
+    '0' = 'SPEED'; '1' = 'PEAK';  '2' = 'MARKER'; '3' = 'COLOR'
+    '4' = 'LEVEL'; '5' = 'SPAN';  '6' = 'MODE';   '7' = 'AF-FFT/OSC'
+    '8' = 'HOLD'
+}
+
+foreach ($p1 in @('0','1')) {
+    $band = if ($p1 -eq '0') { 'MAIN' } else { 'SUB' }
+    Write-Output "--- SS P1=$p1 ($band) ---"
+    foreach ($p2 in @('0','1','2','3','4','5','6','7','8')) {
+        $cmd = "SS$p1$p2;"
+        $ans = Ask $cmd
+        $label = $names[$p2]
+        if ([string]::IsNullOrWhiteSpace($ans)) { $ans = '(no answer)' }
+        Write-Output ("  {0,-7} {1,-12} -> '{2}'" -f $cmd, $label, $ans)
+    }
+    Write-Output ''
+}
+
+$port.Close()
+Write-Output 'Done. No Set frames were sent - the radio is exactly as it was.'

--- a/scripts/probe/ss-write-probe.ps1
+++ b/scripts/probe/ss-write-probe.ps1
@@ -1,0 +1,91 @@
+# ss-write-probe.ps1 - the write half of the SS (SPECTRUM SCOPE) probe.
+#
+# ss-probe.ps1 confirmed the ANSWER format by reading only. This one confirms
+# that Set frames actually land, which is the first bench gate in
+# docs/design/scope-control-via-cat.md.
+#
+# For each sub-command it: reads the current value, writes a DIFFERENT value,
+# reads back to confirm the radio took it, then writes the ORIGINAL value back.
+# The radio is left exactly as it was found.
+#
+# Run with YWC STOPPED (it holds COM4 exclusively).
+# ASCII output only.
+
+$port = New-Object System.IO.Ports.SerialPort 'COM4',38400,'None',8,'one'
+$port.ReadTimeout = 60
+try { $port.Open() } catch {
+    Write-Output "OPEN FAILED (is YWC running and holding COM4?): $($_.Exception.Message)"
+    exit 1
+}
+Start-Sleep -Milliseconds 250
+$port.DiscardInBuffer()
+
+function Ask([string]$cmd, [int]$budgetMs = 300) {
+    $port.DiscardInBuffer()
+    $port.Write($cmd)
+    $sw  = [System.Diagnostics.Stopwatch]::StartNew()
+    $buf = ''
+    while ($sw.ElapsedMilliseconds -lt $budgetMs) {
+        try { $buf += $port.ReadExisting() } catch {}
+        if ($buf -match ';') { break }
+        Start-Sleep -Milliseconds 5
+    }
+    return $buf.Trim()
+}
+
+function Tell([string]$cmd) {
+    $port.Write($cmd)
+    Start-Sleep -Milliseconds 120
+}
+
+# Each test: P1P2, a friendly name, and a value to try that is not the current
+# one. The alternate is chosen per sub-command so we never leave the scope in a
+# state the operator would not recognise even if the restore failed.
+$tests = @(
+    @{ Key = '05'; Name = 'MAIN SPAN';   Alt = '4' }   # 20 kHz
+    @{ Key = '08'; Name = 'MAIN HOLD';   Alt = '1' }   # ON
+    @{ Key = '02'; Name = 'MAIN MARKER'; Alt = '0' }   # OFF
+    @{ Key = '15'; Name = 'SUB SPAN';    Alt = '4' }
+)
+
+foreach ($t in $tests) {
+    $key  = $t.Key
+    $name = $t.Name
+
+    $before = Ask "SS$key;"
+    if ($before -notmatch "^SS$key(.{5});$") {
+        Write-Output ("{0,-12} SKIPPED - unexpected read '{1}'" -f $name, $before)
+        continue
+    }
+    $origField = $Matches[1]
+    $origP3    = $origField.Substring(0,1)
+
+    # Do not write the value it is already on - that proves nothing.
+    $alt = $t.Alt
+    if ($alt -eq $origP3) { $alt = if ($origP3 -eq '0') { '1' } else { '0' } }
+
+    # NOTE: build the padded field with ${alt} + a literal string. Writing
+    # "$alt`0000" looks right and is not - backtick-zero is a NUL character in
+    # a double-quoted PowerShell string, so that sends SS054<NUL>000; instead
+    # of SS0540000;. The radio happens to tolerate it, which is exactly why the
+    # bug survives a casual read of the output.
+    $field = '{0}0000' -f $alt
+
+    Tell "SS$key$field;"
+    $after = Ask "SS$key;"
+
+    $took = ($after -match "^SS$key$alt")
+    Write-Output ("{0,-12} was '{1}' -> wrote '{2}' -> reads '{3}'   {4}" -f `
+        $name, $origField, $field, $after, $(if ($took) { 'WRITE OK' } else { 'NO CHANGE' }))
+
+    # Restore whatever it was on when we arrived.
+    Tell "SS$key$origField;"
+    $restored = Ask "SS$key;"
+    if ($restored -notmatch [regex]::Escape($origField)) {
+        Write-Output ("             !! RESTORE FAILED - now reads '{0}', expected field '{1}'" -f $restored, $origField)
+    }
+}
+
+$port.Close()
+Write-Output ''
+Write-Output 'Done. Every value that was changed has been written back to what it was.'

--- a/wwwroot/js/ui/radio-scope.js
+++ b/wwwroot/js/ui/radio-scope.js
@@ -54,7 +54,10 @@ export class RadioScopeControl {
         this.levelSlider = document.getElementById('scopeLevelSlider');
         this.levelLabel  = document.getElementById('scopeLevelLabel');
 
-        this.band    = 'main';
+        // Server-rendered from RadioStateService.ActiveVfo so the panel is aimed
+        // at the band the radio is actually operating on from the very first
+        // paint. setActiveBand() keeps it there as the operator moves bands.
+        this.band    = this.card.dataset.initialBand === 'sub' ? 'sub' : 'main';
         this.state   = null;
         this.loaded  = false;
         this.busy    = false;
@@ -96,15 +99,7 @@ export class RadioScopeControl {
 
     _wireControls() {
         this.card.querySelectorAll('.scope-band-btn').forEach(btn => {
-            btn.addEventListener('click', () => {
-                this.band = btn.dataset.band;
-                this.card.querySelectorAll('.scope-band-btn')
-                    .forEach(b => b.classList.toggle('active', b === btn));
-                // MAIN and SUB hold genuinely independent settings on the '101,
-                // so switching scope means re-reading, not re-labelling.
-                this.loaded = false;
-                this.refresh();
-            });
+            btn.addEventListener('click', () => this._requestBand(btn.dataset.band));
         });
 
         this.card.querySelectorAll('.scope-span-btn').forEach(btn => {
@@ -143,6 +138,101 @@ export class RadioScopeControl {
         }
     }
 
+    // ── band selection ───────────────────────────────────────────────────────
+
+    // The MAIN/SUB buttons move THE RADIO, not just these controls. The radio
+    // displays the scope of whichever band it is operating on, so there is no
+    // such thing as "look at SUB's scope while operating MAIN" — asking for the
+    // SUB scope and asking for the SUB band are one request, and splitting them
+    // is what made the first version of this row so confusing.
+    //
+    // So this sends VS via the same endpoint as clicking a VFO panel header,
+    // then stops. The ActiveVfo broadcast that comes back re-aims the controls
+    // through setActiveBand(), which keeps one path for "the band changed"
+    // whether the change came from here, from the VFO header, or from the
+    // operator's hand on the front panel.
+    async _requestBand(band) {
+        if (band !== 'main' && band !== 'sub') return;
+        if (band === this.band) return;
+        if (this.busy) return;
+        this.busy = true;
+        try {
+            this._setStatus('…', 'bg-secondary');
+            const res = await fetch(`/api/cat/active-vfo/${band === 'sub' ? 'B' : 'A'}`,
+                                    { method: 'POST' });
+            if (!res.ok) {
+                const data = await res.json().catch(() => null);
+                this._setStatus(data?.error || `Error ${res.status}`, 'bg-danger');
+                return;
+            }
+        } catch (err) {
+            this._setStatus('No response', 'bg-danger');
+            console.error('[radio-scope]', err);
+            return;
+        } finally {
+            this.busy = false;
+        }
+
+        // Reconcile once we are out of the way. Two things can have gone wrong,
+        // and both were observed on the bench rather than imagined:
+        //
+        //  * The ActiveVfo broadcast beat the POST's own response back, so
+        //    _selectBand ran while this method still held `busy` and its
+        //    refresh() was swallowed by the guard in _call. Symptom: the right
+        //    band highlighted, the badge stuck on the ellipsis. `loaded` is
+        //    false in that case, which is exactly what we test for.
+        //  * No broadcast arrived at all, and the panel is still labelled MAIN
+        //    while the radio has moved to SUB — the precise failure this whole
+        //    row exists to prevent.
+        setTimeout(() => {
+            if (this.band !== band) { this._selectBand(band); return; }
+            if (!this.loaded && this.body.style.display !== 'none') this.refresh();
+        }, 400);
+    }
+
+    // Points the controls at a band and re-reads it. MAIN and SUB hold genuinely
+    // independent settings on the '101, so switching scope means re-reading,
+    // not re-labelling. Internal: reached from setActiveBand(), never straight
+    // from a click — a click has to move the radio first.
+    _selectBand(band) {
+        if (band !== 'main' && band !== 'sub') return;
+        this.band = band;
+        this.card.querySelectorAll('.scope-band-btn')
+            .forEach(b => b.classList.toggle('active', b.dataset.band === band));
+        this.loaded = false;
+        if (this.body.style.display !== 'none') {
+            this.refresh();
+        } else {
+            // Nothing to read while collapsed — the panel loads lazily on
+            // expand, and this port is shared with the ~10 Hz meter poll. But
+            // the badge stays visible in the header when collapsed, so leaving
+            // the previous band's summary sitting under the new band's name
+            // would be an outright lie. Blank it; expanding reloads it.
+            this.state = null;
+            this._setStatus('—', 'bg-secondary');
+        }
+    }
+
+    // Called from site.js when the radio's active band changes (the ActiveVfo
+    // SignalR update, i.e. a VS command from any source — this panel, the VFO
+    // headers, or the operator's hand on the front panel). The radio's scope
+    // follows the operating band, so these controls follow it too; otherwise the
+    // operator selects SUB at the rig and carries on adjusting MAIN's scope with
+    // no indication that anything is wrong. That exact confusion is what this
+    // panel's first bench test ran into.
+    //
+    // Every band change reaches _selectBand through here (bar the fallback timer
+    // in _requestBand), which is what keeps the button highlight and the radio in
+    // step no matter who moved the band.
+    setActiveBand(activeVfo) {
+        if (!this.card) return;                    // model has no CAT scope control
+        const band = Number(activeVfo) === 1 ? 'sub' : 'main';
+        // Single-receiver models render no band buttons; SS P1 is fixed at 0.
+        if (!this.card.querySelector(`.scope-band-btn[data-band="${band}"]`)) return;
+        if (band === this.band) return;
+        this._selectBand(band);
+    }
+
     _sendMode(change) {
         const s = this.state || { is3dss: false, placement: 0, size: 0 };
         const is3dss    = change.is3dss    !== undefined ? change.is3dss    : !!s.is3dss;
@@ -164,8 +254,14 @@ export class RadioScopeControl {
     async _call(url, body) {
         if (this.busy) return;               // the port is serial; so are we
         this.busy = true;
-        this._setStatus('…', 'bg-secondary');
         try {
+            // Everything after busy=true belongs inside the try. The first
+            // version set the status here, one line above it, and _setStatus did
+            // not exist: the TypeError escaped this method entirely, so the
+            // finally never ran, busy stayed true forever, and every subsequent
+            // click was swallowed by the guard above without a sound. One
+            // missing method turned into a panel where nothing at all responded.
+            this._setStatus('…', 'bg-secondary');
             const res = await fetch(url, body === null ? {} : {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -219,6 +315,16 @@ export class RadioScopeControl {
         }
 
         this._setStatus(this._summary(state), 'bg-success');
+    }
+
+    /// Repaints the badge in the card header. That badge is the panel's only
+    /// feedback channel — the controls themselves look identical whether a write
+    /// landed, was refused by the radio, or never left the browser — so it needs
+    /// to say something after every single call.
+    _setStatus(text, cls) {
+        if (!this.status) return;
+        this.status.textContent = text;
+        this.status.className = `badge ${cls} small`;
     }
 
     _mark(selector, isActive) {

--- a/wwwroot/js/ui/radio-scope.js
+++ b/wwwroot/js/ui/radio-scope.js
@@ -1,0 +1,243 @@
+// radio-scope.js — controls for the RADIO's own spectrum scope, over CAT.
+//
+// Not to be confused with spectrum-panel.js, which draws YWC's own SDR
+// spectrum from an RSP1 on the rear-panel IF output. This module draws nothing.
+// It sends SS commands and reflects back whatever the radio says it is now
+// showing on its front-panel screen.
+//
+// See docs/design/scope-control-via-cat.md. Frame format is hardware-confirmed
+// on an FTdx101MP; the FTdx10 and FT-710 tables come from their CAT manuals.
+//
+// Design notes worth keeping:
+//
+//  * Every write is followed by a server-side read-back, and the returned state
+//    is what repaints the buttons. The radio wins, always. That matters here
+//    more than in most of the UI because the operator may be standing at the
+//    rig changing the same settings by hand, and because a radio that quietly
+//    refuses a value should look refused rather than accepted.
+//
+//  * The panel reads state lazily, on first expand, not at page load. Six SS
+//    reads on a port shared with the ~10 Hz meter poll is not a cost worth
+//    paying for a panel most users will never open.
+//
+//  * SPAN IS STORED PER MODE on the radio, which is why the highlighted span
+//    button moves on its own when you change display mode. Measured on an
+//    FTdx101MP over ten consecutive mode changes: W/F CURSOR (L) held 20 kHz
+//    while 3DSS FIX held 1 MHz, and each mode brought its own span back every
+//    time. This is the radio's behaviour, not a bug here and not something to
+//    "correct" by re-sending the previous span — doing that would overwrite a
+//    setting the operator deliberately chose on the front panel. Repainting
+//    everything from the read-back after every write is what keeps the UI
+//    honest about it.
+
+const MODE_PLACEMENTS = 3;   // Center, Cursor, Fix
+
+// Mirrors ScopeCommands.ModeValue in Services/CatCommands.cs. The two must
+// agree; if you change the composition rule, change it in both places.
+function composeMode(is3dss, placement, size) {
+    const p = Math.max(0, Math.min(2, placement | 0));
+    if (is3dss) return String(p);
+    const index = 3 + p * MODE_PLACEMENTS + Math.max(0, Math.min(2, size | 0));
+    return index < 10 ? String(index) : String.fromCharCode(65 + index - 10);
+}
+
+export class RadioScopeControl {
+    constructor() {
+        this.card = document.getElementById('radioScopeCard');
+        if (!this.card) return;              // model has no CAT scope control
+
+        this.body     = document.getElementById('radioScopeBody');
+        this.toggle   = document.getElementById('radioScopeToggle');
+        this.chevron  = document.getElementById('radioScopeChevron');
+        this.status   = document.getElementById('radioScopeStatus');
+        this.sizeGroup = document.getElementById('scopeSizeGroup');
+        this.levelSlider = document.getElementById('scopeLevelSlider');
+        this.levelLabel  = document.getElementById('scopeLevelLabel');
+
+        this.band    = 'main';
+        this.state   = null;
+        this.loaded  = false;
+        this.busy    = false;
+
+        this._wireExpand();
+        this._wireControls();
+
+        // Restore the operator's expand/collapse choice, and load state if they
+        // had it open. Same localStorage convention as the spectrum panels.
+        if (localStorage.getItem('ywc.radioScopeOpen') === '1') this._expand();
+    }
+
+    // ── expand / collapse ────────────────────────────────────────────────────
+
+    _wireExpand() {
+        const flip = () => (this.body.style.display === 'none' ? this._expand() : this._collapse());
+        this.toggle.addEventListener('click', flip);
+        this.toggle.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); flip(); }
+        });
+    }
+
+    _expand() {
+        this.body.style.display = '';
+        this.toggle.setAttribute('aria-expanded', 'true');
+        this.chevron?.classList.replace('bi-chevron-down', 'bi-chevron-up');
+        localStorage.setItem('ywc.radioScopeOpen', '1');
+        if (!this.loaded) this.refresh();
+    }
+
+    _collapse() {
+        this.body.style.display = 'none';
+        this.toggle.setAttribute('aria-expanded', 'false');
+        this.chevron?.classList.replace('bi-chevron-up', 'bi-chevron-down');
+        localStorage.setItem('ywc.radioScopeOpen', '0');
+    }
+
+    // ── control wiring ───────────────────────────────────────────────────────
+
+    _wireControls() {
+        this.card.querySelectorAll('.scope-band-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                this.band = btn.dataset.band;
+                this.card.querySelectorAll('.scope-band-btn')
+                    .forEach(b => b.classList.toggle('active', b === btn));
+                // MAIN and SUB hold genuinely independent settings on the '101,
+                // so switching scope means re-reading, not re-labelling.
+                this.loaded = false;
+                this.refresh();
+            });
+        });
+
+        this.card.querySelectorAll('.scope-span-btn').forEach(btn => {
+            btn.addEventListener('click', () => this._send('span', btn.dataset.value));
+        });
+
+        // The three mode axes all resolve to one SS write, composed from the
+        // current state plus whichever axis the operator just moved.
+        this.card.querySelectorAll('.scope-type-btn').forEach(btn => {
+            btn.addEventListener('click', () => this._sendMode({ is3dss: btn.dataset.value === '3dss' }));
+        });
+        this.card.querySelectorAll('.scope-place-btn').forEach(btn => {
+            btn.addEventListener('click', () => this._sendMode({ placement: parseInt(btn.dataset.value, 10) }));
+        });
+        this.card.querySelectorAll('.scope-size-btn').forEach(btn => {
+            btn.addEventListener('click', () => this._sendMode({ size: parseInt(btn.dataset.value, 10) }));
+        });
+
+        this.card.querySelectorAll('.scope-toggle-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const setting = btn.dataset.setting;
+                const now = this.state?.[setting] === '1';
+                this._send(setting, now ? '0' : '1');
+            });
+        });
+
+        if (this.levelSlider) {
+            // Fire on release, not on every pixel of drag — this is a serial
+            // port, not a local slider.
+            this.levelSlider.addEventListener('input', () => {
+                this.levelLabel.textContent = this._formatLevel(this.levelSlider.value);
+            });
+            this.levelSlider.addEventListener('change', () => {
+                this._send('level', this.levelSlider.value);
+            });
+        }
+    }
+
+    _sendMode(change) {
+        const s = this.state || { is3dss: false, placement: 0, size: 0 };
+        const is3dss    = change.is3dss    !== undefined ? change.is3dss    : !!s.is3dss;
+        const placement = change.placement !== undefined ? change.placement : (s.placement | 0);
+        const size      = change.size      !== undefined ? change.size      : (s.size | 0);
+        this._send('mode', composeMode(is3dss, placement, size));
+    }
+
+    // ── transport ────────────────────────────────────────────────────────────
+
+    async refresh() {
+        await this._call(`/api/scope/${this.band}`, null);
+    }
+
+    async _send(setting, value) {
+        await this._call(`/api/scope/${this.band}/${setting}`, { value: String(value) });
+    }
+
+    async _call(url, body) {
+        if (this.busy) return;               // the port is serial; so are we
+        this.busy = true;
+        this._setStatus('…', 'bg-secondary');
+        try {
+            const res = await fetch(url, body === null ? {} : {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body)
+            });
+            const data = await res.json().catch(() => null);
+            if (!res.ok) {
+                // Show the server's own message: the useful failures here are
+                // things like "the FT-710 has no scope HOLD", which are worth
+                // reading rather than flattening into "error".
+                this._setStatus(data?.error || `Error ${res.status}`, 'bg-danger');
+                return;
+            }
+            this.loaded = true;
+            this._apply(data);
+        } catch (err) {
+            this._setStatus('No response', 'bg-danger');
+            console.error('[radio-scope]', err);
+        } finally {
+            this.busy = false;
+        }
+    }
+
+    // ── repaint from the radio's answer ──────────────────────────────────────
+
+    _apply(state) {
+        this.state = state;
+
+        this._mark('.scope-span-btn', b => b.dataset.value === state.span);
+        this._mark('.scope-type-btn', b => (b.dataset.value === '3dss') === !!state.is3dss);
+        this._mark('.scope-place-btn', b => parseInt(b.dataset.value, 10) === (state.placement | 0));
+        this._mark('.scope-size-btn', b => parseInt(b.dataset.value, 10) === (state.size | 0));
+
+        this.card.querySelectorAll('.scope-toggle-btn').forEach(btn => {
+            btn.classList.toggle('active', state[btn.dataset.setting] === '1');
+        });
+
+        // 3DSS has no size variants — the buttons stay in place but go inert,
+        // so the row does not reflow when the operator switches display type.
+        const sizeDisabled = !!state.is3dss;
+        this.sizeGroup?.querySelectorAll('.scope-size-btn')
+            .forEach(b => { b.disabled = sizeDisabled; });
+        this.sizeGroup?.classList.toggle('opacity-50', sizeDisabled);
+
+        if (this.levelSlider && state.level) {
+            const db = parseFloat(state.level);
+            if (!Number.isNaN(db)) {
+                this.levelSlider.value = db;
+                this.levelLabel.textContent = this._formatLevel(db);
+            }
+        }
+
+        this._setStatus(this._summary(state), 'bg-success');
+    }
+
+    _mark(selector, isActive) {
+        this.card.querySelectorAll(selector)
+            .forEach(b => b.classList.toggle('active', isActive(b)));
+    }
+
+    _summary(state) {
+        const spans = ['1k', '2k', '5k', '10k', '20k', '50k', '100k', '200k', '500k', '1M'];
+        const span  = spans[parseInt(state.span, 10)] || '?';
+        const type  = state.is3dss ? '3DSS' : 'W/F';
+        const place = ['Center', 'Cursor', 'Fix'][state.placement | 0] || '';
+        const hold  = state.hold === '1' ? ' · HOLD' : '';
+        return `${type} ${place} · ${span}${hold}`;
+    }
+
+    _formatLevel(db) {
+        const n = parseFloat(db);
+        if (Number.isNaN(n)) return '—';
+        return `${n >= 0 ? '+' : ''}${n.toFixed(1)} dB`;
+    }
+}

--- a/wwwroot/js/ui/radio-scope.js
+++ b/wwwroot/js/ui/radio-scope.js
@@ -41,6 +41,21 @@ function composeMode(is3dss, placement, size) {
     return index < 10 ? String(index) : String.fromCharCode(65 + index - 10);
 }
 
+// Inverse of composeMode, mirroring ScopeCommands.ParseMode in
+// Services/CatCommands.cs. Needed because the radio announces its front-panel
+// mode changes as the composed character, so unpicking it happens in the
+// browser rather than costing a server round-trip to re-read what we were just
+// told.
+function parseMode(ch) {
+    const c = String(ch || '0').toUpperCase();
+    let index = 0;
+    if (c >= '0' && c <= '9')      index = c.charCodeAt(0) - 48;
+    else if (c >= 'A' && c <= 'B') index = c.charCodeAt(0) - 65 + 10;
+    if (index < 3) return { is3dss: true, placement: index, size: 0 };
+    const offset = index - 3;
+    return { is3dss: false, placement: Math.floor(offset / 3), size: offset % 3 };
+}
+
 export class RadioScopeControl {
     constructor() {
         this.card = document.getElementById('radioScopeCard');
@@ -231,6 +246,47 @@ export class RadioScopeControl {
         if (!this.card.querySelector(`.scope-band-btn[data-band="${band}"]`)) return;
         if (band === this.band) return;
         this._selectBand(band);
+    }
+
+    // ── the operator changed something at the rig ────────────────────────────
+
+    // Called from site.js for each unsolicited SS the radio sends when someone
+    // works its front panel. Patches the one sub-command that changed and
+    // repaints, rather than re-reading all six over a port shared with the
+    // ~10 Hz meter poll: the radio has just told us the value, so asking it
+    // again would be both slower and no more truthful.
+    //
+    // { band: "main"|"sub", setting: "0".."8", field: 5 chars }
+    applyRemote(msg) {
+        if (!this.card || !msg) return;
+        if (msg.band !== this.band) return;   // the band we are not showing
+        if (!this.state) return;              // nothing loaded yet; expand reads it
+
+        const v = String(msg.field ?? '');
+        const s = { ...this.state };
+
+        switch (String(msg.setting)) {
+            case '5': s.span   = v[0]; break;
+            case '2': s.marker = v[0]; break;
+            case '1': s.peak   = v[0]; break;
+            case '0': s.speed  = v[0]; break;
+            case '8': s.hold   = v[0]; break;
+            // LEVEL is the one sub-command using the whole five-character
+            // field ("+05.0"), kept as the raw string so there is no float
+            // round-trip to disagree with the server about.
+            case '4': s.level  = v; break;
+            case '6': {
+                s.mode = v[0];
+                const m = parseMode(v[0]);
+                s.is3dss = m.is3dss; s.placement = m.placement; s.size = m.size;
+                break;
+            }
+            // Colour and AF-FFT have no control in this panel. Ignoring them
+            // is correct, not an omission.
+            default: return;
+        }
+
+        this._apply(s);
     }
 
     _sendMode(change) {

--- a/wwwroot/js/ui/site.js
+++ b/wwwroot/js/ui/site.js
@@ -1380,6 +1380,15 @@ connection.on("RadioStateUpdate", function (update) {
         window.radioScopeControl?.setActiveBand(update.value);
     }
 
+    // --- RADIO SCOPE CHANGED AT THE FRONT PANEL ---
+    // The radio announces SS changes the operator makes on the rig itself, so
+    // the scope panel can follow a hand on the front panel the same way it
+    // already follows its own writes. Transient: nothing is stored server-side
+    // (see RadioStateService.BroadcastTransient).
+    if (update.property === "ScopeSetting") {
+        window.radioScopeControl?.applyRemote(update.value);
+    }
+
     // --- SPLIT MODE ---
     if (update.property === "SplitMode") {
         splitMode = update.value;

--- a/wwwroot/js/ui/site.js
+++ b/wwwroot/js/ui/site.js
@@ -1374,6 +1374,10 @@ connection.on("RadioStateUpdate", function (update) {
         // opposite of active, so the SPLIT TX badge and the red border have
         // to switch panels whenever the active VFO changes.
         updateSplitButton();
+        // The radio's own scope display follows the operating band, so point
+        // the CAT scope controls at the same band. Absent on models without
+        // the SS command, and a no-op on single-receiver ones.
+        window.radioScopeControl?.setActiveBand(update.value);
     }
 
     // --- SPLIT MODE ---


### PR DESCRIPTION
Documentation only. No code changes, nothing shipped, no behaviour altered.

## The idea

With USB video capture we can see the radio's own TFT in the browser but we
cannot touch it. The obvious fix was to draw clickable overlays on top of the
video, positioned over the radio's on-screen buttons. That means knowing where
every button sits in the captured frame -- which varies by model, by firmware
screen layout, by capture resolution, and by what the operator currently has
displayed. It is pixel geometry pretending to be a UI.

The alternative: don't touch the radio's screen, command the radio. Yaesu
exposes the scope and meter controls over CAT. Send the command, the radio
changes its own display, and the capture shows the result because it is showing
the radio's actual screen.

Two things worth being clear about:

- This does not replace the video capture work. You still need the capture to
  see the screen. It removes the overlay/compositing layer specifically, which
  was always going to be the fragile part.
- It is worth having without video at all. Remote scope control stands on its
  own for anyone operating from another room, which reaches every user with a
  supported radio rather than only those with a capture dongle.

## What the radio actually answered

Added `scripts/probe/ss-probe.ps1` -- a read-only probe. It sends Read frames
only; no Set frame was sent, so nothing on the radio changed. Run against a
real FTdx101MP (ID0682) on COM4 with YWC stopped.

All 18 reads answered. Highlights:

```
SS04;  LEVEL  -> 'SS04+05.0;'
SS05;  SPAN   -> 'SS0590000;'     MAIN: 1 MHz
SS15;  SPAN   -> 'SS1580000;'     SUB:  500 kHz
SS06;  MODE   -> 'SS0660000;'     MAIN: W/F CURSOR (L)
SS16;  MODE   -> 'SS1620000;'     SUB:  3DSS FIX
SS08;  HOLD   -> 'SS0800000;'
```

That settles two things the layout-mangled CAT manual PDF could not:

1. P3-P7 is one 5-character field, not five one-character fields. `+05.0`
   proves it. Most sub-commands use only the first character and pad with
   zeros.
2. P1 really does address MAIN and SUB independently -- MAIN was on 1 MHz W/F
   CURSOR while SUB was on 500 kHz 3DSS FIX at the same moment.

## Per-radio picture

Full matrix is in the note. The four differences that matter:

- **Mono/Multi has no CAT command on any of the seven models.** Searched every
  CAT manual; no command, no menu entry. This is the one item on the original
  wish-list that stays front-panel-only. If it is essential it needs an
  overlay -- but a much smaller one than the original proposal.
- **The FT-710 has no HOLD.** Its P2 list stops at 7; the FTdx101 and FTdx10 go
  to 8. Genuinely fewer functions, not a documentation gap.
- **The FT-710 spells Expand differently** -- EXPAND/NORMAL where the 101 and
  10 use L/N/S. Incompatible value tables, so the mode selector needs a
  per-model map. Do not unify them.
- **FTDX3000 and FTDX5000 are effectively out.** FTDX3000 has no SS at all
  (scope lives in EX menu 124-148, which is configuration rather than a
  control); FTDX5000 has only a DP display-page selector. Neither has an
  engaged reporter.

## What is NOT established

No write has been attempted. Every frame in the note is a Read. The first
bench gate before any code is to send one Set by hand and read it back --
`SS0540000;` to move MAIN span to 20 kHz, then `SS05;` to confirm it reads
back 4.

Also open: whether SS frames arrive over auto-information when the operator
touches the radio's own screen (determines sync vs poll), and how a
user-facing meter selector would cooperate with the existing borrow-and-restore
in MeterPollingService, which overwrites the meter pair on transmit. That
interaction is the most likely bug in the whole feature.

The FTdx10 and FT-710 columns are from the manuals only. @fabiojvalente -- if
this looks worth doing, the FTdx10 column is the one you could confirm, though
there is nothing to test yet and no rush.

## Scope recommendation

If it goes ahead: FTdx101 and FTdx10 only, per the focus-on-actively-reported-
radios rule. FT-710 support is cheap to add later but would ship unverified.
