### PR TITLE
Stop serving stale JavaScript to upgrading users

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -2370,20 +2370,26 @@
         window.ywcVoiceNudgeStepHzB = @Model.VoiceNudgeStepHzB;
         window.ywcIsWindowsHost = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.IsWindowsHost));
     </script>
+    @* Every import below is tied to the app version, so a release invalidates
+       all of them at once. They used to carry hand-kept numbers (?v=1 … ?v=22)
+       that had to be bumped by whoever edited the module, and in practice were
+       not: three modules changed in an IWC release without a single bump, so
+       upgrading users went on running the old code. Do not reintroduce a
+       hand-kept number here -- if a module changes, the release bumps it. *@
     <script type="module">
-        import { MeterPanel }           from "/js/guages/meter-panel.js?v=1";
-        import { SMeterHistoryPanel }   from "/js/guages/smeter-history-panel.js?v=1";
-        import { FTdx101Meters }        from "/js/orchestrators/FTdx101Meters.js?v=1";
-        import { SdrSpectrumPipeline }  from "/js/sdr/sdr-spectrum-pipeline.js?v=4";
-        import { SpectrumPanel }        from "/js/sdr/spectrum-panel.js?v=5";
-        import { FilterScopePanel }    from "/js/ui/filter-scope-panel.js?v=3";
-        import "/js/ui/if-width-tables.js?v=3";
-        import { BAND_PLANS, BAND_EDGES, getSegments, segmentForHz, nearestBandForHz, loadBandPlanFromServer } from "/js/ui/band-plan.js?v=6";
-        import { loadLabels }           from "/js/ui/a11y-labels.js?v=1";
-        import { initFreqKeyboard }     from "/js/ui/freq-keyboard.js?v=14";
-        import { initMemoriesPanel }   from "/js/ui/memories.js?v=10";
-        import { DxSpotsPanel }         from "/js/ui/dx-spots-panel.js?v=1";
-        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=22";
+        import { MeterPanel }           from "/js/guages/meter-panel.js?v=@Yaesu_Web_Control.AppVersion.Current";
+        import { SMeterHistoryPanel }   from "/js/guages/smeter-history-panel.js?v=@Yaesu_Web_Control.AppVersion.Current";
+        import { FTdx101Meters }        from "/js/orchestrators/FTdx101Meters.js?v=@Yaesu_Web_Control.AppVersion.Current";
+        import { SdrSpectrumPipeline }  from "/js/sdr/sdr-spectrum-pipeline.js?v=@Yaesu_Web_Control.AppVersion.Current";
+        import { SpectrumPanel }        from "/js/sdr/spectrum-panel.js?v=@Yaesu_Web_Control.AppVersion.Current";
+        import { FilterScopePanel }    from "/js/ui/filter-scope-panel.js?v=@Yaesu_Web_Control.AppVersion.Current";
+        import "/js/ui/if-width-tables.js?v=@Yaesu_Web_Control.AppVersion.Current";
+        import { BAND_PLANS, BAND_EDGES, getSegments, segmentForHz, nearestBandForHz, loadBandPlanFromServer } from "/js/ui/band-plan.js?v=@Yaesu_Web_Control.AppVersion.Current";
+        import { loadLabels }           from "/js/ui/a11y-labels.js?v=@Yaesu_Web_Control.AppVersion.Current";
+        import { initFreqKeyboard }     from "/js/ui/freq-keyboard.js?v=@Yaesu_Web_Control.AppVersion.Current";
+        import { initMemoriesPanel }   from "/js/ui/memories.js?v=@Yaesu_Web_Control.AppVersion.Current";
+        import { DxSpotsPanel }         from "/js/ui/dx-spots-panel.js?v=@Yaesu_Web_Control.AppVersion.Current";
+        import { initRemoteAudioUi }    from "/js/audio/remote-audio-ui.js?v=@Yaesu_Web_Control.AppVersion.Current";
         window.bandPlanData = BAND_PLANS;
         window.getBandSegments = getSegments;
         window.getBandSegmentForHz = segmentForHz;

--- a/Pages/MeterCalibration/Index.cshtml
+++ b/Pages/MeterCalibration/Index.cshtml
@@ -49,7 +49,7 @@
             createTempGauge,
             createIDDGauge,
             createVDDGauge
-        } from "/js/guages/gaugeFactory.js";
+        } from "/js/guages/gaugeFactory.js?v=@Yaesu_Web_Control.AppVersion.Current";
 
         const meterUiConfig = [
             { name: "S-Meter", title: "S-Meter", type: "s_meter", statusPath: ["vfoA", "sMeter"], creator: createSMeterGauge },

--- a/Pages/RemoteAudio.cshtml
+++ b/Pages/RemoteAudio.cshtml
@@ -159,7 +159,7 @@
         window.ywcTxToggleKey = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.TxToggleKey));
     </script>
     <script type="module">
-        import { initRemoteAudioPopout } from "/js/audio/remote-audio-ui.js?v=22";
+        import { initRemoteAudioPopout } from "/js/audio/remote-audio-ui.js?v=@Yaesu_Web_Control.AppVersion.Current";
         initRemoteAudioPopout();
     </script>
 </body>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -25,9 +25,10 @@
     <script src="~/lib/canvas-gauges/gauge.min.js"></script>
 
     <!-- Calibration engine — exposes window.calibrationEngine for site.js -->
-    <!-- v=15: bump this when calibration-engine.js or calibration-tables.js changes -->
+    @* Version-tied, so a release invalidates it. It previously carried a
+       hand-kept ?v=15 with a comment telling the next editor to bump it. *@
     <script type="module">
-        import { calibrateNumeric, calibrateSMeterLabel, calibrateSMeterForGauge, loadFromBackend } from '/js/calibration/calibration-engine.js?v=15';
+        import { calibrateNumeric, calibrateSMeterLabel, calibrateSMeterForGauge, loadFromBackend } from '/js/calibration/calibration-engine.js?v=@Yaesu_Web_Control.AppVersion.Current';
         // Expose immediately with default tables so site.js never gets undefined.
         window.calibrationEngine = { calibrateNumeric, calibrateSMeterLabel, calibrateSMeterForGauge };
         // S-Meter calibration drives BOTH the gauge needle position (SMETER
@@ -44,7 +45,7 @@
 
     <!-- Meter formatters — exposes window.MeterFormatters for site.js -->
     <script type="module">
-        import { MeterFormatters } from '/js/ui/meter-formatters.js?v=8';
+        import { MeterFormatters } from '/js/ui/meter-formatters.js?v=@Yaesu_Web_Control.AppVersion.Current';
         window.MeterFormatters = MeterFormatters;
     </script>
 </head>

--- a/Program.cs
+++ b/Program.cs
@@ -590,14 +590,45 @@ try
         app.UseHsts();
     }
 
-    app.UseStaticFiles();
+    // Static files must be REVALIDATED, not trusted from cache.
+    //
+    // Without an explicit Cache-Control, ASP.NET Core sends only Last-Modified
+    // and ETag, which leaves the browser free to apply heuristic freshness —
+    // commonly a tenth of the file's age. A file that was already a fortnight
+    // old when the browser cached it therefore stays "fresh" for a day or more,
+    // and the browser will not so much as ask whether it changed.
+    //
+    // Installing a new version over the top replaces the file on disk but does
+    // nothing to that cached copy, so an upgrading user gets the new page with
+    // the old JavaScript behind it and any fix living in that JavaScript simply
+    // never arrives. Ctrl+F5 clears it, which is not something an operator
+    // should have to know. This was found in IWC, where it had silently
+    // swallowed both headline fixes of a release; YWC carried the same hole.
+    //
+    // "no-cache" does NOT mean "do not store": the browser keeps the file and
+    // revalidates it, so an unchanged file costs one conditional GET answered
+    // with a 304 and no body. On a localhost or LAN app that is free, and it is
+    // the price of never shipping a fix that fails to arrive.
+    app.UseStaticFiles(new StaticFileOptions
+    {
+        OnPrepareResponse = ctx =>
+        {
+            ctx.Context.Response.Headers.CacheControl = "no-cache, must-revalidate";
+        }
+    });
     var picturesPath = System.IO.Path.Combine(app.Environment.ContentRootPath, "pictures");
     if (System.IO.Directory.Exists(picturesPath))
     {
         app.UseStaticFiles(new StaticFileOptions
         {
             FileProvider = new Microsoft.Extensions.FileProviders.PhysicalFileProvider(picturesPath),
-            RequestPath = "/pictures"
+            RequestPath = "/pictures",
+            // Same reasoning as above. These are user-supplied images, so a
+            // replaced picture must not go on being served from cache either.
+            OnPrepareResponse = ctx =>
+            {
+                ctx.Context.Response.Headers.CacheControl = "no-cache, must-revalidate";
+            }
         });
     }
     app.UseWebSockets();

--- a/wwwroot/js/audio/audio-capture.js
+++ b/wwwroot/js/audio/audio-capture.js
@@ -1,7 +1,8 @@
+// ?v=1 is a one-time cache-buster, not a number to bump — see gaugeFactory.js.
 import {
   SAMPLE_RATE, FRAME_SAMPLES, MSG_OPUS_TX, MSG_PCM_TX, OPUS_FRAME_DURATION_US,
   frameMessage, floatToPcm16, supportsWebCodecsOpus
-} from './audio-protocol.js';
+} from './audio-protocol.js?v=1';
 
 /**
  * Captures microphone PCM, encodes Opus (WebCodecs) or PCM16, sends via callback.

--- a/wwwroot/js/audio/audio-playback.js
+++ b/wwwroot/js/audio/audio-playback.js
@@ -1,7 +1,8 @@
+// ?v=1 is a one-time cache-buster, not a number to bump — see gaugeFactory.js.
 import {
   SAMPLE_RATE, FRAME_SAMPLES, MSG_OPUS_RX, MSG_PCM_RX,
   pcm16ToFloat, supportsWebCodecsOpus
-} from './audio-protocol.js';
+} from './audio-protocol.js?v=1';
 
 /**
  * Low-latency playback of RX Opus or PCM16 frames.

--- a/wwwroot/js/audio/audio-session.js
+++ b/wwwroot/js/audio/audio-session.js
@@ -1,9 +1,10 @@
+// ?v=1 is a one-time cache-buster, not a number to bump — see gaugeFactory.js.
 import {
   MSG_CONTROL, MSG_OPUS_RX, MSG_PCM_RX,
   frameMessage, parseBody, buildCodecOfferList
-} from './audio-protocol.js';
-import { AudioCapture } from './audio-capture.js';
-import { AudioPlayback } from './audio-playback.js';
+} from './audio-protocol.js?v=1';
+import { AudioCapture } from './audio-capture.js?v=1';
+import { AudioPlayback } from './audio-playback.js?v=1';
 
 /**
  * Owns the /audio WebSocket session and wires capture ↔ playback.

--- a/wwwroot/js/audio/remote-audio-ui.js
+++ b/wwwroot/js/audio/remote-audio-ui.js
@@ -1,5 +1,6 @@
-import { createAudioSession } from './audio-session.js';
-import { supportsWebCodecsOpus } from './audio-protocol.js';
+// ?v=1 is a one-time cache-buster, not a number to bump — see gaugeFactory.js.
+import { createAudioSession } from './audio-session.js?v=1';
+import { supportsWebCodecsOpus } from './audio-protocol.js?v=1';
 
 const CHANNEL_NAME = 'ywc-remote-audio';
 const POPOUT_STORAGE_KEY = 'ywc.remoteAudio.popout';

--- a/wwwroot/js/guages/gaugeFactory.js
+++ b/wwwroot/js/guages/gaugeFactory.js
@@ -2,7 +2,20 @@
 // Creates gauge instances based on a type string.
 // No layout logic, no DOM queries, no calibration logic.
 
-import { SMeterGauge, PowerGauge, SWRGauge, ALCGauge, TempGauge, CompressionGauge, IDDGauge, VDDGauge } from './gauge.js';
+// The ?v=1 below is a ONE-TIME cache-buster. Do not bump it.
+//
+// An import made from inside a module never passes through Razor, so it cannot
+// carry the app version the way the page's own imports do — the URL is baked
+// into this file. That leaves two holes, and this fixes the second of them:
+// a browser holding a stale copy of gauge.js keeps serving it however many
+// times gaugeFactory.js is re-fetched, because the URL never changed.
+//
+// Program.cs now sends "no-cache, must-revalidate" on static files, which
+// prevents this happening again — but it cannot reach a copy cached BEFORE
+// that header existed. Changing the URL once is the only thing that can.
+// Once every user is past that upgrade the marker is inert, and bumping it
+// achieves nothing the version-tied parent import has not already done.
+import { SMeterGauge, PowerGauge, SWRGauge, ALCGauge, TempGauge, CompressionGauge, IDDGauge, VDDGauge } from './gauge.js?v=1';
 
 // Registry of gauge constructors.
 // Add new meter types here as your UI grows.

--- a/wwwroot/js/guages/meter-panel.js
+++ b/wwwroot/js/guages/meter-panel.js
@@ -3,8 +3,9 @@
 // exposes update() as the single point of entry for needle changes.
 // No calibration, no WebSocket, no DOM queries beyond canvas IDs.
 
-import { createGauge } from './gaugeFactory.js';
-import { updateGaugeValue } from './update-engine.js';
+// ?v=1 is a one-time cache-buster, not a number to bump — see gaugeFactory.js.
+import { createGauge } from './gaugeFactory.js?v=1';
+import { updateGaugeValue } from './update-engine.js?v=1';
 
 export class MeterPanel {
 

--- a/wwwroot/js/guages/smeter-history-panel.js
+++ b/wwwroot/js/guages/smeter-history-panel.js
@@ -17,7 +17,8 @@
 // DOM access outside the canvas, no string formatting. The caller pushes raw
 // 0-255 values via push(); the panel does its own ring-buffer + render loop.
 
-import { calibrateSMeterLabel } from '../calibration/calibration-engine.js';
+// ?v=1 is a one-time cache-buster, not a number to bump — see gaugeFactory.js.
+import { calibrateSMeterLabel } from '../calibration/calibration-engine.js?v=1';
 
 export class SMeterHistoryPanel {
 

--- a/wwwroot/js/sdr/sdr-spectrum-pipeline.js
+++ b/wwwroot/js/sdr/sdr-spectrum-pipeline.js
@@ -16,7 +16,8 @@
 // Uses the same { property, value } message envelope as the rest of the app
 // so the existing WsUpdatePipeline can be reused for dispatching.
 
-import { WsUpdatePipeline } from '../websocket/ws-update-pipeline.js';
+// ?v=1 is a one-time cache-buster, not a number to bump — see gaugeFactory.js.
+import { WsUpdatePipeline } from '../websocket/ws-update-pipeline.js?v=1';
 
 export class SdrSpectrumPipeline {
 

--- a/wwwroot/js/sdr/spectrum-panel.js
+++ b/wwwroot/js/sdr/spectrum-panel.js
@@ -7,7 +7,8 @@
 // Frequency axis labels are computed from the VFO frequency reported by
 // SdrSpectrumPipeline so the display is always centred on the current band.
 
-import { modeForHz } from '../ui/band-plan.js';
+// ?v=1 is a one-time cache-buster, not a number to bump — see gaugeFactory.js.
+import { modeForHz } from '../ui/band-plan.js?v=1';
 
 export class SpectrumPanel {
 

--- a/wwwroot/js/ui/dx-spots-panel.js
+++ b/wwwroot/js/ui/dx-spots-panel.js
@@ -5,7 +5,8 @@
 // regardless of whether an SDR is configured — relies only on the SignalR
 // DxSpot event stream, which flows unconditionally.
 
-import { modeForHz } from './band-plan.js';
+// ?v=1 is a one-time cache-buster, not a number to bump — see gaugeFactory.js.
+import { modeForHz } from './band-plan.js?v=1';
 
 const LS_KEY     = 'dxSpotsPanel';
 const AGE_MAX_MS = 15 * 60 * 1000;   // matches DxSpotAgeMinutes default


### PR DESCRIPTION
Port of the caching fix found in IWC (IWC PR #32). YWC had the same hole, and rather more of it.

## The bug

With no `Cache-Control` on static files, ASP.NET Core sends only `Last-Modified` and `ETag`. That leaves the browser free to apply **heuristic freshness** — commonly a tenth of the file's age. A file already a fortnight old when the browser cached it therefore stays "fresh" for a day or more without so much as a conditional request, and **installing a new version over the top does nothing to that cached copy**.

The user gets the new page with the old JavaScript behind it, and any fix living in that JavaScript simply never arrives. `Ctrl+F5` clears it, which is not something an operator should have to know.

In IWC this silently swallowed *both* headline fixes of a release. Worse than the lost fixes: a tester reporting "still broken" is indistinguishable from a real failure.

## The fix — three parts, all needed

**1. `Program.cs` — revalidate.** `no-cache, must-revalidate` on static files. It means *revalidate*, not *do not store*: an unchanged file costs one conditional GET answered `304` with no body, which on a LAN app is free. Also applied to the `/pictures` provider, since a replaced picture has exactly the same problem.

**2. Razor imports tied to the app version.** 17 of them, now `?v=@Yaesu_Web_Control.AppVersion.Current`, so a release invalidates the lot at once. They previously carried hand-kept numbers (`?v=1` … `?v=22`) that whoever edited a module was expected to bump — and in practice did not. One, `gaugeFactory.js` on the Meter Calibration page, had **no version at all**.

**3. One-time `?v=1` on the 13 module-to-module imports.** This is the part that is easy to miss. An import made *from inside a module* never passes through Razor, so it cannot carry the app version — and a stale parent goes on requesting the stale child URL for ever, so versioning only the top-level imports cannot rescue the children. Changing the URL once is the only thing that can reach a copy cached before the header existed. The comment in `gaugeFactory.js` explains it and says not to bump it.

YWC had 13 internal imports to IWC's 4 — the remote-audio modules account for the difference.

## Verification

`dotnet build` clean, 0 warnings, 0 errors. Every internal import confirmed versioned and no hand-kept `?v=` left in Razor; BOMs on the three `.cshtml` files that carry one are intact.

⚠️ **Not runtime-verified here.** YWC has no stub-radio mode and a global single-instance mutex, so starting it would have opened the CAT port to the radio unprompted. The identical change *was* runtime-verified in IWC — header served, imports rendering the version, and a conditional GET returning `304`.

Worth a look when you next run YWC: the first load after this still needs one `Ctrl+F5` (the fix can only take hold once the browser has fetched the new files), and never again after that.

## Not done

No README release-notes entry. The latest section is v2.4.3-pre6, dated and describing pre6, and this was not in it — so the entry belongs with whichever release ships this, at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)