### PR TITLE
Publish unstable-YYYYMMDD snapshots from develop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,11 @@ jobs:
         run: dotnet test Tests/YaesuWebControl.Tests/YaesuWebControl.Tests.csproj --configuration Release --verbosity normal
 
   build-windows:
+    # Unstable snapshots of develop are published by unstable.yml. Creating
+    # that GitHub Release would otherwise re-enter this workflow (on:
+    # release) and the docker job would try to parse unstable-YYYYMMDD as
+    # SemVer.
+    if: github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'unstable-')
     runs-on: windows-latest
     permissions:
       contents: write
@@ -184,7 +189,7 @@ jobs:
   # finished. Failing at 20 minutes (~10x the 1m50s normal, so a merely slow
   # runner won't trip it) makes that visible instead of silent.
   build-macos:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && (github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'unstable-'))
     runs-on: macos-latest
     timeout-minutes: 20
     permissions:
@@ -230,6 +235,7 @@ jobs:
   # Multi-arch CAT-only Linux image → GHCR (amd64 + arm64).
   # workflow_dispatch with empty tag → build only, no push (smoke test).
   build-docker:
+    if: github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'unstable-')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -321,7 +327,7 @@ jobs:
     # job, so the check would go silent in precisely the case it exists for.
     # The event guard stays inside the same expression — a dispatch or a PR has
     # no release to inspect.
-    if: ${{ always() && github.event_name == 'release' }}
+    if: ${{ always() && github.event_name == 'release' && !startsWith(github.event.release.tag_name, 'unstable-') }}
     needs: [build-windows, build-macos, build-docker]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -1,0 +1,242 @@
+name: Unstable develop snapshot
+
+# Snapshot of `develop`, versioned unstable-YYYYMMDD (UTC). Not a supported
+# release. Several pushes on the same UTC day replace that day's prerelease
+# in place. Marked prerelease so GitHub's /releases/latest — and the in-app
+# update banner that reads it — stay on the last full release. GHCR :latest
+# is never moved; the image is tagged unstable-YYYYMMDD and unstable.
+#
+# Builds first, then one job creates the GitHub Release and attaches the
+# Windows installer and macOS DMGs. That avoids an empty prerelease if a
+# build fails. The Docker image is pushed from its own job (it is not a
+# release asset).
+#
+# Creating the prerelease would otherwise re-enter release.yml (on:
+# release). That workflow skips tags that start with unstable- so it does
+# not try to parse this version as SemVer. GITHUB_TOKEN-created releases
+# also do not trigger other workflows; the skip is belt-and-braces.
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+concurrency:
+  group: unstable-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prep:
+    if: github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set.outputs.version }}
+      image: ${{ steps.set.outputs.image }}
+    steps:
+      - id: set
+        run: |
+          echo "version=unstable-$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+          echo "image=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+  build-windows:
+    needs: prep
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Stamp unstable version
+        env:
+          VERSION: ${{ needs.prep.outputs.version }}
+        run: |
+          (Get-Content Models/AppVersion.cs -Raw) `
+            -replace 'Current = "[^"]*"', "Current = `"$env:VERSION`"" |
+            Set-Content Models/AppVersion.cs -NoNewline
+        shell: pwsh
+
+      - name: Setup .NET 10
+        run: |
+          $v = dotnet --version 2>$null
+          if ($v -and $v.StartsWith('10.')) {
+            Write-Host ".NET $v already installed — skipping download"
+          } else {
+            Write-Host "Installing .NET 10..."
+            Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -OutFile 'dotnet-install.ps1'
+            .\dotnet-install.ps1 -Channel '10.0' -InstallDir "$env:LOCALAPPDATA\Microsoft\dotnet"
+            $env:PATH = "$env:LOCALAPPDATA\Microsoft\dotnet;$env:PATH"
+            Write-Host "Installed: $(dotnet --version)"
+          }
+        shell: pwsh
+
+      - name: Install NSIS
+        run: choco install nsis --yes
+        shell: pwsh
+
+      - name: Publish 64-bit self-contained app
+        run: |
+          dotnet publish Yaesu_Web_Control.csproj `
+            --framework net10.0-windows `
+            --configuration Release `
+            --runtime win-x64 `
+            --self-contained true `
+            --output publish
+        shell: pwsh
+
+      - name: Build NSIS installer
+        env:
+          VERSION: ${{ needs.prep.outputs.version }}
+        run: |
+          $makensis = (Get-Command makensis.exe -ErrorAction SilentlyContinue)?.Source
+          if (-not $makensis) { $makensis = "C:\\Program Files (x86)\\NSIS\\makensis.exe" }
+          if (!(Test-Path $makensis)) { Write-Error "makensis.exe not found at $makensis"; exit 1 }
+          Write-Host "Using NSIS at: $makensis"
+          & $makensis "/DVERSION=$env:VERSION" installer.nsi
+          if ($LASTEXITCODE -ne 0) { Write-Error "NSIS failed (exit $LASTEXITCODE)"; exit 1 }
+          $found = Get-ChildItem -Filter "*Setup*.exe" | Select-Object -First 1
+          if (!$found) { Write-Error "No *Setup*.exe found after NSIS ran"; exit 1 }
+          if ($found.Name -ne "Yaesu_Web_Control_Setup.exe") {
+            Rename-Item $found.FullName "Yaesu_Web_Control_Setup.exe"
+          }
+          if (!(Test-Path "Yaesu_Web_Control_Setup.exe")) {
+            Write-Error "Yaesu_Web_Control_Setup.exe not found after build"
+            exit 1
+          }
+          Write-Host "OK: $('{0:N0}' -f (Get-Item Yaesu_Web_Control_Setup.exe).Length) bytes"
+        shell: pwsh
+
+      - name: Upload installer as workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-installer
+          path: Yaesu_Web_Control_Setup.exe
+
+  # Same timeout rationale as release.yml (hosted arm64 macOS runners can stall).
+  build-macos:
+    needs: prep
+    runs-on: macos-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Stamp unstable version
+        env:
+          VERSION: ${{ needs.prep.outputs.version }}
+        run: sed -i '' "s/Current = \"[^\"]*\"/Current = \"${VERSION}\"/" Models/AppVersion.cs
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build macOS DMGs (arm64 + x64)
+        env:
+          VERSION: ${{ needs.prep.outputs.version }}
+        run: |
+          chmod +x scripts/macos/build-dmg.sh
+          ./scripts/macos/build-dmg.sh all
+          ls -lh publish/dmg/*.dmg
+
+      - name: Upload DMGs as workflow artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-dmgs
+          path: publish/dmg/*.dmg
+
+  build-docker:
+    needs: prep
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      actions: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Stamp unstable version
+        env:
+          VERSION: ${{ needs.prep.outputs.version }}
+        run: sed -i "s/Current = \"[^\"]*\"/Current = \"${VERSION}\"/" Models/AppVersion.cs
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ needs.prep.outputs.image }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ needs.prep.outputs.version }}
+            type=raw,value=unstable
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  publish-release:
+    needs: [prep, build-windows, build-macos, build-docker]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          merge-multiple: true
+          path: dist
+
+      - name: Recreate prerelease ${{ needs.prep.outputs.version }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.prep.outputs.version }}
+          IMAGE: ${{ needs.prep.outputs.image }}
+        run: |
+          ls -lh dist
+          gh release delete "$VERSION" --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag || true
+          gh release create "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --prerelease \
+            --latest=false \
+            --target "$GITHUB_SHA" \
+            --title "Unstable $VERSION" \
+            --notes "$(cat <<EOF
+          Automated snapshot of \`develop\` at \`${GITHUB_SHA}\`.
+
+          This is not a supported release. Installers, DMGs, and the GHCR image
+          are overwritten if \`develop\` moves again on the same UTC day.
+
+          Image: \`${IMAGE}:${VERSION}\` (also tagged \`unstable\`).
+          EOF
+          )" \
+            dist/Yaesu_Web_Control_Setup.exe \
+            dist/*.dmg

--- a/installer.nsi
+++ b/installer.nsi
@@ -1,6 +1,8 @@
 !define APPNAME "Yaesu Web Control"
 !define COMPANY "MM5AGM"
+!ifndef VERSION
 !define VERSION "2.4.3"
+!endif
 !define INSTALLDIR "$PROGRAMFILES64\${COMPANY}\${APPNAME}"
 Name "${APPNAME} ${VERSION}"
 OutFile "Yaesu_Web_Control_Setup.exe"


### PR DESCRIPTION
## Summary
- Adds a `develop` workflow that builds the Windows installer, macOS DMGs, and multi-arch Docker image, then publishes them as a GitHub prerelease tagged `unstable-YYYYMMDD` (UTC). Same-day pushes replace that day’s snapshot in place.
- Stamps that version into the built app / NSIS DisplayVersion / DMG names, and tags GHCR as `unstable-YYYYMMDD` plus a moving `unstable` tag. `:latest` and `/releases/latest` are left on the last full release.
- Skips `unstable-*` tags in the existing release workflow so creating the prerelease cannot start a second SemVer build.

## Test plan
- [ ] Merge to `develop` and confirm **Unstable develop snapshot** runs (or use **Run workflow**).
- [ ] Confirm a prerelease `unstable-YYYYMMDD` appears with `Yaesu_Web_Control_Setup.exe` and both macOS DMGs.
- [ ] Confirm GHCR has `unstable-YYYYMMDD` and `unstable`, and that `latest` did not move.
- [ ] Confirm the GitHub “latest release” and in-app update banner still point at the last full release.
- [ ] Push a second commit to `develop` on the same UTC day and confirm the same tag is replaced rather than duplicated.


Made with [Cursor](https://cursor.com)