### PR TITLE
Fix Linux Radio Display stuck at 800×600@20 fps

### DIFF
--- a/Services/Video/LinuxV4l2Devices.cs
+++ b/Services/Video/LinuxV4l2Devices.cs
@@ -12,6 +12,7 @@ namespace Yaesu_Web_Control.Services.Video
     internal static class LinuxV4l2Devices
     {
         private const int O_RDONLY = 0;
+        private const int O_RDWR = 2;
         private const int O_NONBLOCK = 0x800;
         private const uint V4L2_CAP_VIDEO_CAPTURE = 0x00000001;
         private const uint V4L2_CAP_VIDEO_CAPTURE_MPLANE = 0x00001000;
@@ -179,6 +180,9 @@ namespace Yaesu_Web_Control.Services.Video
         private static readonly UIntPtr VidIocEnumFramesizes = unchecked((UIntPtr)0xC02C564A);
         // _IOWR('V', 75, struct v4l2_frmivalenum) — 52 bytes
         private static readonly UIntPtr VidIocEnumFrameintervals = unchecked((UIntPtr)0xC034564B);
+        // _IOWR('V', 4/5, struct v4l2_format) — 208 bytes on 64-bit (union 8-aligned)
+        private static readonly UIntPtr VidIocGFmt = unchecked((UIntPtr)0xC0D05604);
+        private static readonly UIntPtr VidIocSFmt = unchecked((UIntPtr)0xC0D05605);
         // _IOWR('V', 21/22, struct v4l2_streamparm) — 204 bytes
         private static readonly UIntPtr VidIocGParm = unchecked((UIntPtr)0xC0CC5615);
         private static readonly UIntPtr VidIocSParm = unchecked((UIntPtr)0xC0CC5616);
@@ -229,16 +233,91 @@ namespace Yaesu_Web_Control.Services.Video
             }
         }
 
+        public static int OpenCaptureFd(int index)
+        {
+            var fd = Open(DevicePath(index), O_RDWR | O_NONBLOCK);
+            return fd;
+        }
+
+        public static void CloseFd(int fd)
+        {
+            if (fd >= 0)
+                _ = Close(fd);
+        }
+
+        public static bool TrySetFrameRateFd(int fd, int fps) =>
+            fd >= 0 && fps >= 1 &&
+            (TrySetFrameRateOnFd(fd, V4l2BufTypeVideoCapture, fps)
+             || TrySetFrameRateOnFd(fd, V4l2BufTypeVideoCaptureMplane, fps));
+
         /// <summary>
-        /// VIDIOC_S_PARM timeperframe. OpenCV's CAP_PROP_FPS often does not
-        /// stick on V4L2 after the first S_FMT.
+        /// VIDIOC_S_FMT MJPEG + VIDIOC_S_PARM on an already-open RDWR fd.
+        /// </summary>
+        public static bool TryConfigureMjpeg(int fd, int width, int height, int fps)
+        {
+            if (fd < 0 || width < 2 || height < 2 || fps < 1)
+                return false;
+
+            return TrySetMjpegFormatOnFd(fd, V4l2BufTypeVideoCapture, width, height, fps)
+                || TrySetMjpegFormatOnFd(fd, V4l2BufTypeVideoCaptureMplane, width, height, fps);
+        }
+
+        /// <summary>
+        /// VIDIOC_S_FMT MJPEG + VIDIOC_S_PARM. Must be RDWR; OpenCV's FPS
+        /// property at 800×600@30 is what UVC turns into YUYV@20 on USB2.
+        /// Call after VideoCapture opens and before the first Read.
+        /// </summary>
+        public static bool TrySetMjpegFormat(int index, int width, int height, int fps)
+        {
+            var fd = OpenCaptureFd(index);
+            if (fd < 0)
+                return false;
+
+            try
+            {
+                return TryConfigureMjpeg(fd, width, height, fps);
+            }
+            finally
+            {
+                _ = Close(fd);
+            }
+        }
+
+        private static bool TrySetMjpegFormatOnFd(int fd, uint bufType, int width, int height, int fps)
+        {
+            var fmt = new V4l2Format { Type = bufType };
+            if (Ioctl(fd, VidIocGFmt, ref fmt) != 0)
+                return false;
+
+            fmt.Width = (uint)width;
+            fmt.Height = (uint)height;
+            fmt.PixelFormat = FourCc('M', 'J', 'P', 'G');
+            fmt.Field = 1; // V4L2_FIELD_NONE
+            fmt.BytesPerLine = 0;
+            fmt.SizeImage = 0;
+            if (Ioctl(fd, VidIocSFmt, ref fmt) != 0)
+                return false;
+
+            TrySetFrameRateOnFd(fd, bufType, fps);
+
+            var check = new V4l2Format { Type = bufType };
+            if (Ioctl(fd, VidIocGFmt, ref check) != 0)
+                return IsJpegPixelFormat(fmt.PixelFormat);
+
+            return IsJpegPixelFormat(check.PixelFormat)
+                && check.Width >= 2
+                && check.Height >= 2;
+        }
+
+        /// <summary>
+        /// VIDIOC_S_PARM timeperframe. Needs a writable fd.
         /// </summary>
         public static bool TrySetFrameRate(int index, int fps)
         {
             if (fps < 1)
                 return false;
 
-            var fd = Open(DevicePath(index), O_RDONLY | O_NONBLOCK);
+            var fd = Open(DevicePath(index), O_RDWR | O_NONBLOCK);
             if (fd < 0)
                 return false;
 
@@ -269,10 +348,12 @@ namespace Yaesu_Web_Control.Services.Video
             for (uint fmtIndex = 0; fmtIndex < EnumCap; fmtIndex++)
             {
                 var fmt = new V4l2FmtDesc { Index = fmtIndex, Type = bufType };
-                if (Ioctl(fd, VidIocEnumFmt, ref fmt) != 0 || fmt.PixelFormat == 0)
+                if (Ioctl(fd, VidIocEnumFmt, ref fmt) != 0)
                     break;
+                if (fmt.PixelFormat == 0)
+                    continue;
 
-                var jpeg = IsJpegPixelFormat(fmt.PixelFormat);
+                var jpeg = IsJpegPixelFormat(fmt.PixelFormat) || (fmt.Flags & 0x0001) != 0;
                 for (uint sizeIndex = 0; sizeIndex < EnumCap; sizeIndex++)
                 {
                     var size = new V4l2FrmSizeEnum
@@ -387,6 +468,9 @@ namespace Yaesu_Web_Control.Services.Video
         [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
         private static extern int Ioctl(int fd, UIntPtr request, ref V4l2StreamParm arg);
 
+        [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
+        private static extern int Ioctl(int fd, UIntPtr request, ref V4l2Format arg);
+
         [StructLayout(LayoutKind.Sequential, Size = 204)]
         private struct V4l2StreamParm
         {
@@ -397,6 +481,29 @@ namespace Yaesu_Web_Control.Services.Video
             public uint TpfDenominator;
             public uint ExtendedMode;
             public uint ReadBuffers;
+        }
+
+        /// <summary>
+        /// 64-bit v4l2_format: type + 4-byte pad (union contains pointers via
+        /// v4l2_window) + pix (width/height/fourcc…).
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, Size = 208)]
+        private struct V4l2Format
+        {
+            public uint Type;
+            public uint Pad;
+            public uint Width;
+            public uint Height;
+            public uint PixelFormat;
+            public uint Field;
+            public uint BytesPerLine;
+            public uint SizeImage;
+            public uint Colorspace;
+            public uint Priv;
+            public uint Flags;
+            public uint YcbcrEnc;
+            public uint Quantization;
+            public uint XferFunc;
         }
     }
 }

--- a/Services/Video/LinuxV4l2Devices.cs
+++ b/Services/Video/LinuxV4l2Devices.cs
@@ -179,6 +179,9 @@ namespace Yaesu_Web_Control.Services.Video
         private static readonly UIntPtr VidIocEnumFramesizes = unchecked((UIntPtr)0xC02C564A);
         // _IOWR('V', 75, struct v4l2_frmivalenum) — 52 bytes
         private static readonly UIntPtr VidIocEnumFrameintervals = unchecked((UIntPtr)0xC034564B);
+        // _IOWR('V', 21/22, struct v4l2_streamparm) — 204 bytes
+        private static readonly UIntPtr VidIocGParm = unchecked((UIntPtr)0xC0CC5615);
+        private static readonly UIntPtr VidIocSParm = unchecked((UIntPtr)0xC0CC5616);
 
         private const uint V4l2BufTypeVideoCapture = 1;
         private const uint V4l2BufTypeVideoCaptureMplane = 9;
@@ -189,12 +192,24 @@ namespace Yaesu_Web_Control.Services.Video
         private const uint V4l2FrmIvalStepwise = 3;
         private const int EnumCap = 32;
 
+        private static uint FourCc(char a, char b, char c, char d) =>
+            (uint)(a | (b << 8) | (c << 16) | (d << 24));
+
+        private static bool IsJpegPixelFormat(uint pixelFormat) =>
+            pixelFormat == FourCc('M', 'J', 'P', 'G') || pixelFormat == FourCc('J', 'P', 'E', 'G');
+
         /// <summary>
         /// Advertised capture rates via ENUM_FMT / FRAMESIZES / FRAMEINTERVALS.
         /// Empty if the node is busy or the driver does not report intervals.
         /// Does not start streaming.
         /// </summary>
-        public static int[] TryQueryFpsRates(int index)
+        public static int[] TryQueryFpsRates(int index) =>
+            VideoFpsOptions.UniqueSorted(TryQueryPins(index).Select(p => p.Fps));
+
+        public static int TryQueryMaxFps(int index) =>
+            VideoFpsOptions.Max(TryQueryFpsRates(index));
+
+        public static List<VideoCapturePinRank.Pin> TryQueryPins(int index)
         {
             var fd = Open(DevicePath(index), O_RDONLY | O_NONBLOCK);
             if (fd < 0)
@@ -202,11 +217,11 @@ namespace Yaesu_Web_Control.Services.Video
 
             try
             {
-                var raw = new List<double>();
-                CollectRatesForBufType(fd, V4l2BufTypeVideoCapture, raw);
-                if (raw.Count == 0)
-                    CollectRatesForBufType(fd, V4l2BufTypeVideoCaptureMplane, raw);
-                return VideoFpsOptions.UniqueSorted(raw);
+                var pins = new List<VideoCapturePinRank.Pin>();
+                CollectPinsForBufType(fd, V4l2BufTypeVideoCapture, pins);
+                if (pins.Count == 0)
+                    CollectPinsForBufType(fd, V4l2BufTypeVideoCaptureMplane, pins);
+                return pins;
             }
             finally
             {
@@ -214,10 +229,42 @@ namespace Yaesu_Web_Control.Services.Video
             }
         }
 
-        public static int TryQueryMaxFps(int index) =>
-            VideoFpsOptions.Max(TryQueryFpsRates(index));
+        /// <summary>
+        /// VIDIOC_S_PARM timeperframe. OpenCV's CAP_PROP_FPS often does not
+        /// stick on V4L2 after the first S_FMT.
+        /// </summary>
+        public static bool TrySetFrameRate(int index, int fps)
+        {
+            if (fps < 1)
+                return false;
 
-        private static void CollectRatesForBufType(int fd, uint bufType, List<double> dest)
+            var fd = Open(DevicePath(index), O_RDONLY | O_NONBLOCK);
+            if (fd < 0)
+                return false;
+
+            try
+            {
+                return TrySetFrameRateOnFd(fd, V4l2BufTypeVideoCapture, fps)
+                    || TrySetFrameRateOnFd(fd, V4l2BufTypeVideoCaptureMplane, fps);
+            }
+            finally
+            {
+                _ = Close(fd);
+            }
+        }
+
+        private static bool TrySetFrameRateOnFd(int fd, uint bufType, int fps)
+        {
+            var parm = new V4l2StreamParm { Type = bufType };
+            if (Ioctl(fd, VidIocGParm, ref parm) != 0)
+                return false;
+
+            parm.TpfNumerator = 1;
+            parm.TpfDenominator = (uint)fps;
+            return Ioctl(fd, VidIocSParm, ref parm) == 0;
+        }
+
+        private static void CollectPinsForBufType(int fd, uint bufType, List<VideoCapturePinRank.Pin> dest)
         {
             for (uint fmtIndex = 0; fmtIndex < EnumCap; fmtIndex++)
             {
@@ -225,6 +272,7 @@ namespace Yaesu_Web_Control.Services.Video
                 if (Ioctl(fd, VidIocEnumFmt, ref fmt) != 0 || fmt.PixelFormat == 0)
                     break;
 
+                var jpeg = IsJpegPixelFormat(fmt.PixelFormat);
                 for (uint sizeIndex = 0; sizeIndex < EnumCap; sizeIndex++)
                 {
                     var size = new V4l2FrmSizeEnum
@@ -237,19 +285,20 @@ namespace Yaesu_Web_Control.Services.Video
 
                     if (size.Type == V4l2FrmSizeDiscrete)
                     {
-                        CollectIntervalRates(fd, fmt.PixelFormat, size.U0, size.U1, dest);
+                        CollectPinIntervals(fd, fmt.PixelFormat, size.U0, size.U1, jpeg, dest);
                     }
                     else if (size.Type == V4l2FrmSizeStepwise)
                     {
-                        CollectIntervalRates(fd, fmt.PixelFormat, size.U0, size.U3, dest);
-                        CollectIntervalRates(fd, fmt.PixelFormat, size.U1, size.U4, dest);
+                        CollectPinIntervals(fd, fmt.PixelFormat, size.U0, size.U3, jpeg, dest);
+                        CollectPinIntervals(fd, fmt.PixelFormat, size.U1, size.U4, jpeg, dest);
                     }
                 }
             }
         }
 
-        private static void CollectIntervalRates(
-            int fd, uint pixelFormat, uint width, uint height, List<double> dest)
+        private static void CollectPinIntervals(
+            int fd, uint pixelFormat, uint width, uint height, bool jpeg,
+            List<VideoCapturePinRank.Pin> dest)
         {
             if (width < 2 || height < 2)
                 return;
@@ -268,7 +317,7 @@ namespace Yaesu_Web_Control.Services.Video
 
                 if (ival.Type == V4l2FrmIvalDiscrete)
                 {
-                    dest.Add(IntervalToFps(ival.U0, ival.U1));
+                    dest.Add(new VideoCapturePinRank.Pin((int)width, (int)height, IntervalToFps(ival.U0, ival.U1), jpeg));
                 }
                 else if (ival.Type is V4l2FrmIvalContinuous or V4l2FrmIvalStepwise)
                 {
@@ -276,9 +325,12 @@ namespace Yaesu_Web_Control.Services.Video
                     var slowest = IntervalToFps(ival.U2, ival.U3);
                     if (slowest <= 0)
                         slowest = fastest;
-                    dest.Add(fastest);
-                    dest.Add(slowest);
-                    VideoFpsOptions.AddPresetsInRange(dest, slowest, fastest);
+                    dest.Add(new VideoCapturePinRank.Pin((int)width, (int)height, fastest, jpeg));
+                    dest.Add(new VideoCapturePinRank.Pin((int)width, (int)height, slowest, jpeg));
+                    var extras = new List<double>();
+                    VideoFpsOptions.AddPresetsInRange(extras, slowest, fastest);
+                    foreach (var fps in extras)
+                        dest.Add(new VideoCapturePinRank.Pin((int)width, (int)height, fps, jpeg));
                 }
             }
         }
@@ -331,5 +383,20 @@ namespace Yaesu_Web_Control.Services.Video
 
         [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
         private static extern int Ioctl(int fd, UIntPtr request, ref V4l2FrmIvalEnum arg);
+
+        [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
+        private static extern int Ioctl(int fd, UIntPtr request, ref V4l2StreamParm arg);
+
+        [StructLayout(LayoutKind.Sequential, Size = 204)]
+        private struct V4l2StreamParm
+        {
+            public uint Type;
+            public uint Capability;
+            public uint CaptureMode;
+            public uint TpfNumerator;
+            public uint TpfDenominator;
+            public uint ExtendedMode;
+            public uint ReadBuffers;
+        }
     }
 }

--- a/Services/Video/LinuxV4l2MjpegSession.cs
+++ b/Services/Video/LinuxV4l2MjpegSession.cs
@@ -1,0 +1,316 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Microsoft.Extensions.Logging;
+
+namespace Yaesu_Web_Control.Services.Video
+{
+    /// <summary>
+    /// Native V4L2 MJPEG mmap capture. OpenCV's V4L2 backend renegotiates
+    /// 800×600@30 to YUYV@20 (USB2 uncompressed cap) even when the dongle
+    /// advertises MJPEG 800×600 at 30/50/60.
+    /// </summary>
+    [SupportedOSPlatform("linux")]
+    internal sealed class LinuxV4l2MjpegSession : IJpegCaptureSession
+    {
+        private const int BufferCount = 4;
+        private const int Eagain = 11;
+        private const int ProtRead = 1;
+        private const int ProtWrite = 2;
+        private const int MapShared = 1;
+        private const uint MemoryMmap = 1;
+        private const uint BufTypeCapture = 1;
+        private static readonly IntPtr MapFailed = new(-1);
+
+        // _IOWR('V', 8, v4l2_requestbuffers=20)
+        private static readonly UIntPtr VidIocReqbufs = unchecked((UIntPtr)0xC0145608);
+        // _IOWR('V', 9/15/17, v4l2_buffer=88) on 64-bit
+        private static readonly UIntPtr VidIocQuerybuf = unchecked((UIntPtr)0xC0585609);
+        private static readonly UIntPtr VidIocQbuf = unchecked((UIntPtr)0xC058560F);
+        private static readonly UIntPtr VidIocDqbuf = unchecked((UIntPtr)0xC0585611);
+        // _IOW('V', 18/19, int)
+        private static readonly UIntPtr VidIocStreamon = unchecked((UIntPtr)0x40045612);
+        private static readonly UIntPtr VidIocStreamoff = unchecked((UIntPtr)0x40045613);
+
+        private readonly int _fd;
+        private readonly MappedBuffer[] _buffers;
+        private readonly ILogger _logger;
+        private bool _streaming;
+        private bool _disposed;
+
+        private LinuxV4l2MjpegSession(int fd, MappedBuffer[] buffers, int width, int height, double fps, ILogger logger)
+        {
+            _fd = fd;
+            _buffers = buffers;
+            Width = width;
+            Height = height;
+            DeviceFps = fps;
+            _logger = logger;
+        }
+
+        public int Width { get; }
+        public int Height { get; }
+        public double DeviceFps { get; private set; }
+
+        public static LinuxV4l2MjpegSession? TryOpen(
+            int index, int targetFps, int maxWidth, ILogger logger, out bool noUsableMjpegPin)
+        {
+            noUsableMjpegPin = false;
+            var pins = LinuxV4l2Devices.TryQueryPins(index);
+            var pick = VideoCapturePinRank.PickMjpegCaptureMeetingFps(pins, targetFps, maxWidth);
+            if (pick is null)
+            {
+                noUsableMjpegPin = !pins.Any(p => p.Jpeg);
+                logger.LogWarning("Radio Display V4L2: no MJPEG pin for {Fps} fps ({PinCount} pins)", targetFps, pins.Count);
+                return null;
+            }
+
+            var fd = LinuxV4l2Devices.OpenCaptureFd(index);
+            if (fd < 0)
+            {
+                logger.LogWarning("Radio Display V4L2: could not open {Path} RDWR", LinuxV4l2Devices.DevicePath(index));
+                return null;
+            }
+
+            MappedBuffer[]? mapped = null;
+            try
+            {
+                if (!LinuxV4l2Devices.TryConfigureMjpeg(fd, pick.Value.Width, pick.Value.Height, targetFps)
+                    && !(targetFps >= 30 && LinuxV4l2Devices.TryConfigureMjpeg(fd, 640, 480, targetFps)))
+                {
+                    logger.LogWarning(
+                        "Radio Display V4L2: S_FMT MJPEG {W}x{H}@{Fps} failed",
+                        pick.Value.Width, pick.Value.Height, targetFps);
+                    noUsableMjpegPin = false;
+                    LinuxV4l2Devices.CloseFd(fd);
+                    return null;
+                }
+
+                mapped = MapBuffers(fd);
+                if (mapped is null)
+                {
+                    logger.LogWarning("Radio Display V4L2: REQBUFS/mmap failed");
+                    LinuxV4l2Devices.CloseFd(fd);
+                    return null;
+                }
+
+                var type = (int)BufTypeCapture;
+                if (Ioctl(fd, VidIocStreamon, ref type) != 0)
+                {
+                    logger.LogWarning("Radio Display V4L2: STREAMON failed errno={Errno}", Marshal.GetLastPInvokeError());
+                    Unmap(mapped);
+                    LinuxV4l2Devices.CloseFd(fd);
+                    return null;
+                }
+
+                logger.LogInformation(
+                    "Radio Display V4L2 MJPEG {W}x{H} target {Fps} fps (native mmap, not OpenCV)",
+                    pick.Value.Width, pick.Value.Height, targetFps);
+
+                var session = new LinuxV4l2MjpegSession(fd, mapped, pick.Value.Width, pick.Value.Height, targetFps, logger);
+                session._streaming = true;
+                return session;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Radio Display V4L2 MJPEG open failed");
+                if (mapped is not null)
+                    Unmap(mapped);
+                LinuxV4l2Devices.CloseFd(fd);
+                return null;
+            }
+        }
+
+        public bool TrySetFrameRate(int targetFps)
+        {
+            if (_disposed || targetFps < 1)
+                return false;
+            if (LinuxV4l2Devices.TrySetFrameRateFd(_fd, targetFps))
+            {
+                DeviceFps = targetFps;
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool TryReadJpeg(out byte[]? jpeg)
+        {
+            jpeg = null;
+            if (_disposed || !_streaming)
+                return false;
+
+            var buf = new V4l2Buffer
+            {
+                Type = BufTypeCapture,
+                Memory = MemoryMmap
+            };
+            if (Ioctl(_fd, VidIocDqbuf, ref buf) != 0)
+            {
+                var errno = Marshal.GetLastPInvokeError();
+                if (errno != Eagain)
+                    _logger.LogDebug("Radio Display V4L2 DQBUF errno={Errno}", errno);
+                return false;
+            }
+
+            try
+            {
+                if (buf.Index >= (uint)_buffers.Length || buf.BytesUsed < 4)
+                    return false;
+
+                var map = _buffers[buf.Index];
+                var len = (int)Math.Min(buf.BytesUsed, map.Length);
+                if (map.Start == IntPtr.Zero || len < 4)
+                    return false;
+                if (Marshal.ReadByte(map.Start) != 0xFF || Marshal.ReadByte(map.Start, 1) != 0xD8)
+                    return false;
+
+                var bytes = new byte[len];
+                Marshal.Copy(map.Start, bytes, 0, len);
+                jpeg = TrimJpeg(bytes);
+                return jpeg is { Length: > 0 };
+            }
+            finally
+            {
+                buf.Type = BufTypeCapture;
+                buf.Memory = MemoryMmap;
+                _ = Ioctl(_fd, VidIocQbuf, ref buf);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            if (_streaming)
+            {
+                var type = (int)BufTypeCapture;
+                try { _ = Ioctl(_fd, VidIocStreamoff, ref type); } catch { /* ignore */ }
+                _streaming = false;
+            }
+
+            Unmap(_buffers);
+            LinuxV4l2Devices.CloseFd(_fd);
+        }
+
+        private static MappedBuffer[]? MapBuffers(int fd)
+        {
+            var req = new V4l2RequestBuffers
+            {
+                Count = BufferCount,
+                Type = BufTypeCapture,
+                Memory = MemoryMmap
+            };
+            if (Ioctl(fd, VidIocReqbufs, ref req) != 0 || req.Count < 2)
+                return null;
+
+            var mapped = new MappedBuffer[req.Count];
+            for (uint i = 0; i < req.Count; i++)
+            {
+                var buf = new V4l2Buffer
+                {
+                    Index = i,
+                    Type = BufTypeCapture,
+                    Memory = MemoryMmap
+                };
+                if (Ioctl(fd, VidIocQuerybuf, ref buf) != 0)
+                {
+                    Unmap(mapped);
+                    return null;
+                }
+
+                var ptr = mmap(IntPtr.Zero, (nuint)buf.Length, ProtRead | ProtWrite, MapShared, fd, buf.Offset);
+                if (ptr == MapFailed || ptr == IntPtr.Zero)
+                {
+                    Unmap(mapped);
+                    return null;
+                }
+
+                mapped[i] = new MappedBuffer(ptr, buf.Length);
+                buf.Type = BufTypeCapture;
+                buf.Memory = MemoryMmap;
+                buf.Index = i;
+                if (Ioctl(fd, VidIocQbuf, ref buf) != 0)
+                {
+                    Unmap(mapped);
+                    return null;
+                }
+            }
+
+            return mapped;
+        }
+
+        private static void Unmap(MappedBuffer[] buffers)
+        {
+            foreach (var b in buffers)
+            {
+                if (b.Start == IntPtr.Zero || b.Start == MapFailed)
+                    continue;
+                try { _ = munmap(b.Start, (nuint)b.Length); } catch { /* ignore */ }
+            }
+        }
+
+        private static byte[] TrimJpeg(byte[] bytes)
+        {
+            for (var i = bytes.Length - 2; i >= 2; i--)
+            {
+                if (bytes[i] == 0xFF && bytes[i + 1] == 0xD9)
+                    return bytes.AsSpan(0, i + 2).ToArray();
+            }
+
+            return bytes;
+        }
+
+        private readonly record struct MappedBuffer(IntPtr Start, uint Length);
+
+        [StructLayout(LayoutKind.Sequential, Size = 20)]
+        private struct V4l2RequestBuffers
+        {
+            public uint Count;
+            public uint Type;
+            public uint Memory;
+            public uint Capabilities;
+            public byte Flags;
+            public byte R0, R1, R2;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Size = 88)]
+        private struct V4l2Buffer
+        {
+            public uint Index;
+            public uint Type;
+            public uint BytesUsed;
+            public uint Flags;
+            public uint Field;
+            public uint TimestampPad;
+            public long TimestampSec;
+            public long TimestampUsec;
+            public uint TcType;
+            public uint TcFlags;
+            public uint TcRest;
+            public uint TcUser;
+            public uint Sequence;
+            public uint Memory;
+            public uint Offset;
+            public uint OffsetPad;
+            public uint Length;
+            public uint Reserved2;
+            public int RequestFd;
+        }
+
+        [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
+        private static extern int Ioctl(int fd, UIntPtr request, ref V4l2RequestBuffers arg);
+
+        [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
+        private static extern int Ioctl(int fd, UIntPtr request, ref V4l2Buffer arg);
+
+        [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
+        private static extern int Ioctl(int fd, UIntPtr request, ref int arg);
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern IntPtr mmap(IntPtr addr, nuint length, int prot, int flags, int fd, long offset);
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int munmap(IntPtr addr, nuint length);
+    }
+}

--- a/Services/Video/VideoCapturePinRank.cs
+++ b/Services/Video/VideoCapturePinRank.cs
@@ -99,6 +99,32 @@ namespace Yaesu_Web_Control.Services.Video
             PickMjpegCapture(pins, requestedFps, maxWidth);
 
         /// <summary>
+        /// Linux: honour the panel FPS. <see cref="PickSize"/> locks 800×600
+        /// because that pin can do 15, then nearest-to-30 becomes 20 on
+        /// dongles whose 800×600 MJPEG type tops out at 20. Prefer a JPEG pin
+        /// that can actually run at <paramref name="requestedFps"/> — 640×480@30
+        /// beats 800×600@20 when the operator asked for 30.
+        /// </summary>
+        public static Pin? PickMjpegCaptureMeetingFps(
+            IReadOnlyList<Pin> pins, int requestedFps, int maxWidth)
+        {
+            var jpeg = pins.Where(p => p.Jpeg).ToList();
+            if (jpeg.Count == 0)
+                return null;
+
+            var target = EncodeTarget(maxWidth);
+            var size = PickFormat(jpeg, requestedFps, MinWidth, target, panelAspectOnly: true)
+                ?? PickFormat(jpeg, requestedFps, MinWidth, target, panelAspectOnly: false)
+                ?? PickFormat(jpeg, requestedFps, minWidth: 2, target, panelAspectOnly: false)
+                ?? PickSize(jpeg, requestedFps, maxWidth);
+            if (size is null)
+                return null;
+
+            return NearestFps(jpeg, size.Value.Width, size.Value.Height, jpeg: true, requestedFps)
+                ?? size.Value;
+        }
+
+        /// <summary>
         /// Discrete type at the locked size whose advertised rate is nearest
         /// <paramref name="requestedFps"/> (59.94 vs 60 uses the native ratio).
         /// </summary>

--- a/Services/Video/VideoCaptureService.cs
+++ b/Services/Video/VideoCaptureService.cs
@@ -76,6 +76,7 @@ namespace Yaesu_Web_Control.Services.Video
         private int _deviceOpenFlag;
         private bool _mfUnavailable;
         private bool _dshowMjpegUnavailable;
+        private bool _linuxMjpegUnavailable;
         /// <summary>
         /// Set by <see cref="MarkDisconnected"/>. The outer loop must exit so
         /// we do not reopen <c>index:N</c> after Windows hands that slot to
@@ -367,6 +368,7 @@ namespace Yaesu_Web_Control.Services.Video
             Volatile.Write(ref _measuredFps, 0);
             _mfUnavailable = false;
             _dshowMjpegUnavailable = false;
+            _linuxMjpegUnavailable = false;
             _logger.LogInformation("Radio Display capture stopped");
         }
 
@@ -395,6 +397,7 @@ namespace Yaesu_Web_Control.Services.Video
         {
             _mfUnavailable = false;
             _dshowMjpegUnavailable = false;
+            _linuxMjpegUnavailable = false;
             SetStatus("connecting");
             if (!_disconnectHalt.IsActive)
                 _lastError = null;
@@ -430,6 +433,7 @@ namespace Yaesu_Web_Control.Services.Video
                 // MJPEG; the latches only skip fall-through inside this attempt.
                 _mfUnavailable = false;
                 _dshowMjpegUnavailable = false;
+                _linuxMjpegUnavailable = false;
 
                 var maxWidth = settings.VideoMaxWidth < 0 ? 0 : Math.Clamp(settings.VideoMaxWidth, 0, 1920);
                 var rates = VideoDeviceFpsCaps.PeekRates(settings.VideoCaptureDeviceKey);
@@ -441,6 +445,16 @@ namespace Yaesu_Web_Control.Services.Video
                 VideoCapture? cap = null;
                 try
                 {
+                    if (OperatingSystem.IsLinux() && !_linuxMjpegUnavailable &&
+                        RunLinuxMjpegSession(index, maxWidth, targetFps, ct))
+                    {
+                        if (ct.IsCancellationRequested || ShouldHaltAfterDisconnect())
+                            break;
+                        SetStatus("connecting");
+                        SleepOrCancel(1000, ct);
+                        continue;
+                    }
+
                     if (OperatingSystem.IsWindows() && !_dshowMjpegUnavailable &&
                         RunDshowMjpegSession(index, maxWidth, targetFps, ct))
                     {
@@ -966,7 +980,41 @@ namespace Yaesu_Web_Control.Services.Video
             }
         }
 
-        [SupportedOSPlatform("windows")]
+        [SupportedOSPlatform("linux")]
+        private bool RunLinuxMjpegSession(int index, int maxWidth, int targetFps, CancellationToken ct)
+        {
+            LinuxV4l2MjpegSession? session = null;
+            var opened = false;
+            try
+            {
+                session = LinuxV4l2MjpegSession.TryOpen(
+                    index, targetFps, maxWidth, _logger, out var noUsableMjpegPin);
+                if (session is null)
+                {
+                    if (noUsableMjpegPin)
+                        _linuxMjpegUnavailable = true;
+                    return false;
+                }
+
+                opened = true;
+                Volatile.Write(ref _openDeviceIndex, index);
+                Volatile.Write(ref _deviceOpenFlag, 1);
+                RunJpegPassthroughLoop(session, index, maxWidth, targetFps, "V4L2", ct);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Radio Display V4L2 MJPEG session failed");
+                return opened;
+            }
+            finally
+            {
+                Volatile.Write(ref _deviceOpenFlag, 0);
+                Volatile.Write(ref _openDeviceIndex, -1);
+                session?.Dispose();
+            }
+        }
+
         private void RunJpegPassthroughLoop(
             IJpegCaptureSession session, int index, int maxWidth, int targetFps, string via, CancellationToken ct)
         {
@@ -1348,7 +1396,6 @@ namespace Yaesu_Web_Control.Services.Video
                     (int)VideoCaptureProperties.ConvertRgb, 0,
                     (int)VideoCaptureProperties.FrameWidth, wantW,
                     (int)VideoCaptureProperties.FrameHeight, wantH,
-                    (int)VideoCaptureProperties.Fps, targetFps,
                     (int)VideoCaptureProperties.BufferSize, 3
                 ];
             }
@@ -1369,9 +1416,10 @@ namespace Yaesu_Web_Control.Services.Video
                 {
                     var linuxBgrParams = new[]
                     {
+                        (int)VideoCaptureProperties.FourCC, mjpeg,
+                        (int)VideoCaptureProperties.ConvertRgb, 0,
                         (int)VideoCaptureProperties.FrameWidth, wantW,
                         (int)VideoCaptureProperties.FrameHeight, wantH,
-                        (int)VideoCaptureProperties.Fps, targetFps,
                         (int)VideoCaptureProperties.BufferSize, 3
                     };
 
@@ -1473,10 +1521,18 @@ namespace Yaesu_Web_Control.Services.Video
             if (cap is null)
                 return null;
 
-            ApplyPreferredCaptureFormat(cap, maxWidth, targetFps, wantW, wantH);
+            ApplyPreferredCaptureFormat(cap, maxWidth, targetFps, wantW, wantH, setFps: false);
             if (OperatingSystem.IsLinux())
-                LinuxV4l2Devices.TrySetFrameRate(index, targetFps);
-            try { cap.Set(VideoCaptureProperties.Fps, targetFps); } catch { /* ignore */ }
+            {
+                if (!LinuxV4l2Devices.TrySetMjpegFormat(index, wantW, wantH, targetFps)
+                    && targetFps >= 30
+                    && LinuxV4l2Devices.TrySetMjpegFormat(index, 640, 480, targetFps))
+                {
+                    wantW = 640;
+                    wantH = 480;
+                    ApplyPreferredCaptureFormat(cap, maxWidth, targetFps, wantW, wantH, setFps: false);
+                }
+            }
 
             if (!requestJpegPassthrough)
             {
@@ -1746,7 +1802,8 @@ namespace Yaesu_Web_Control.Services.Video
         /// 800×600 YUY2@30 is what made the driver drop to 640.
         /// </summary>
         private static void ApplyPreferredCaptureFormat(
-            VideoCapture cap, int maxWidth, int targetFps, int? width = null, int? height = null)
+            VideoCapture cap, int maxWidth, int targetFps, int? width = null, int? height = null,
+            bool setFps = true)
         {
             var (wantW, wantH) = width is >= 2 && height is >= 2
                 ? (width.Value, height.Value)
@@ -1754,7 +1811,11 @@ namespace Yaesu_Web_Control.Services.Video
             PreferMjpegFourCc(cap);
             try { cap.Set(VideoCaptureProperties.FrameWidth, wantW); } catch { /* ignore */ }
             try { cap.Set(VideoCaptureProperties.FrameHeight, wantH); } catch { /* ignore */ }
-            try { cap.Set(VideoCaptureProperties.Fps, targetFps); } catch { /* ignore */ }
+            if (setFps)
+            {
+                try { cap.Set(VideoCaptureProperties.Fps, targetFps); } catch { /* ignore */ }
+            }
+
             try { cap.Set(VideoCaptureProperties.BufferSize, 3); } catch { /* not all backends */ }
         }
 

--- a/Services/Video/VideoCaptureService.cs
+++ b/Services/Video/VideoCaptureService.cs
@@ -658,12 +658,27 @@ namespace Yaesu_Web_Control.Services.Video
 
                         emptySince.Reset();
 
-                        // Prefer the Mat size from the UI-thread Read — property
-                        // Gets from another thread are unreliable on AVFoundation.
-                        var reportW = frame.Width > 1 ? frame.Width : (int)cap.Get(VideoCaptureProperties.FrameWidth);
-                        var reportH = frame.Height > 1 ? frame.Height : (int)cap.Get(VideoCaptureProperties.FrameHeight);
-                        if (reportW <= 1) reportW = frame.Width;
-                        if (reportH <= 1) reportH = frame.Height;
+                        // JPEG bitstream Mats are 1×nbytes (width = compressed
+                        // size, varies every frame). Picture size is in the SOF.
+                        var reportW = frame.Width;
+                        var reportH = frame.Height;
+                        if (LooksLikeJpegMat(frame) &&
+                            VideoJpegSof.TryReadSize(frame.Data, (int)(frame.Total() * frame.ElemSize()), out var sofW, out var sofH))
+                        {
+                            reportW = sofW;
+                            reportH = sofH;
+                        }
+                        else
+                        {
+                            reportW = frame.Width > 1 && frame.Width <= 1920
+                                ? frame.Width
+                                : (int)cap.Get(VideoCaptureProperties.FrameWidth);
+                            reportH = frame.Height > 1 && frame.Height <= 1200
+                                ? frame.Height
+                                : (int)cap.Get(VideoCaptureProperties.FrameHeight);
+                            if (reportW <= 1 || reportW > 1920) reportW = frame.Width;
+                            if (reportH <= 1 || reportH > 1200) reportH = frame.Height;
+                        }
 
                         // Surface size even before the first JPEG so the UI is
                         // not stuck at 0×0 / 0 fps while encode catches up.
@@ -1298,16 +1313,42 @@ namespace Yaesu_Web_Control.Services.Video
             // handled by WindowsMfMjpegSession. Ask for MJPEG 800×600 first so a
             // failed MF open does not land on YUY2 640×480@30 (USB2 rejects
             // uncompressed 800×600@30 and the driver drops the size).
+            // Linux V4L2 must pass FourCC at open too: post-open Set(FourCC)
+            // is ignored after VIDIOC_S_FMT, and YUYV 800×600 is USB2-capped
+            // at 15 fps. CONVERT_RGB=0 keeps the JPEG bitstream for passthrough.
             var (wantW, wantH) = PreferredCaptureSize(maxWidth);
+            if (OperatingSystem.IsLinux())
+            {
+                var pick = VideoCapturePinRank.PickMjpegCaptureMeetingFps(
+                    LinuxV4l2Devices.TryQueryPins(index), targetFps, maxWidth);
+                if (pick is { Width: >= 2, Height: >= 2 } p)
+                {
+                    wantW = p.Width;
+                    wantH = p.Height;
+                }
+            }
+
+            var mjpeg = VideoWriter.FourCC('M', 'J', 'P', 'G');
             int[] bgrParams;
             if (OperatingSystem.IsWindows())
             {
-                var mjpeg = VideoWriter.FourCC('M', 'J', 'P', 'G');
                 bgrParams =
                 [
                     (int)VideoCaptureProperties.FourCC, mjpeg,
                     (int)VideoCaptureProperties.FrameWidth, wantW,
                     (int)VideoCaptureProperties.FrameHeight, wantH,
+                    (int)VideoCaptureProperties.BufferSize, 3
+                ];
+            }
+            else if (OperatingSystem.IsLinux())
+            {
+                bgrParams =
+                [
+                    (int)VideoCaptureProperties.FourCC, mjpeg,
+                    (int)VideoCaptureProperties.ConvertRgb, 0,
+                    (int)VideoCaptureProperties.FrameWidth, wantW,
+                    (int)VideoCaptureProperties.FrameHeight, wantH,
+                    (int)VideoCaptureProperties.Fps, targetFps,
                     (int)VideoCaptureProperties.BufferSize, 3
                 ];
             }
@@ -1326,12 +1367,48 @@ namespace Yaesu_Web_Control.Services.Video
             {
                 if (OperatingSystem.IsLinux())
                 {
-                    var byPath = TryOpenPath(LinuxV4l2Devices.DevicePath(index), api, bgrParams, out lastError);
-                    if (byPath is not null)
+                    var linuxBgrParams = new[]
                     {
-                        ApplyPreferredCaptureFormat(byPath, maxWidth, targetFps);
-                        return byPath;
-                    }
+                        (int)VideoCaptureProperties.FrameWidth, wantW,
+                        (int)VideoCaptureProperties.FrameHeight, wantH,
+                        (int)VideoCaptureProperties.Fps, targetFps,
+                        (int)VideoCaptureProperties.BufferSize, 3
+                    };
+
+                    var opened = FinishLinuxOpen(
+                        TryOpenPath(LinuxV4l2Devices.DevicePath(index), api, bgrParams, out lastError),
+                        index, wantW, wantH, maxWidth, targetFps, ref jpegPassthrough);
+                    if (opened is not null)
+                        return opened;
+
+                    opened = FinishLinuxOpen(
+                        TryOpen(index, api, bgrParams, out lastError),
+                        index, wantW, wantH, maxWidth, targetFps, ref jpegPassthrough);
+                    if (opened is not null)
+                        return opened;
+
+                    opened = FinishLinuxOpen(
+                        TryOpenPath(LinuxV4l2Devices.DevicePath(index), api, linuxBgrParams, out lastError),
+                        index, wantW, wantH, maxWidth, targetFps, ref jpegPassthrough,
+                        requestJpegPassthrough: false);
+                    if (opened is not null)
+                        return opened;
+
+                    opened = FinishLinuxOpen(
+                        TryOpen(index, api, linuxBgrParams, out lastError),
+                        index, wantW, wantH, maxWidth, targetFps, ref jpegPassthrough,
+                        requestJpegPassthrough: false);
+                    if (opened is not null)
+                        return opened;
+
+                    opened = FinishLinuxOpen(
+                        TryOpen(index, api, paramsArray: null, out lastError),
+                        index, wantW, wantH, maxWidth, targetFps, ref jpegPassthrough,
+                        requestJpegPassthrough: false);
+                    if (opened is not null)
+                        return opened;
+
+                    continue;
                 }
 
                 var cap = TryOpen(index, api, bgrParams, out lastError);
@@ -1376,6 +1453,90 @@ namespace Yaesu_Web_Control.Services.Video
             {
                 // Device may ignore; native mode still preferred over forced YUY2.
             }
+        }
+
+        /// <summary>
+        /// Linux: lock MJPEG + raw JPEG Mats when the dongle actually delivers
+        /// SOI. CONVERT_RGB=0 after a YUYV negotiate would break ImEncode, so
+        /// a non-JPEG probe either restores BGR conversion or discards the open.
+        /// </summary>
+        private static VideoCapture? FinishLinuxOpen(
+            VideoCapture? cap,
+            int index,
+            int wantW,
+            int wantH,
+            int maxWidth,
+            int targetFps,
+            ref bool jpegPassthrough,
+            bool requestJpegPassthrough = true)
+        {
+            if (cap is null)
+                return null;
+
+            ApplyPreferredCaptureFormat(cap, maxWidth, targetFps, wantW, wantH);
+            if (OperatingSystem.IsLinux())
+                LinuxV4l2Devices.TrySetFrameRate(index, targetFps);
+            try { cap.Set(VideoCaptureProperties.Fps, targetFps); } catch { /* ignore */ }
+
+            if (!requestJpegPassthrough)
+            {
+                jpegPassthrough = false;
+                try { cap.Set(VideoCaptureProperties.ConvertRgb, 1); } catch { /* ignore */ }
+                return cap;
+            }
+
+            try { cap.Set(VideoCaptureProperties.ConvertRgb, 0); } catch { /* ignore */ }
+
+            using var probe = new Mat();
+            var readOk = false;
+            try { readOk = cap.Read(probe); }
+            catch { /* treat as failed probe */ }
+
+            if (readOk && !probe.Empty() && LooksLikeJpegMat(probe))
+            {
+                jpegPassthrough = true;
+                return cap;
+            }
+
+            try { cap.Set(VideoCaptureProperties.ConvertRgb, 1); } catch { /* ignore */ }
+
+            if (readOk && !probe.Empty())
+            {
+                jpegPassthrough = false;
+                return cap;
+            }
+
+            try { cap.Release(); } catch { /* ignore */ }
+            try { cap.Dispose(); } catch { /* ignore */ }
+            return null;
+        }
+
+        private static bool LooksLikeJpegMat(Mat frame)
+        {
+            if (frame.Empty())
+                return false;
+
+            var len = (int)(frame.Total() * frame.ElemSize());
+            if (len < 100)
+                return false;
+
+            try
+            {
+                if (Marshal.ReadByte(frame.Data) != 0xFF || Marshal.ReadByte(frame.Data, 1) != 0xD8)
+                    return false;
+            }
+            catch
+            {
+                return false;
+            }
+
+            // Decoded BGR/YUV images are WxH; MJPEG bitstreams are 1-row (or
+            // 1-col) 8U buffers whose long side is the compressed length.
+            if (frame.Height <= 2 || frame.Width <= 2)
+                return true;
+            if (frame.Channels() is 3 or 4 && frame.Width <= 1920 && frame.Height <= 1200)
+                return false;
+            return frame.Width > 1920 || frame.Height > 1200;
         }
 
         /// <summary>
@@ -1584,9 +1745,12 @@ namespace Yaesu_Web_Control.Services.Video
         /// DirectShow does not pick YUY2 640×480@30. FPS last — requesting
         /// 800×600 YUY2@30 is what made the driver drop to 640.
         /// </summary>
-        private static void ApplyPreferredCaptureFormat(VideoCapture cap, int maxWidth, int targetFps)
+        private static void ApplyPreferredCaptureFormat(
+            VideoCapture cap, int maxWidth, int targetFps, int? width = null, int? height = null)
         {
-            var (wantW, wantH) = PreferredCaptureSize(maxWidth);
+            var (wantW, wantH) = width is >= 2 && height is >= 2
+                ? (width.Value, height.Value)
+                : PreferredCaptureSize(maxWidth);
             PreferMjpegFourCc(cap);
             try { cap.Set(VideoCaptureProperties.FrameWidth, wantW); } catch { /* ignore */ }
             try { cap.Set(VideoCaptureProperties.FrameHeight, wantH); } catch { /* ignore */ }
@@ -1656,15 +1820,10 @@ namespace Yaesu_Web_Control.Services.Video
         private static bool TryCopyJpeg(Mat frame, out byte[]? jpeg)
         {
             jpeg = null;
-            if (frame.Empty())
+            if (!LooksLikeJpegMat(frame))
                 return false;
 
             var len = (int)(frame.Total() * frame.ElemSize());
-            if (len < 4)
-                return false;
-
-            if (Marshal.ReadByte(frame.Data) != 0xFF || Marshal.ReadByte(frame.Data, 1) != 0xD8)
-                return false;
 
             var bytes = new byte[len];
             Marshal.Copy(frame.Data, bytes, 0, len);

--- a/Services/Video/VideoJpegSof.cs
+++ b/Services/Video/VideoJpegSof.cs
@@ -1,0 +1,80 @@
+using System.Runtime.InteropServices;
+
+namespace Yaesu_Web_Control.Services.Video
+{
+    /// <summary>
+    /// JPEG Start-Of-Frame size. V4L2 MJPEG with CONVERT_RGB=0 is a 1-row
+    /// bitstream Mat whose <c>Width</c> is the compressed byte length — not
+    /// the picture size the Radio Display panel should show.
+    /// </summary>
+    internal static class VideoJpegSof
+    {
+        public static bool TryReadSize(byte[] jpeg, out int width, out int height) =>
+            TryReadSize(jpeg.AsSpan(), out width, out height);
+
+        public static bool TryReadSize(IntPtr data, int length, out int width, out int height)
+        {
+            width = 0;
+            height = 0;
+            if (data == IntPtr.Zero || length < 12)
+                return false;
+
+            var n = Math.Min(length, 65_536);
+            var heap = new byte[n];
+            Marshal.Copy(data, heap, 0, n);
+            return TryReadSize(heap.AsSpan(), out width, out height);
+        }
+
+        public static bool TryReadSize(ReadOnlySpan<byte> jpeg, out int width, out int height)
+        {
+            width = 0;
+            height = 0;
+            if (jpeg.Length < 12 || jpeg[0] != 0xFF || jpeg[1] != 0xD8)
+                return false;
+
+            var i = 2;
+            while (i + 8 < jpeg.Length)
+            {
+                if (jpeg[i] != 0xFF)
+                {
+                    i++;
+                    continue;
+                }
+
+                var marker = jpeg[i + 1];
+                if (marker == 0xFF)
+                {
+                    i++;
+                    continue;
+                }
+
+                if (marker is 0xD8 or 0xD9 or >= 0xD0 and <= 0xD7)
+                {
+                    i += 2;
+                    continue;
+                }
+
+                if (i + 3 >= jpeg.Length)
+                    return false;
+
+                var segLen = (jpeg[i + 2] << 8) | jpeg[i + 3];
+                if (segLen < 2)
+                    return false;
+
+                // SOF0–SOF3 (baseline / extended / progressive / lossless).
+                if (marker is 0xC0 or 0xC1 or 0xC2 or 0xC3)
+                {
+                    if (i + 8 >= jpeg.Length)
+                        return false;
+                    height = (jpeg[i + 5] << 8) | jpeg[i + 6];
+                    width = (jpeg[i + 7] << 8) | jpeg[i + 8];
+                    return width is >= 2 and <= 7680 && height is >= 2 and <= 4320;
+                }
+
+                i += 2 + segLen;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Tests/YaesuWebControl.Tests/VideoJpegSofTests.cs
+++ b/Tests/YaesuWebControl.Tests/VideoJpegSofTests.cs
@@ -1,0 +1,92 @@
+using Yaesu_Web_Control.Services.Video;
+
+namespace YaesuWebControl.Tests;
+
+public sealed class VideoJpegSofTests
+{
+    [Fact]
+    public void TryReadSize_ReadsSof0Dimensions()
+    {
+        // SOI + SOF0 800×600
+        byte[] jpeg =
+        [
+            0xFF, 0xD8,
+            0xFF, 0xC0, 0x00, 0x0B, 0x08, 0x02, 0x58, 0x03, 0x20, 0x03, 0x01,
+            0xFF, 0xD9
+        ];
+
+        Assert.True(VideoJpegSof.TryReadSize(jpeg, out var w, out var h));
+        Assert.Equal(800, w);
+        Assert.Equal(600, h);
+    }
+
+    [Fact]
+    public void TryReadSize_SkipsAppAndDqtBeforeSof()
+    {
+        byte[] jpeg =
+        [
+            0xFF, 0xD8,
+            0xFF, 0xE0, 0x00, 0x04, 0x00, 0x00,
+            0xFF, 0xC0, 0x00, 0x0B, 0x08, 0x01, 0xE0, 0x02, 0x80, 0x03, 0x01
+        ];
+
+        Assert.True(VideoJpegSof.TryReadSize(jpeg, out var w, out var h));
+        Assert.Equal(640, w);
+        Assert.Equal(480, h);
+    }
+
+    [Fact]
+    public void TryReadSize_RejectsMissingSoi()
+    {
+        byte[] jpeg = [0x00, 0x00, 0xFF, 0xC0, 0x00, 0x0B, 0x08, 0x02, 0x58, 0x03, 0x20, 0x03];
+        Assert.False(VideoJpegSof.TryReadSize(jpeg, out _, out _));
+    }
+}
+
+public sealed class VideoCapturePinRankFpsTests
+{
+    [Fact]
+    public void MeetingFps_Prefers640At30Over800At20()
+    {
+        VideoCapturePinRank.Pin[] pins =
+        [
+            new(800, 600, 20, Jpeg: true),
+            new(640, 480, 30, Jpeg: true)
+        ];
+
+        var pick = VideoCapturePinRank.PickMjpegCaptureMeetingFps(pins, requestedFps: 30, maxWidth: 800);
+        Assert.NotNull(pick);
+        Assert.Equal(640, pick.Value.Width);
+        Assert.Equal(480, pick.Value.Height);
+        Assert.Equal(30, pick.Value.Fps);
+    }
+
+    [Fact]
+    public void MeetingFps_Keeps800WhenItCanDo30()
+    {
+        VideoCapturePinRank.Pin[] pins =
+        [
+            new(800, 600, 30, Jpeg: true),
+            new(640, 480, 30, Jpeg: true)
+        ];
+
+        var pick = VideoCapturePinRank.PickMjpegCaptureMeetingFps(pins, requestedFps: 30, maxWidth: 800);
+        Assert.NotNull(pick);
+        Assert.Equal(800, pick.Value.Width);
+        Assert.Equal(600, pick.Value.Height);
+    }
+
+    [Fact]
+    public void MeetingFps_FallsBackWhenNothingCanDoRequest()
+    {
+        VideoCapturePinRank.Pin[] pins =
+        [
+            new(800, 600, 20, Jpeg: true)
+        ];
+
+        var pick = VideoCapturePinRank.PickMjpegCaptureMeetingFps(pins, requestedFps: 30, maxWidth: 800);
+        Assert.NotNull(pick);
+        Assert.Equal(800, pick.Value.Width);
+        Assert.Equal(20, pick.Value.Fps);
+    }
+}

--- a/Tests/YaesuWebControl.Tests/YaesuWebControl.Tests.csproj
+++ b/Tests/YaesuWebControl.Tests/YaesuWebControl.Tests.csproj
@@ -19,7 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Yaesu_Web_Control.csproj" />
+    <ProjectReference Include="..\..\Yaesu_Web_Control.csproj">
+      <SetTargetFramework>TargetFramework=net10.0</SetTargetFramework>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/Yaesu_Web_Control.csproj
+++ b/Yaesu_Web_Control.csproj
@@ -14,6 +14,10 @@
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="YaesuWebControl.Tests" />
+  </ItemGroup>
+
   <!-- Windows product build: WinForms tray host, voice (SAPI), SDR worker companion. -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">
     <OutputType>WinExe</OutputType>


### PR DESCRIPTION
TL,DR: The might raspberry pi3b can now do 30fps while capturing at 800x600 with `load average: 0.91, 1.57, 1.62`

## Summary
- Linux HDMI/UVC dongles advertise MJPEG 800×600 at 30/50/60, but OpenCV’s V4L2 backend was negotiating **YUYV 800×600@20** (the USB2 uncompressed cap). Radio Display now uses a native V4L2 MJPEG mmap session (same passthrough idea as Windows DirectShow/MF).
- JPEG bitstream Mats were reported as `~69070×600` because `Width` was the compressed byte length; size now comes from the JPEG SOF header.
- Pin ranking prefers an MJPEG mode that can actually meet the selected FPS instead of locking 800×600 because it can do 15.

## Test plan
- [ ] On a Pi/Linux host with a Macrosilicon-style dongle, confirm `v4l2-ctl --list-formats-ext` shows MJPEG 800×600@30 (and YUYV 800×600@20).
- [ ] Enable Radio Display, set **30 fps**, Start. Badge should be `800×600 @ ~30fps` (not 20, not a jumping ~70k width).
- [ ] Logs should include `Radio Display V4L2 MJPEG … (native mmap, not OpenCV)`.
- [ ] 15 fps still works; Stop/Start and device switch still release the node.
- [ ] Windows/macOS Radio Display unchanged.