### PR TITLE
Stop the Radio Display showing a tiled picture on merging grabbers

### DIFF
--- a/Services/Video/IJpegCaptureSession.cs
+++ b/Services/Video/IJpegCaptureSession.cs
@@ -1,4 +1,4 @@
-namespace Yaesu_Web_Control.Services.Video
+﻿namespace Yaesu_Web_Control.Services.Video
 {
     /// <summary>
     /// Compressed-MJPEG capture that copies JPEG bytes as-is (DirectShow pin
@@ -12,5 +12,14 @@ namespace Yaesu_Web_Control.Services.Video
         double DeviceFps { get; }
         bool TryReadJpeg(out byte[]? jpeg);
         bool TrySetFrameRate(int targetFps);
+
+        /// <summary>
+        /// True once the device has been seen packing several pictures into one
+        /// sample. Some HDMI grabbers do this in every mode that runs through
+        /// their internal scaler: the JPEG is well formed but its scan holds more
+        /// than one frame, which renders as a tiled, repeated picture. Capture
+        /// switches to the device's native mode when this is reported.
+        /// </summary>
+        bool DeviceMergesFrames => false;
     }
 }

--- a/Services/Video/VideoCapturePinRank.cs
+++ b/Services/Video/VideoCapturePinRank.cs
@@ -1,4 +1,4 @@
-namespace Yaesu_Web_Control.Services.Video
+﻿namespace Yaesu_Web_Control.Services.Video
 {
     /// <summary>
     /// Radio Display pin ranking shared by Windows DirectShow MJPEG, Media
@@ -70,6 +70,30 @@ namespace Yaesu_Web_Control.Services.Video
                 ?? PickFormat(pins, 60, MinWidth, target, panelAspectOnly: true)
                 ?? PickFormat(pins, wantFps, MinWidth, target, panelAspectOnly: false)
                 ?? PickFormat(pins, requestedFps, MinWidth, target, panelAspectOnly: false);
+        }
+
+        /// <summary>
+        /// Largest MJPEG mode the device offers — normally the one it passes
+        /// through without its internal scaler. Used after the device is caught
+        /// merging frames in a scaled mode; the picture is scaled down here
+        /// instead, which costs CPU but is the only correct output such a
+        /// device produces.
+        /// </summary>
+        public static Pin? PickNativeMjpeg(IReadOnlyList<Pin> pins)
+        {
+            Pin? best = null;
+            foreach (var p in pins)
+            {
+                if (!p.Jpeg)
+                    continue;
+                if (best is null ||
+                    (long)p.Width * p.Height > (long)best.Value.Width * best.Value.Height ||
+                    ((long)p.Width * p.Height == (long)best.Value.Width * best.Value.Height &&
+                     p.Fps > best.Value.Fps))
+                    best = p;
+            }
+
+            return best;
         }
 
         /// <summary>

--- a/Services/Video/VideoCaptureService.cs
+++ b/Services/Video/VideoCaptureService.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using OpenCvSharp;
@@ -76,6 +76,7 @@ namespace Yaesu_Web_Control.Services.Video
         private int _deviceOpenFlag;
         private bool _mfUnavailable;
         private bool _dshowMjpegUnavailable;
+        private bool _dshowPreferNativeMjpeg;
         private bool _linuxMjpegUnavailable;
         /// <summary>
         /// Set by <see cref="MarkDisconnected"/>. The outer loop must exit so
@@ -953,7 +954,8 @@ namespace Yaesu_Web_Control.Services.Video
             try
             {
                 ds = WindowsDshowMjpegSession.TryOpen(
-                    index, targetFps, maxWidth, _logger, out var noUsableMjpegPin);
+                    index, targetFps, maxWidth, _logger, out var noUsableMjpegPin,
+                    _dshowPreferNativeMjpeg);
                 if (ds is null)
                 {
                     if (noUsableMjpegPin)
@@ -1057,6 +1059,22 @@ namespace Yaesu_Web_Control.Services.Video
                     !VideoDeviceKey.TryResolveOpenIndex(settings.VideoCaptureDeviceKey, out var newIndex) ||
                     newIndex != index)
                 {
+                    break;
+                }
+
+                // The device is packing several pictures into one sample, which
+                // renders as a tiled repeat. Nothing downstream can undo that —
+                // the merge is inside a single JPEG scan — so drop the session and
+                // reopen on the device's native mode. Checked before the read: the
+                // session stops publishing merged samples once it is sure, so
+                // waiting for a frame here would stall until the unplug watchdog.
+                if (session.DeviceMergesFrames && !_dshowPreferNativeMjpeg)
+                {
+                    _dshowPreferNativeMjpeg = true;
+                    _logger.LogWarning(
+                        "Radio Display: {Via} device is merging frames at {W}x{H} — reopening on its " +
+                        "native mode and scaling here instead",
+                        via, session.Width, session.Height);
                     break;
                 }
 

--- a/Services/Video/WindowsDshowMjpegSession.cs
+++ b/Services/Video/WindowsDshowMjpegSession.cs
@@ -1,4 +1,4 @@
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Microsoft.Extensions.Logging;
 
@@ -38,9 +38,20 @@ namespace Yaesu_Web_Control.Services.Video
         private readonly AutoResetEvent _frameReady = new(false);
         private readonly object _frameLock = new();
         private readonly ILogger _logger;
+        /// <summary>Trailing-data samples that together prove the device merges frames.</summary>
+        private const int MergedFrameEvidence = 3;
+
+        private long _trailingSamples;
+        private long _mergedSamples;
+        private int _mergesFrames;
+        private long _unterminatedSamples;
+        private long _imagelessSamples;
         private readonly List<StreamCap> _caps;
         private byte[]? _latestJpeg;
         private bool _disposed;
+
+        public bool DeviceMergesFrames => Volatile.Read(ref _mergesFrames) != 0;
+
 
         public int Width { get; private set; }
         public int Height { get; private set; }
@@ -78,7 +89,8 @@ namespace Yaesu_Web_Control.Services.Video
         }
 
         public static WindowsDshowMjpegSession? TryOpen(
-            int dshowIndex, int targetFps, int maxWidth, ILogger logger, out bool noUsableMjpegPin)
+            int dshowIndex, int targetFps, int maxWidth, ILogger logger, out bool noUsableMjpegPin,
+            bool preferNativeMode = false)
         {
             noUsableMjpegPin = false;
             if (!OperatingSystem.IsWindows())
@@ -174,7 +186,9 @@ namespace Yaesu_Web_Control.Services.Video
                     formats.Count == 0 ? "(none reported)" : string.Join(", ", formats));
 
                 var pins = caps.Select(c => c.Pin).ToList();
-                var chosen = VideoCapturePinRank.PickMjpegCapture(pins, targetFps, maxWidth);
+                var chosen = ForcedPin(pins, logger)
+                    ?? (preferNativeMode ? VideoCapturePinRank.PickNativeMjpeg(pins) : null)
+                    ?? VideoCapturePinRank.PickMjpegCapture(pins, targetFps, maxWidth);
                 if (chosen is null)
                 {
                     logger.LogInformation(
@@ -670,24 +684,228 @@ namespace Yaesu_Web_Control.Services.Video
 
                 var bytes = new byte[bufferLen];
                 Marshal.Copy(buffer, bytes, 0, bufferLen);
-                var end = FindJpegEoi(bytes);
-                var jpeg = end >= 0 && end + 1 < bytes.Length
-                    ? bytes.AsSpan(0, end + 1).ToArray()
-                    : bytes;
+
+                // Trim to the end of the FIRST image, found by walking markers.
+                // Scanning backwards for FF D9 takes the LAST EOI in the buffer,
+                // which appends anything sitting past the real frame end — the
+                // decoder then renders that tail as extra image content.
+                var end = FindFirstImageEnd(bytes, out var hasScan);
+                byte[] jpeg;
+                if (end > 0)
+                {
+                    // A terminated image with no scan carries no pixels — some
+                    // grabbers emit a bare FF D8 FF D9 after a replug until the
+                    // source relocks. Publishing those keeps the frame counter
+                    // and the status badge running over a picture that can never
+                    // appear, so drop them and let the stall watchdog say so.
+                    if (!hasScan)
+                    {
+                        owner.NoteImagelessSample(bytes.Length, end);
+                        return 0;
+                    }
+
+                    if (end < bytes.Length)
+                    {
+                        // A tail holding another SOI means the driver put more than
+                        // one picture in this sample, and the first one is itself a
+                        // tiled repeat. Never show those. A tail without an SOI is
+                        // only padding, so trim it and publish as normal.
+                        if (TailHasSoi(bytes, end))
+                        {
+                            owner.NoteMergedSample(bytes, end);
+                            return 0;
+                        }
+
+                        owner.NoteTrailingBytes(bytes, end);
+                    }
+
+                    jpeg = end == bytes.Length ? bytes : bytes.AsSpan(0, end).ToArray();
+                }
+                else
+                {
+                    owner.NoteUnterminatedFrame(bytes.Length);
+                    jpeg = bytes;
+                }
+
                 owner.OnFrame(jpeg);
                 return 0;
             }
         }
 
-        private static int FindJpegEoi(byte[] bytes)
+        /// <summary>True when the bytes after the first image begin another JPEG.</summary>
+        private static bool TailHasSoi(byte[] bytes, int end)
         {
-            for (var i = bytes.Length - 2; i >= 2; i--)
+            for (var i = end; i < bytes.Length - 1; i++)
             {
-                if (bytes[i] == 0xFF && bytes[i + 1] == 0xD9)
-                    return i + 1;
+                if (bytes[i] == 0xFF && bytes[i + 1] == 0xD8)
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Diagnostic override: YWC_VIDEO_FORCE_PIN=WxH pins the capture to that
+        /// MJPEG mode instead of the ranked pick. Temporary — it exists to test
+        /// which modes this grabber can actually render cleanly.
+        /// </summary>
+        private static VideoCapturePinRank.Pin? ForcedPin(
+            IReadOnlyList<VideoCapturePinRank.Pin> pins, ILogger logger)
+        {
+            var spec = Environment.GetEnvironmentVariable("YWC_VIDEO_FORCE_PIN");
+            if (string.IsNullOrWhiteSpace(spec))
+                return null;
+
+            var parts = spec.Split('x', 'X');
+            if (parts.Length != 2 ||
+                !int.TryParse(parts[0], out var w) ||
+                !int.TryParse(parts[1], out var h))
+            {
+                logger.LogWarning("Radio Display: YWC_VIDEO_FORCE_PIN='{Spec}' not WxH — ignored", spec);
+                return null;
+            }
+
+            VideoCapturePinRank.Pin? best = null;
+            foreach (var p in pins)
+            {
+                if (!p.Jpeg || p.Width != w || p.Height != h)
+                    continue;
+                if (best is null || p.Fps > best.Value.Fps)
+                    best = p;
+            }
+
+            if (best is null)
+                logger.LogWarning("Radio Display: YWC_VIDEO_FORCE_PIN={Spec} has no MJPEG pin — ignored", spec);
+            else
+                logger.LogWarning("Radio Display: YWC_VIDEO_FORCE_PIN={Spec} — forcing {W}x{H}@{Fps}",
+                    spec, best.Value.Width, best.Value.Height, best.Value.Fps);
+            return best;
+        }
+
+        /// <summary>
+        /// Index just past the EOI of the first complete JPEG in <paramref name="bytes"/>,
+        /// or -1 if the buffer holds no terminated image. Walks the marker structure
+        /// rather than searching for FF D9: that byte pair occurs freely inside marker
+        /// segment payloads (an APPn thumbnail is itself a JPEG and ends in one), so a
+        /// naive search can stop short or run long. <paramref name="hasScan"/> reports
+        /// whether that image actually contained entropy-coded pixel data.
+        /// </summary>
+        private static int FindFirstImageEnd(byte[] bytes, out bool hasScan)
+        {
+            hasScan = false;
+            if (bytes.Length < 2 || bytes[0] != 0xFF || bytes[1] != 0xD8)
+                return -1;
+
+            var i = 2;
+            while (i < bytes.Length - 1)
+            {
+                if (bytes[i] != 0xFF) { i++; continue; }
+
+                var marker = bytes[i + 1];
+                if (marker == 0xFF) { i++; continue; }              // fill byte
+                if (marker == 0xD9) return i + 2;                   // EOI
+                if (marker == 0x01 || (marker >= 0xD0 && marker <= 0xD7))
+                {
+                    i += 2;                                          // standalone
+                    continue;
+                }
+
+                if (i + 4 > bytes.Length) return -1;
+                var segmentLength = (bytes[i + 2] << 8) | bytes[i + 3];
+                if (segmentLength < 2) return -1;
+
+                if (marker == 0xDA)
+                {
+                    hasScan = true;
+                    // Start of scan: entropy-coded data follows. FF inside it is
+                    // either stuffed (FF 00) or a restart marker; anything else
+                    // ends the scan.
+                    var j = i + 2 + segmentLength;
+                    while (j < bytes.Length - 1)
+                    {
+                        if (bytes[j] == 0xFF)
+                        {
+                            var next = bytes[j + 1];
+                            if (next != 0x00 && !(next >= 0xD0 && next <= 0xD7))
+                                break;
+                        }
+                        j++;
+                    }
+
+                    if (j >= bytes.Length - 1) return -1;
+                    i = j;
+                    continue;
+                }
+
+                i += 2 + segmentLength;
             }
 
             return -1;
+        }
+
+        /// <summary>
+        /// Records a sample that carried bytes past the end of its first image.
+        /// Logged sparsely: this is diagnostic evidence for an intermittent
+        /// corruption, not a per-frame condition worth flooding the log with.
+        /// </summary>
+        private void NoteTrailingBytes(byte[] bytes, int end)
+        {
+            var occurrence = Interlocked.Increment(ref _trailingSamples);
+            if (occurrence != 1 && occurrence % 100 != 0)
+                return;
+
+            _logger.LogWarning(
+                "Radio Display: DirectShow sample carried {Extra} padding bytes past the first JPEG " +
+                "(sample {Total} bytes, occurrence {Occurrence}). Trimmed to the first image.",
+                bytes.Length - end, bytes.Length, occurrence);
+        }
+
+        /// <summary>
+        /// Records a dropped sample that held more than one picture. A mode the
+        /// device renders correctly produces none of these at all, so a handful is
+        /// already conclusive rather than borderline.
+        /// </summary>
+        private void NoteMergedSample(byte[] bytes, int end)
+        {
+            var occurrence = Interlocked.Increment(ref _mergedSamples);
+            if (occurrence >= MergedFrameEvidence)
+                Volatile.Write(ref _mergesFrames, 1);
+
+            if (occurrence != 1 && occurrence % 100 != 0)
+                return;
+
+            _logger.LogWarning(
+                "Radio Display: DirectShow sample held more than one picture " +
+                "(sample {Total} bytes, first image {First} bytes, occurrence {Occurrence}). " +
+                "Dropped — the device is merging frames.",
+                bytes.Length, end, occurrence);
+        }
+
+        /// <summary>Records a dropped sample whose first image held no scan data.</summary>
+        private void NoteImagelessSample(int length, int end)
+        {
+            var occurrence = Interlocked.Increment(ref _imagelessSamples);
+            if (occurrence != 1 && occurrence % 100 != 0)
+                return;
+
+            _logger.LogWarning(
+                "Radio Display: DirectShow sample of {Length} bytes held a {ImageLength}-byte JPEG " +
+                "with no image data (occurrence {Occurrence}). Dropped — the capture device is " +
+                "delivering empty frames.",
+                length, end, occurrence);
+        }
+
+        /// <summary>Records a sample with no terminated image; forwarded unchanged.</summary>
+        private void NoteUnterminatedFrame(int length)
+        {
+            var occurrence = Interlocked.Increment(ref _unterminatedSamples);
+            if (occurrence != 1 && occurrence % 100 != 0)
+                return;
+
+            _logger.LogWarning(
+                "Radio Display: DirectShow sample of {Length} bytes had no complete JPEG " +
+                "(occurrence {Occurrence}). Forwarded unchanged.",
+                length, occurrence);
         }
 
         [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
## The fault

My USB HDMI grabber renders every downscaled MJPEG mode it advertises as a
tiled repeat of the radio's screen. Only its largest mode is correct:

| Mode requested | Result |
|---|---|
| 800x600 (4:3) | 5 copies |
| 1280x960 (4:3) | 2 copies |
| 1280x720 (16:9) | 2 copies |
| 1920x1080 (16:9) | clean |

It is not an aspect-ratio problem - 1280x720 is 16:9 and still fails. It is
that every mode below the device's native one runs through its internal
scaler, and that scaler is broken. The Windows Camera app looked fine
throughout because it takes 1920x1080; our pin ranking prefers 4:3.

## Why nothing downstream could fix it

Good and bad samples are both perfectly well-formed JPEGs:

| | Clean | Tiled |
|---|---|---|
| SOF | 1280x960 4:2:2 | 1280x960 4:2:2 |
| SOS / EOI | 1 / 1 | 1 / 1 |
| Restart markers | 0 | 0 |
| Scan length | 177,465 bytes | 257,392 bytes |

One image, one scan, ending exactly at its EOI. The extra pictures are inside
that single entropy-coded scan, so there is nothing to split or trim.

What does mark a bad sample is its tail: it carries the start of the next
frame past its own EOI. Over comparable runs, the failing mode produced 9
rate-limited warnings (one logged per hundred, so ~900 samples) and the
working mode produced zero. That makes three such samples conclusive rather
than borderline.

## The change

1. Drop merged samples instead of publishing them. A tail beginning with
   another SOI means the driver put several pictures in one sample. A tail
   without an SOI is only padding, so it is trimmed and published as normal.
2. After three merged samples, reopen on the device's largest MJPEG mode and
   scale down in software. Nothing is hardcoded to 1920x1080 or to this
   grabber - the fault is detected by signature, and the native mode is
   whatever that device reports.
3. Drop 4-byte `FF D8 FF D9` samples - valid JPEGs containing no image. This
   grabber emits them continuously in every mode including the good one,
   nearly 3000 in a single run. Publishing them overwrote real frames, which
   is how the panel could sit black while the badge read a healthy green
   14.7 fps. Dropping them also lets the existing stall watchdog report an
   honest disconnect.
4. Trim by walking the marker structure instead of scanning backwards for
   `FF D9`. That byte pair occurs freely inside marker payloads - an APPn
   thumbnail is itself a JPEG ending in one - so the backwards scan could
   stop short or run long.

`YWC_VIDEO_FORCE_PIN=WxH` pins capture to a single MJPEG mode. That is how
the four modes in the first table were compared.

## Result on the bench

```
20:48:14.011  sample held more than one picture - Dropped   <- occurrence 1
20:48:14.722  device is merging frames at 1280x960
20:48:16.562  negotiated 1920x1080 passthrough+scale
20:48:16.575  first JPEG published (1280x720)               <- first frame shown
```

No "first JPEG published" line for 1280x960: not one corrupt frame reached
the panel. The display stays blank for about two seconds, then the picture
arrives correct and stays correct - frames hold a steady 144-154 KB with zero
merge warnings after the switch.

## Scope

Linux and Media Foundation sessions take the interface default of "not a
merger" and are behaviourally unchanged. If those dongles do the same thing,
the detection lifts into the V4L2 session as it stands.

## Test plan

- [x] FTDX101MP + USB HDMI grabber on Windows: starts on 1280x960, detects,
      reopens on 1920x1080, no corrupt frame published
- [x] Sustained clean capture verified by frame inspection, not just status
- [x] `dotnet build -f net10.0-windows` clean, 13 tests pass
- [ ] Linux Radio Display unaffected (no code path changed, worth a look)

Bench-tested on my own rig only - one grabber, one radio. The detection
threshold is deliberately conservative, but a second pair of eyes on whether
any healthy device could legitimately pack two pictures into one sample
would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
