### PR TITLE
Keep both VFO panels live on single-receiver radios

### DIFF
--- a/Controllers/CatController.cs
+++ b/Controllers/CatController.cs
@@ -976,57 +976,72 @@ namespace Yaesu_Web_Control.Controllers
                 if (recv != "A" && recv != "B")
                     return BadRequest(new { error = "Invalid receiver specified" });
 
-                await _catClient.SendCommandAsync($"MD{VfoP1Outgoing(recv)}{request.Mode};", "User");
-                if (VfoIsB(recv)) _radioStateService.ModeB = displayMode;
-                else               _radioStateService.ModeA = displayMode;
+                // MD is per-VFO even on single-receiver radios (FTdx10 CAT
+                // manual: P1 0=MAIN/VFO-A, 1=SUB/VFO-B). VfoP1Outgoing would
+                // send MD0 for both panels and change the active VFO's mode
+                // when the operator edited the inactive one.
+                bool requestedB = recv == "B";
+                string mdP1 = RadioCapabilities.ModeP1(recv);
+                await _catClient.SendCommandAsync($"MD{mdP1}{request.Mode};", "User");
+                if (requestedB) _radioStateService.ModeB = displayMode;
+                else            _radioStateService.ModeA = displayMode;
 
-                // Re-apply Contour and APF state — mode changes on the FTdx101 cause the
-                // radio to restore its per-mode Contour/APF settings, overriding what we have set.
-                var modeSettings = await _settingsService.GetSettingsAsync();
-                bool isFtdx3000 = modeSettings.RadioModel == "FTDX3000";
-                bool targetB = VfoIsB(recv);
-                // P1=0 on FTDX3000 (special CO format) and on every single-receiver
-                // model (P1 Fixed=0). Dual-receiver -> P1 by VFO.
-                string p1 = isFtdx3000 ? "0" : VfoP1Outgoing(recv);
+                // Re-apply Contour and APF state — a mode change on the live
+                // receiver causes the radio to restore its per-mode Contour/APF
+                // settings, overriding what we have set. Skip when the mode
+                // change was on the inactive VFO of a single-receiver radio:
+                // CO is P1=0-Fixed there, so re-applying would write the other
+                // panel's contour onto the live VFO.
+                bool liveReceiverChanged = !_radioStateService.IsSingleReceiver
+                    || (_radioStateService.ActiveVfo == 1) == requestedB;
 
-                if (isFtdx3000)
+                if (liveReceiverChanged)
                 {
-                    bool cOn = _radioStateService.ContourOnA;
-                    bool aOn = _radioStateService.ApfOnA;
-                    if (cOn)
+                    var modeSettings = await _settingsService.GetSettingsAsync();
+                    bool isFtdx3000 = modeSettings.RadioModel == "FTDX3000";
+                    // P1=0 on FTDX3000 (special CO format) and on every single-receiver
+                    // model (P1 Fixed=0). Dual-receiver -> P1 by VFO.
+                    string p1 = isFtdx3000 ? "0" : VfoP1Outgoing(recv);
+
+                    if (isFtdx3000)
                     {
-                        await _catClient.SendCommandAsync("CO0001;", "User");
-                        int vv = Math.Max(1, Math.Min(40, _radioStateService.ContourFreqA / 100));
-                        await _catClient.SendCommandAsync($"CO01{vv:D2};", "User");
-                    }
-                    else if (aOn)
-                    {
-                        await _catClient.SendCommandAsync("CO0002;", "User");
-                        int vv = Math.Max(0, Math.Min(20, (_radioStateService.ApfFreqA / 25) + 10));
-                        await _catClient.SendCommandAsync($"CO02{vv:D2};", "User");
+                        bool cOn = _radioStateService.ContourOnA;
+                        bool aOn = _radioStateService.ApfOnA;
+                        if (cOn)
+                        {
+                            await _catClient.SendCommandAsync("CO0001;", "User");
+                            int vv = Math.Max(1, Math.Min(40, _radioStateService.ContourFreqA / 100));
+                            await _catClient.SendCommandAsync($"CO01{vv:D2};", "User");
+                        }
+                        else if (aOn)
+                        {
+                            await _catClient.SendCommandAsync("CO0002;", "User");
+                            int vv = Math.Max(0, Math.Min(20, (_radioStateService.ApfFreqA / 25) + 10));
+                            await _catClient.SendCommandAsync($"CO02{vv:D2};", "User");
+                        }
+                        else
+                        {
+                            await _catClient.SendCommandAsync("CO0000;", "User");
+                        }
                     }
                     else
                     {
-                        await _catClient.SendCommandAsync("CO0000;", "User");
+                        bool contourOn  = requestedB ? _radioStateService.ContourOnB  : _radioStateService.ContourOnA;
+                        int  contourHz  = requestedB ? _radioStateService.ContourFreqB : _radioStateService.ContourFreqA;
+                        bool apfOn      = requestedB ? _radioStateService.ApfOnB       : _radioStateService.ApfOnA;
+                        int  apfHz      = requestedB ? _radioStateService.ApfFreqB     : _radioStateService.ApfFreqA;
+
+                        int  cFreq = Math.Max(100, Math.Min(3200, contourHz));
+                        await _catClient.SendCommandAsync($"CO{p1}0000{(contourOn ? 1 : 0)};", "User");
+                        await _catClient.SendCommandAsync($"CO{p1}1{cFreq:D4};", "User");
+
+                        int  aVvvv = Math.Max(0, Math.Min(50, (apfHz / 10) + 25));
+                        await _catClient.SendCommandAsync($"CO{p1}2000{(apfOn ? 1 : 0)};", "User");
+                        await _catClient.SendCommandAsync($"CO{p1}3{aVvvv:D4};", "User");
                     }
                 }
-                else
-                {
-                    bool contourOn  = targetB ? _radioStateService.ContourOnB  : _radioStateService.ContourOnA;
-                    int  contourHz  = targetB ? _radioStateService.ContourFreqB : _radioStateService.ContourFreqA;
-                    bool apfOn      = targetB ? _radioStateService.ApfOnB       : _radioStateService.ApfOnA;
-                    int  apfHz      = targetB ? _radioStateService.ApfFreqB     : _radioStateService.ApfFreqA;
 
-                    int  cFreq = Math.Max(100, Math.Min(3200, contourHz));
-                    await _catClient.SendCommandAsync($"CO{p1}0000{(contourOn ? 1 : 0)};", "User");
-                    await _catClient.SendCommandAsync($"CO{p1}1{cFreq:D4};", "User");
-
-                    int  aVvvv = Math.Max(0, Math.Min(50, (apfHz / 10) + 25));
-                    await _catClient.SendCommandAsync($"CO{p1}2000{(apfOn ? 1 : 0)};", "User");
-                    await _catClient.SendCommandAsync($"CO{p1}3{aVvvv:D4};", "User");
-                }
-
-                _logger.LogInformation("Sending CAT command: MD{Vfo}{Mode}; for Receiver {Receiver}", VfoP1Outgoing(recv), request.Mode, recv);
+                _logger.LogInformation("Sending CAT command: MD{Vfo}{Mode}; for Receiver {Receiver}", mdP1, request.Mode, recv);
                 return Ok(new { message = $"Mode {displayMode} selected for Receiver {receiver}" });
             }
             catch (Exception ex)

--- a/Controllers/CatController.cs
+++ b/Controllers/CatController.cs
@@ -1921,6 +1921,10 @@ namespace Yaesu_Web_Control.Controllers
                 var rxSettings = await _settingsService.GetSettingsAsync();
                 var rx = v == "B" ? 1 : 0;
 
+                // Capture TX before ActiveVfo moves — EffectiveTxVfo() depends on it.
+                var wasSplit = _radioStateService.SplitMode > 0;
+                var previousTx = EffectiveTxVfo();
+
                 // The FTDX3000 selects the RX VFO via FR, and uses 0/4 (NOT 0/1):
                 // FR0; = VFO-A RX, FR4; = VFO-B RX. Confirmed from a real FTDX3000
                 // in daily use by iu1teu (#78) — it does not use VS for this. The
@@ -1932,9 +1936,62 @@ namespace Yaesu_Web_Control.Controllers
                     await _catClient.SendCommandAsync($"VS{rx};", "WebUI", CancellationToken.None);
 
                 _radioStateService.ActiveVfo = rx;
-                _radioStateService.SplitMode = _radioStateService.TxVfo != rx ? 1 : 0;
-                _logger.LogInformation("RX VFO set to {Vfo} (split={Split})", v, _radioStateService.SplitMode);
-                return Ok(new { rxVfo = rx, splitMode = _radioStateService.SplitMode });
+
+                // On single-receiver radios FT often stays at 0 when the operating
+                // VFO moves (same root cause as the Index TX-button effective-VFO
+                // rule). Deriving split from raw TxVfo made "RX B, both on B"
+                // look like reverse split (RX B / TX A red). Keep non-split
+                // moves coherent: TX follows RX. When already split, TX stays
+                // put and split clears only if RX lands on that TX VFO.
+                if (_radioStateService.IsSingleReceiver)
+                {
+                    if (!wasSplit)
+                    {
+                        _radioStateService.TxVfo = rx;
+                        _radioStateService.SplitMode = 0;
+                        if (rxSettings.RadioModel == "FTDX3000")
+                        {
+                            // FTDX3000: FT2; = TX with VFO A (no split). For
+                            // both-on-B there is no "FT no-split on B" opcode —
+                            // FR already steers the operating VFO; leave FT alone
+                            // unless we need A. FT3; would force split onto B.
+                            if (rx == 0)
+                                await _catClient.SendCommandAsync("FT2;", "WebUI", CancellationToken.None);
+                        }
+                        else
+                        {
+                            // FTdx10 / FT-710 / FT-991A: nudge FT to match so a
+                            // later SetTxVfo / split derive sees a coherent value.
+                            // Harmless when the radio ignores FT outside split.
+                            await _catClient.SendCommandAsync($"FT{rx};", "WebUI", CancellationToken.None);
+                        }
+                    }
+                    else
+                    {
+                        _radioStateService.TxVfo = previousTx;
+                        _radioStateService.SplitMode = previousTx != rx ? 1 : 0;
+                        if (_radioStateService.SplitMode == 0)
+                        {
+                            // Cleared split by moving RX onto the TX VFO.
+                            if (rxSettings.RadioModel == "FTDX3000")
+                                await _catClient.SendCommandAsync("FT2;", "WebUI", CancellationToken.None);
+                            else
+                                await _catClient.SendCommandAsync("ST0;", "WebUI", CancellationToken.None);
+                        }
+                    }
+                }
+                else
+                {
+                    _radioStateService.SplitMode = _radioStateService.TxVfo != rx ? 1 : 0;
+                }
+
+                _logger.LogInformation("RX VFO set to {Vfo} (tx={Tx}, split={Split})",
+                    v, _radioStateService.TxVfo == 1 ? "B" : "A", _radioStateService.SplitMode);
+                return Ok(new {
+                    rxVfo = rx,
+                    txVfo = EffectiveTxVfo(),
+                    splitMode = _radioStateService.SplitMode
+                });
             }
             catch (Exception ex)
             {
@@ -1957,16 +2014,23 @@ namespace Yaesu_Web_Control.Controllers
             {
                 await EnsureConnectedAsync();
                 var tx = v == "B" ? 1 : 0;
+                var txSettings = await _settingsService.GetSettingsAsync();
+                var splitOn = tx != _radioStateService.ActiveVfo;
 
-                // FT selects the transmit VFO on all supported models: FT0; = TX on
-                // VFO A, FT1; = TX on VFO B. Already proven driving the FTDX3000
-                // Split button (#78).
+                // FT selects the transmit VFO: FT0; = TX on A, FT1; = TX on B.
+                // Proven on FTDX3000 for the independent TX selector (#78).
+                // (The Split button path on FTDX3000 uses FT2/FT3 instead.)
                 await _catClient.SendCommandAsync($"FT{tx};", "WebUI", CancellationToken.None);
 
+                // FTdx10 / FT-710 / FT-991A also need ST to engage/clear split;
+                // FTDX3000 has no ST (FT alone is enough for its firmware).
+                if (_radioStateService.IsSingleReceiver && txSettings.RadioModel != "FTDX3000")
+                    await _catClient.SendCommandAsync(splitOn ? "ST1;" : "ST0;", "WebUI", CancellationToken.None);
+
                 _radioStateService.TxVfo = tx;
-                _radioStateService.SplitMode = tx != _radioStateService.ActiveVfo ? 1 : 0;
+                _radioStateService.SplitMode = splitOn ? 1 : 0;
                 _logger.LogInformation("TX VFO set to {Vfo} (split={Split})", v, _radioStateService.SplitMode);
-                return Ok(new { txVfo = tx, splitMode = _radioStateService.SplitMode });
+                return Ok(new { txVfo = EffectiveTxVfo(), splitMode = _radioStateService.SplitMode });
             }
             catch (Exception ex)
             {

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -25,7 +25,7 @@
     // agrees with the range check CatController.SetPower applies to the same value.
     int maxPowerWatts = Yaesu_Web_Control.Services.RadioCapabilities.MaxPowerWatts(Model.RadioModel);
     // Quick Memory Bank Store/Recall buttons (Thomas OZ1JTE request) — rendered
-    // once, next to VFO A's band buttons, since QMB is a radio-global function.
+    // once, under VFO A's filter/audio scope, since QMB is a radio-global function.
     bool hasQmb = Yaesu_Web_Control.Services.RadioCapabilities.SupportsQmb(Model.RadioModel);
     // Render VC Tune controls only when both the model supports VC Tune (FTdx101MP)
     // AND the hardware ID is positively confirmed to support VT CAT commands.
@@ -142,7 +142,7 @@
 }
 
 <!-- Cache-busted CSS reference -->
-<link rel="stylesheet" href="~/css/site.css?v=20260520a" />
+<link rel="stylesheet" href="~/css/site.css?v=20260818a" />
 <link rel="stylesheet" href="~/css/closer-to-raw-power.css?v=20260226n" />
 <style>
     #saveMemBtnA, #saveMemBtnB { font-weight: 700 !important; font-size: 0.85rem !important; color: #212529 !important; }
@@ -1016,62 +1016,17 @@
                     </div>
                 </div>
                 <div class="card-body p-2">
-                    <!-- Receiver Controls Group: Save-to-Mem, Band buttons, Mode select.
+                    <!-- Receiver Controls Group: Band buttons, Mode, filter/audio
+                         scope column (canvas + Save-to-Mem + QMB), AGC column.
                          The S-meter and its history strip moved to the top meter row
                          in v2.3.9 (Jacek SP3L #34, Colin's design call) -- the radio
                          has only one calibrated S-meter, so showing it once at the
                          top is honest. -->
                     <div class="receiver-controls-group d-flex flex-nowrap mb-0 gap-2 align-items-start">
-                        <!-- Left: Save-to-Mem button (S-meter moved to top row) -->
-                        <div class="flex-shrink-0">
-                            <button id="saveMemBtnA" type="button"
-                                    class="btn btn-outline-secondary btn-sm"
-                                    style="padding:1px 4px;"
-                                    onclick="saveVfoToMemory('A')"
-                                    aria-label="Save VFO A to memories"
-                                    title="Save VFO A frequency, mode and clarifier to app memories">
-                                Save to Mem
-                            </button>
-                            <span id="saveMemStatusA" class="visually-hidden" role="status" aria-live="polite"></span>
-                        </div>
-                        <!-- Middle: Band buttons + Mode/Antenna below + filter scope -->
-                        <div class="flex-grow-1 d-flex flex-column gap-1">
+                        <!-- Band buttons + Mode/Antenna (sized to content so the
+                             scope column can sit in the leftover middle gap) -->
+                        <div class="flex-shrink-0 d-flex flex-column gap-1">
                             @await Html.PartialAsync("_BandButtonsPartial", Tuple.Create("unused", "A", Model.SelectedBandA))
-                            @if (hasQmb)
-                            {
-                                <!-- Quick Memory Bank (QMB) — global radio function, shown once.
-                                     Store (QI;) pushes the current VFO into the QMB stack; Recall
-                                     (QR;) recalls / cycles through the stored slots. Buttons only,
-                                     per Thomas OZ1JTE's request (no stack-contents display). -->
-                                <div class="d-flex align-items-center gap-2 mt-1" id="qmbControls">
-                                    <span class="vfo-control-label" aria-hidden="true">QMB</span>
-                                    <button id="qmbStoreBtn" type="button"
-                                            class="btn btn-outline-secondary btn-sm"
-                                            style="padding:1px 6px;"
-                                            onclick="qmbStore()"
-                                            aria-label="Store current VFO to Quick Memory Bank"
-                                            title="Store the current VFO frequency and mode into the radio's Quick Memory Bank">
-                                        Store
-                                    </button>
-                                    <button id="qmbRecallBtn" type="button"
-                                            class="btn btn-outline-secondary btn-sm"
-                                            style="padding:1px 6px;"
-                                            onclick="qmbRecall()"
-                                            aria-label="Recall from Quick Memory Bank"
-                                            title="Recall from the Quick Memory Bank — the display switches to QMB; repeated presses step through the stored slots. Use V/M to return to VFO.">
-                                        Recall
-                                    </button>
-                                    <button id="qmbVfoBtn" type="button"
-                                            class="btn btn-outline-secondary btn-sm"
-                                            style="padding:1px 6px;"
-                                            onclick="qmbVfo()"
-                                            aria-label="Return to VFO mode (V/M key)"
-                                            title="Return to VFO mode — leaves QMB (mirrors the radio's V/M key).">
-                                        V/M
-                                    </button>
-                                    <span id="qmbStatus" class="visually-hidden" role="status" aria-live="polite"></span>
-                                </div>
-                            }
                             <div class="d-flex align-items-center gap-2 mt-1">
                                 <label class="vfo-control-label" for="modeSelectA">Mode</label>
                                 <select class="form-select form-select-sm vfo-mode-select" id="modeSelectA"
@@ -1137,11 +1092,61 @@
                                  style="font-size:1.1rem; font-weight:700; color:#000; margin-top:0.3rem; max-width:320px; overflow-wrap:break-word;"
                                  aria-live="polite"></div>
                         </div>
-                        <!-- Filter scope display VFO A — sits between band buttons and AGC column -->
-                        <div class="flex-shrink-0" id="filterScopeContainerA" style="width:160px;">
+                        <!-- Filter/audio scope column — canvas with Save-to-Mem and
+                             QMB stacked under it. The slot grows so this stack sits
+                             in the middle of the gap between bands and AGC. -->
+                        <div class="filter-scope-column-slot">
+                        <div class="flex-shrink-0 d-flex flex-column gap-1" id="filterScopeContainerA" style="width:160px;">
                             <canvas id="filterScopeCanvasA" role="img" aria-hidden="true"
                                     aria-label="VFO A filter display" data-a11y-key="filter.scopeA"
                                     style="display:block; height:80px; border-radius:4px;"></canvas>
+                            <button id="saveMemBtnA" type="button"
+                                    class="btn btn-outline-secondary btn-sm w-100"
+                                    style="padding:1px 4px;"
+                                    onclick="saveVfoToMemory('A')"
+                                    aria-label="Save VFO A to memories"
+                                    title="Save VFO A frequency, mode and clarifier to app memories">
+                                Save to Mem
+                            </button>
+                            <span id="saveMemStatusA" class="visually-hidden" role="status" aria-live="polite"></span>
+                            @if (hasQmb)
+                            {
+                                <!-- Quick Memory Bank (QMB) — global radio function, shown once.
+                                     Store (QI;) pushes the current VFO into the QMB stack; Recall
+                                     (QR;) recalls / cycles through the stored slots. Buttons only,
+                                     per Thomas OZ1JTE's request (no stack-contents display). -->
+                                <div class="d-flex flex-column gap-1" id="qmbControls">
+                                    <span class="vfo-control-label" aria-hidden="true">QMB</span>
+                                    <div class="d-flex align-items-stretch gap-1">
+                                        <button id="qmbStoreBtn" type="button"
+                                                class="btn btn-outline-secondary btn-sm flex-fill"
+                                                style="padding:1px 4px;"
+                                                onclick="qmbStore()"
+                                                aria-label="Store current VFO to Quick Memory Bank"
+                                                title="Store the current VFO frequency and mode into the radio's Quick Memory Bank">
+                                            Store
+                                        </button>
+                                        <button id="qmbRecallBtn" type="button"
+                                                class="btn btn-outline-secondary btn-sm flex-fill"
+                                                style="padding:1px 4px;"
+                                                onclick="qmbRecall()"
+                                                aria-label="Recall from Quick Memory Bank"
+                                                title="Recall from the Quick Memory Bank — the display switches to QMB; repeated presses step through the stored slots. Use V/M to return to VFO.">
+                                            Recall
+                                        </button>
+                                        <button id="qmbVfoBtn" type="button"
+                                                class="btn btn-outline-secondary btn-sm flex-fill"
+                                                style="padding:1px 4px;"
+                                                onclick="qmbVfo()"
+                                                aria-label="Return to VFO mode (V/M key)"
+                                                title="Return to VFO mode — leaves QMB (mirrors the radio's V/M key).">
+                                            V/M
+                                        </button>
+                                    </div>
+                                    <span id="qmbStatus" class="visually-hidden" role="status" aria-live="polite"></span>
+                                </div>
+                            }
+                        </div>
                         </div>
                         <!-- Right: Controls column (2-column grid) -->
                         <div class="vfo-controls-column">
@@ -1466,23 +1471,13 @@
                     </div>
                 </div>
                 <div class="card-body p-2">
-                    <!-- Receiver Controls Group: Save-to-Mem, Band buttons, Mode select.
+                    <!-- Receiver Controls Group: Band buttons, Mode, filter/audio
+                         scope column (canvas + Save-to-Mem), AGC column.
                          S-meter moved to top meter row in v2.3.9 (see VFO A panel). -->
                     <div class="receiver-controls-group d-flex flex-nowrap mb-0 gap-2 align-items-start">
-                        <!-- Left: Save-to-Mem button (S-meter moved to top row) -->
-                        <div class="flex-shrink-0">
-                            <button id="saveMemBtnB" type="button"
-                                    class="btn btn-outline-secondary btn-sm"
-                                    style="padding:1px 4px;"
-                                    onclick="saveVfoToMemory('B')"
-                                    aria-label="Save VFO B to memories"
-                                    title="Save VFO B frequency, mode and clarifier to app memories">
-                                Save to Mem
-                            </button>
-                            <span id="saveMemStatusB" class="visually-hidden" role="status" aria-live="polite"></span>
-                        </div>
-                        <!-- Middle: Band buttons + Mode/Antenna below -->
-                        <div class="flex-grow-1 band-buttons-shifted d-flex flex-column gap-1">
+                        <!-- Band buttons + Mode/Antenna (sized to content so the
+                             scope column can sit in the leftover middle gap) -->
+                        <div class="flex-shrink-0 d-flex flex-column gap-1">
                             @await Html.PartialAsync("_BandButtonsPartial", Tuple.Create("unused", "B", Model.SelectedBandB))
                             <div class="d-flex align-items-center gap-2 mt-1">
                                 <label class="vfo-control-label" for="modeSelectB">Mode</label>
@@ -1552,11 +1547,23 @@
                                      aria-live="polite"></div>
                             </div>
                         }
-                        <!-- Filter scope display VFO B — sits between band buttons and AGC column -->
-                        <div class="flex-shrink-0" id="filterScopeContainerB" style="width:160px;">
+                        <!-- Filter/audio scope column — canvas with Save-to-Mem stacked
+                             under it (QMB is VFO A only). Slot centers it in the gap. -->
+                        <div class="filter-scope-column-slot">
+                        <div class="flex-shrink-0 d-flex flex-column gap-1" id="filterScopeContainerB" style="width:160px;">
                             <canvas id="filterScopeCanvasB" role="img" aria-hidden="true"
                                     aria-label="VFO B filter display" data-a11y-key="filter.scopeB"
                                     style="display:block; height:80px; border-radius:4px;"></canvas>
+                            <button id="saveMemBtnB" type="button"
+                                    class="btn btn-outline-secondary btn-sm w-100"
+                                    style="padding:1px 4px;"
+                                    onclick="saveVfoToMemory('B')"
+                                    aria-label="Save VFO B to memories"
+                                    title="Save VFO B frequency, mode and clarifier to app memories">
+                                Save to Mem
+                            </button>
+                            <span id="saveMemStatusB" class="visually-hidden" role="status" aria-live="polite"></span>
+                        </div>
                         </div>
                         <!-- Right: Controls column (2-column grid) -->
                         <div class="vfo-controls-column">

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -16,13 +16,8 @@
     bool isFtdx3000 = Model.RadioModel == "FTDX3000";
     bool isFtdx5000 = Model.RadioModel == "FTDX5000MP" || Model.RadioModel == "FTDX5000D";
 
-    // Single-receiver radios (FTdx10, FT-710, FTDX3000) store per-VFO RX
-    // settings but expose only the active VFO's state via CAT — see
-    // docs/decisions/0003-single-vs-dual-receiver-ui.md. The home page
-    // greys out the inactive VFO panel on these radios to reflect that
-    // editing it via CAT would silently swap the radio's active VFO.
-    // Dual-receiver radios (FTdx101MP/D) keep both panels active because
-    // each VFO is its own physical receiver chain.
+    // Single- vs dual-receiver layout gates (RX/TX selectors, S-meter B, etc.)
+    // — see docs/decisions/0003-single-vs-dual-receiver-ui.md.
     bool isSingleReceiver  = Yaesu_Web_Control.Services.RadioCapabilities.IsSingleReceiver(Model.RadioModel);
     bool hasAntennaSelector = Yaesu_Web_Control.Services.RadioCapabilities.HasAntennaSelector(Model.RadioModel);
     // Rated TX output. Server-rendered rather than derived in JavaScript so the
@@ -158,61 +153,6 @@
     .vfo-active > .card.receiver-card {
         box-shadow: 0 0 0 2px #ffc107, 0 0 10px rgba(255, 193, 7, 0.5);
         transition: box-shadow 0.2s ease;
-    }
-
-    /* Single-receiver radios (FTdx10, FT-710, FTDX3000): the inactive VFO
-       card BODY is greyed and made non-interactive. The card HEADER stays
-       normal so TX / ZIN / badges remain full-colour and clickable — dimming
-       the whole column (including the header) made the TX button look
-       disabled in split mode even though it was still active (CSS cannot
-       undo a parent's opacity/filter on a child).
-       Editing body controls on the inactive section via CAT would silently
-       swap the radio's active VFO; better to disable visually and require
-       an explicit A/B swap on the rig first.
-       See docs/decisions/0003-single-vs-dual-receiver-ui.md
-       Reported by Jacek SP3L on #34. */
-    .vfo-inactive > .card > .card-body {
-        pointer-events: none;
-    }
-    .vfo-inactive > .card > .card-body > * {
-        opacity: 0.55;
-        filter: grayscale(0.5);
-        transition: opacity 0.25s ease, filter 0.25s ease;
-    }
-    /* R10/R11 (Jacek SP3L #34): in split mode the inactive panel IS the TX
-       VFO and its frequency must remain interactive so operators can set
-       the TX frequency from YWC without un-splitting first. .vfo-tx-editable
-       is added by applyVfoActiveStyling() only when splitMode>0. The freq
-       row is undimmed as a unit (parent opacity cannot be undone on nested
-       children), then non-frequency siblings in that row (roofing, AF gain)
-       are re-dimmed. */
-    .vfo-inactive.vfo-tx-editable > .card > .card-body > .vfo-freq-row {
-        opacity: 1;
-        filter: none;
-    }
-    .vfo-inactive.vfo-tx-editable > .card > .card-body > .vfo-freq-row > *:not(.frequency-display):not(.freq-step-controls):not(.fkb-open-btn) {
-        opacity: 0.55;
-        filter: grayscale(0.5);
-        pointer-events: none;
-    }
-    .vfo-inactive.vfo-tx-editable .frequency-display,
-    .vfo-inactive.vfo-tx-editable .freq-step-controls,
-    .vfo-inactive.vfo-tx-editable .fkb-open-btn {
-        /* pointer-events:auto on a child overrides pointer-events:none on
-           an ancestor — that is the CSS exception that makes the carve-out
-           work. !important is needed on <button> (fkb-open / ▲▼). */
-        pointer-events: auto !important;
-    }
-
-    /* Hide live receive indicators on the inactive VFO panel — on a real
-       single-receiver radio there is no signal data for the inactive VFO,
-       so showing a moving S-meter and a scrolling history would be
-       misleading (suggests a signal is being received when nothing is).
-       Display:none rather than visibility:hidden so the panel shrinks
-       and the active panel's prominence is reinforced. */
-    .vfo-inactive .analog-meter-container,
-    .vfo-inactive .smeter-history-container {
-        display: none !important;
     }
 
     /* Grey the S-meters while transmitting.

--- a/Services/CatCommands.cs
+++ b/Services/CatCommands.cs
@@ -310,7 +310,9 @@
         // re-query burst after front-panel A/B presses.
         public static readonly string[] SingleReceiverPerVfoQueries =
         {
-            "MD0;",          // mode — per-VFO at CAT level; re-read after VS for safety
+            // Mode is per-VFO at CAT (MD0=A, MD1=B) even on single-receiver.
+            // Both are re-read after VS; the dispatcher routes by P1.
+            "MD0;", "MD1;",
             "RF0;",          // roofing filter
             "GT0;",          // AGC
             "PA0;",          // IPO/AMP

--- a/Services/CatMessageDispatcher.cs
+++ b/Services/CatMessageDispatcher.cs
@@ -153,9 +153,13 @@
                         HandleInitialization(message);
                         break;
                     case "MD":
-                        // Example: MD01; (VFO A, LSB), MD12; (VFO B, USB)
-                        // Single-receiver: P1 is "0 Fixed" — routes via SetPerVfo's
-                        // 300 ms buffer so A/B-press broadcasts land on ActiveVfo.
+                        // Example: MD01; (VFO A, LSB), MD12; (VFO B, USB).
+                        // MD is per-VFO at CAT level on every supported model
+                        // (FTdx10 manual: P1 0=MAIN, 1=SUB) — not P1=0-Fixed
+                        // like GT/PA/SH. Route by P1 the same way AN does,
+                        // including on single-receiver: using SetPerVfo here
+                        // wrote an inactive-VFO mode change onto the active
+                        // VFO's slot.
                         if (message.Length >= 5)
                         {
                             var modeCode = message[3];
@@ -180,10 +184,8 @@
                             };
                             if (mode != null)
                             {
-                                SetPerVfo(message[2], routeB => {
-                                    if (routeB) _stateService.ModeB = mode;
-                                    else        _stateService.ModeA = mode;
-                                });
+                                if (message[2] == '1') _stateService.ModeB = mode;
+                                else                   _stateService.ModeA = mode;
                             }
                         }
                         break;

--- a/Services/CatMessageDispatcher.cs
+++ b/Services/CatMessageDispatcher.cs
@@ -524,6 +524,16 @@
                         {
                             var previous = _stateService.ActiveVfo;
                             _stateService.ActiveVfo = activeVfo;
+                            // Single-receiver, not in split: front-panel A/B moves
+                            // the operating VFO for both RX and TX, but FT often
+                            // stays at 0. Mirror ActiveVfo into TxVfo so the RX/TX
+                            // selectors and any TxVfo readers stay coherent.
+                            if (_stateService.IsSingleReceiver
+                                && _stateService.SplitMode == 0
+                                && _stateService.TxVfo != activeVfo)
+                            {
+                                _stateService.TxVfo = activeVfo;
+                            }
                             if (_stateService.IsSingleReceiver
                                 && _stateService.IsInitialized
                                 && previous != activeVfo)

--- a/Services/RadioCapabilities.cs
+++ b/Services/RadioCapabilities.cs
@@ -276,11 +276,30 @@ public static class RadioCapabilities
     /// position and rejects P1=1; on dual-receiver "0" for A, "1" for B.
     /// Shared by CatController (mouse/keyboard input) and IntentDispatcher
     /// (voice input) so the routing rule lives in exactly one place.
+    ///
+    /// Do not use this for MD (operating mode). Mode is per-VFO at CAT
+    /// level on every supported model — see <see cref="ModeP1"/>.
     /// </summary>
     public static string VfoP1(bool isSingleReceiver, string receiver) =>
         isSingleReceiver
             ? "0"
             : (receiver.Equals("B", StringComparison.OrdinalIgnoreCase) ? "1" : "0");
+
+    /// <summary>
+    /// P1 for the MD (operating mode) command. Unlike receive-controls
+    /// (GT, PA, SH, CO, …) whose P1 is 0-Fixed on single-receiver radios,
+    /// MD is documented on the FTdx10 (and the rest of the family) as
+    /// 0 = MAIN / VFO-A, 1 = SUB / VFO-B. VFO A and VFO B are
+    /// frequency-and-mode memory slots even when there is only one
+    /// physical receiver, so the inactive VFO's mode is independently
+    /// addressable — the same way FA/FB address frequency.
+    ///
+    /// Using <see cref="VfoP1"/> here would send MD0 for both panels on
+    /// an FTdx10 and change the active VFO's mode when the operator
+    /// edited the inactive one.
+    /// </summary>
+    public static string ModeP1(string receiver) =>
+        receiver.Equals("B", StringComparison.OrdinalIgnoreCase) ? "1" : "0";
 
     /// <summary>
     /// Returns true if the per-VFO state write should target *B (vs *A) for
@@ -289,6 +308,9 @@ public static class RadioCapabilities
     /// is a hint, not an addressable target -- so this mirrors
     /// <paramref name="activeVfo"/> (0 = A, 1 = B). On dual-receiver radios
     /// the target wins outright.
+    ///
+    /// Do not use this for MD state writes. Mode follows the requested
+    /// VFO, not the active one — see <see cref="ModeP1"/>.
     /// </summary>
     public static bool VfoIsB(bool isSingleReceiver, int activeVfo, string receiver) =>
         isSingleReceiver

--- a/Services/RadioCapabilities.cs
+++ b/Services/RadioCapabilities.cs
@@ -1,18 +1,15 @@
 namespace Yaesu_Web_Control.Services;
 
-// Capability lookup for per-model behaviour differences. Currently used only
-// for the dual- vs single-receiver UI decision (active-VFO greying-out and
-// PTT placement on single-receiver radios), but the pattern scales: future
-// per-model variations (4 m band availability, max TX power, roofing-filter
-// availability) can hang off this same static class.
+// Capability lookup for per-model behaviour differences. Currently used for
+// the dual- vs single-receiver UI decision (RX/TX selectors, S-meter B,
+// dual-receiver active-band highlight, PTT placement), but the pattern
+// scales: future per-model variations (4 m band availability, max TX power,
+// roofing-filter availability) can hang off this same static class.
 //
 // See docs/decisions/0003-single-vs-dual-receiver-ui.md for the design
 // rationale and Jacek SP3L's #34 report that drove it.
 //
-// Single-receiver is the safe default for unknown models — it applies the
-// active/inactive UI restriction, which over-constrains an unfamiliar radio
-// rather than letting it edit both VFOs' controls simultaneously when
-// possibly only one set actually exists in the hardware.
+// Single-receiver is the safe default for unknown models.
 public static class RadioCapabilities
 {
     // Hardware revision IDs confirmed to reject VT CAT commands despite the

--- a/Tests/YaesuWebControl.Tests/ModeVfoRoutingTests.cs
+++ b/Tests/YaesuWebControl.Tests/ModeVfoRoutingTests.cs
@@ -1,0 +1,132 @@
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Yaesu_Web_Control.Hubs;
+using Yaesu_Web_Control.Services;
+
+namespace YaesuWebControl.Tests;
+
+// On single-receiver radios (FTdx10 / FT-710 / FTDX3000) receive-controls
+// (GT, PA, SH, CO, …) are P1=0-Fixed and address whichever VFO is active.
+// MD is not in that set: the FTdx10 CAT manual documents P1 as 0=MAIN /
+// VFO-A, 1=SUB / VFO-B, same as FA/FB. Using VfoP1 / SetPerVfo for mode
+// made an inactive-VFO mode change rewrite the active VFO as well.
+public sealed class ModeVfoRoutingTests
+{
+    [Theory]
+    [InlineData("A", "0")]
+    [InlineData("a", "0")]
+    [InlineData("B", "1")]
+    [InlineData("b", "1")]
+    public void ModeP1_FollowsTheRequestedVfo(string receiver, string expected)
+        => Assert.Equal(expected, RadioCapabilities.ModeP1(receiver));
+
+    [Fact]
+    public void ModeP1_IsNotCollapsedToZeroOnSingleReceiver_UnlikeVfoP1()
+    {
+        Assert.Equal("0", RadioCapabilities.VfoP1(isSingleReceiver: true, "B"));
+        Assert.Equal("1", RadioCapabilities.ModeP1("B"));
+    }
+
+    [Fact]
+    public void FormatMode_AddressesVfoBIndependently()
+    {
+        Assert.Equal("MD02;", CatCommands.FormatMode("USB", isSubVfo: false));
+        Assert.Equal("MD12;", CatCommands.FormatMode("USB", isSubVfo: true));
+        Assert.Equal("MD0C;", CatCommands.FormatMode("DATA-U", isSubVfo: false));
+        Assert.Equal("MD1C;", CatCommands.FormatMode("DATA-U", isSubVfo: true));
+    }
+
+    [Fact]
+    public void Dispatcher_OnSingleReceiver_RoutesMd1ToModeB_EvenWhenVfoAIsActive()
+    {
+        var (state, dispatcher) = NewDispatcher(singleReceiver: true, activeVfo: 0);
+        state.ModeA = "USB";
+        state.ModeB = "LSB";
+
+        dispatcher.DispatchMessage("MD1C;");
+
+        Assert.Equal("USB", state.ModeA);
+        Assert.Equal("DATA-U", state.ModeB);
+    }
+
+    [Fact]
+    public void Dispatcher_OnSingleReceiver_RoutesMd0ToModeA_EvenWhenVfoBIsActive()
+    {
+        var (state, dispatcher) = NewDispatcher(singleReceiver: true, activeVfo: 1);
+        state.ModeA = "USB";
+        state.ModeB = "LSB";
+
+        dispatcher.DispatchMessage("MD03;");
+
+        Assert.Equal("CW-U", state.ModeA);
+        Assert.Equal("LSB", state.ModeB);
+    }
+
+    [Fact]
+    public void Dispatcher_OnDualReceiver_StillRoutesByP1()
+    {
+        var (state, dispatcher) = NewDispatcher(singleReceiver: false, activeVfo: 0);
+        state.ModeA = "USB";
+        state.ModeB = "LSB";
+
+        dispatcher.DispatchMessage("MD14;");
+
+        Assert.Equal("USB", state.ModeA);
+        Assert.Equal("FM", state.ModeB);
+    }
+
+    private static (RadioStateService State, CatMessageDispatcher Dispatcher) NewDispatcher(
+        bool singleReceiver, int activeVfo)
+    {
+        var persistence = new RadioStatePersistenceService(
+            NullLogger<RadioStatePersistenceService>.Instance, null!);
+
+        var state = new RadioStateService(
+            NullLogger<RadioStateService>.Instance,
+            persistence,
+            new SilentHubContext(),
+            new UnknownBandPlan())
+        {
+            IsSingleReceiver = singleReceiver,
+            ActiveVfo = activeVfo
+        };
+
+        var dispatcher = new CatMessageDispatcher(
+            state, NullLogger<CatMessageDispatcher>.Instance);
+
+        return (state, dispatcher);
+    }
+
+    private sealed class SilentHubContext : IHubContext<RadioHub>
+    {
+        public IHubClients Clients { get; } = new SilentClients();
+        public IGroupManager Groups => throw new NotSupportedException();
+    }
+
+    private sealed class SilentClients : IHubClients
+    {
+        private static readonly IClientProxy Proxy = new SilentProxy();
+        public IClientProxy All => Proxy;
+        public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds) => Proxy;
+        public IClientProxy Client(string connectionId) => Proxy;
+        public IClientProxy Clients(IReadOnlyList<string> connectionIds) => Proxy;
+        public IClientProxy Group(string groupName) => Proxy;
+        public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds) => Proxy;
+        public IClientProxy Groups(IReadOnlyList<string> groupNames) => Proxy;
+        public IClientProxy User(string userId) => Proxy;
+        public IClientProxy Users(IReadOnlyList<string> userIds) => Proxy;
+    }
+
+    private sealed class SilentProxy : IClientProxy
+    {
+        public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed class UnknownBandPlan : IBandPlanService
+    {
+        public string CurrentRegion => "Region1";
+        public IReadOnlyList<BandEdge> CurrentEdges => Array.Empty<BandEdge>();
+        public string BandForFrequency(long hz) => "Unknown";
+    }
+}

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -573,7 +573,7 @@ Both panels have identical controls — changing a control on either panel write
 | B | A | Reverse split — receive on B, transmit on A |
 | B | B | Normal — receive and transmit on VFO B |
 
-The currently selected **RX** button is filled in; the selected **TX** button turns **red** whenever you are in split (RX and TX on different VFOs) and is filled grey otherwise. The selectors follow the radio live, so if you change the receive or transmit VFO at the rig the buttons update to match.
+The currently selected **RX** button is filled **green** (receiving); the selected **TX** button is filled **red** (transmitting) — the same colour convention as the radio's front panel. Unselected buttons stay outlined. The selectors follow the radio live, so if you change the receive or transmit VFO at the rig the buttons update to match.
 
 These selectors are **not shown on the dual-receiver FtdX101MP / FtdX101D**, where VFO A and VFO B are two independent physical receivers. On those radios you choose the operating (receive) band by clicking a VFO panel's header, and the transmit VFO follows the **Split** button — see §5.5 above and §5.10 Transmit Controls.
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -536,12 +536,7 @@ There are two VFO panels side by side:
 - **VFO A** (blue border) — the main receiver, present on all supported radios.
 - **VFO B** (green border) — on the FTdx101MP and FTdx101D this is a fully independent sub-receiver. On single-receiver radios (**FTdx10, FT-710, FTDX3000, FT-991A**) there is only one physical receiver chain inside the radio, so VFO B is a frequency / mode memory slot through which the single receiver is steered.
 
-**Greying behaviour on single-receiver radios** (FTdx10, FT-710, FTDX3000, FT-991A):
-
-- **Normal mode** (split off): the **active** VFO panel is fully usable; the **inactive** VFO's card body is greyed. Mode, IF Width, Notch, and the rest still display their stored values for reference, but cannot be edited — those values only apply when you swap that VFO to be active via the **A↔B** button. The card header (title, ZIN, TX when shown) stays normal colour.
-- **Split mode**: the **receive** VFO is fully usable; the **transmit** VFO's card body is greyed — opposite of normal mode for which panel is inactive. The TX panel's **frequency field is still editable** so you can set the TX frequency from YWC without un-splitting first — click a digit and scroll the mouse wheel, or use the keyboard icon next to MHz to type one in. Everything else in that card body stays read-only. The card header stays normal, so the TX button and SPLIT badge on the transmit panel remain full-colour and clearly active.
-
-On **dual-receiver radios** (FTdx101MP / FTdx101D) neither panel is greyed at any time — both VFOs are real physical receiver chains and are always independently usable.
+Both VFO panels stay full colour and fully editable on every supported radio — including single-receiver models (FTdx10, FT-710, FTDX3000, FT-991A). On those radios the toolbar **RX** / **TX** selectors show which VFO is receiving and transmitting; you can still set the other VFO's frequency, mode, and controls without swapping first. On **dual-receiver radios** (FTdx101MP / FTdx101D) an amber ring marks which band (MAIN / SUB) the main tuning knob currently controls.
 
 **S-meter location — not in the VFO panels.** From v2.3.9 the S-meter(s) and their 30-second history strips live in the **top meter row** (just below the toolbar), not inside the VFO A / VFO B panels.
 
@@ -549,7 +544,7 @@ On **dual-receiver radios** (FTdx101MP / FTdx101D) there are **two** S-meter gau
 
 **Antenna selector visibility:** the per-VFO antenna dropdown is hidden on radios with a single antenna jack (**FTdx10, FT-991A**) since there is nothing to select between. Radios with multiple antenna jacks (FTdx101MP, FTdx101D, FT-710, FTDX3000) keep the selector.
 
-Both panels have identical controls — changing a control on the active (fully usable) panel writes to the radio immediately; changing a control on the inactive panel's greyed body does nothing (apart from the TX frequency in split, as noted).
+Both panels have identical controls — changing a control on either panel writes to the radio.
 
 **VFO-B toggle** — the **VFO-B** button in the toolbar shows or hides the VFO B panel. The last state is remembered across sessions.
 

--- a/Yaesu_Web_Control.csproj
+++ b/Yaesu_Web_Control.csproj
@@ -70,6 +70,10 @@
     <Content Remove="core\**" />
     <EmbeddedResource Remove="core\**" />
     <None Remove="core\**" />
+    <!-- Tests/ holds a separate xUnit project (and leftover bin/obj from it).
+         The Web SDK still globs **/*.cs, so without this removal a previous
+         test build's copied Pages/*.cshtml.cs and generated AssemblyInfo
+         compile into this assembly and collide with the real page models. -->
     <Compile Remove="Tests\**" />
     <Content Remove="Tests\**" />
     <EmbeddedResource Remove="Tests\**" />

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -360,6 +360,15 @@ pre, code { tab-size: 4; }
     font-weight: bold;
 }
 
+/* Slot that absorbs leftover width between the band buttons and the
+   AGC column, then centers the filter/audio-scope stack in that gap. */
+.filter-scope-column-slot {
+    flex: 1 1 auto;
+    display: flex;
+    justify-content: center;
+    min-width: 160px;
+}
+
 /* Right-hand controls column — 2-column grid of label+select pairs */
 .vfo-controls-column {
     flex-shrink: 0;
@@ -367,7 +376,6 @@ pre, code { tab-size: 4; }
     grid-template-columns: repeat(2, minmax(110px, 1fr));
     gap: 0.3rem 0.4rem;
     align-content: start;
-    margin-left: auto;
 }
 
 .vfo-control-item {

--- a/wwwroot/js/ui/site.js
+++ b/wwwroot/js/ui/site.js
@@ -933,22 +933,20 @@ function updateSplitButton() {
 // Index TX button — because on FTdx10 / FT-710 the FT register often stays
 // at 0 when the operating VFO moves (front-panel A/B or RX selector), so
 // raw txVfo would leave TX stuck on A and falsely light split-red.
-// Selected RX is filled grey; selected TX is red when split is on, grey
-// when RX and TX are the same VFO.
+// Colours match Yaesu front-panel convention: green = receiving, red = transmitting.
 function updateRxTxSelectors() {
     const rxA = document.getElementById('rxVfoA');
     if (!rxA) return; // group only rendered on single-receiver radios
     const pick = (el, on, onClass) => {
         if (!el) return;
-        el.classList.remove('btn-secondary', 'btn-danger', 'btn-outline-secondary');
+        el.classList.remove('btn-secondary', 'btn-success', 'btn-danger', 'btn-outline-secondary');
         el.classList.add(on ? onClass : 'btn-outline-secondary');
     };
-    pick(rxA, activeVfo === 0, 'btn-secondary');
-    pick(document.getElementById('rxVfoB'), activeVfo === 1, 'btn-secondary');
+    pick(rxA, activeVfo === 0, 'btn-success');
+    pick(document.getElementById('rxVfoB'), activeVfo === 1, 'btn-success');
     const effTx = effectiveTxVfo();
-    const split = splitMode > 0 || effTx !== activeVfo;
-    pick(document.getElementById('txVfoA'), effTx === 0, split ? 'btn-danger' : 'btn-secondary');
-    pick(document.getElementById('txVfoB'), effTx === 1, split ? 'btn-danger' : 'btn-secondary');
+    pick(document.getElementById('txVfoA'), effTx === 0, 'btn-danger');
+    pick(document.getElementById('txVfoB'), effTx === 1, 'btn-danger');
 }
 
 async function setRxVfo(vfo) {

--- a/wwwroot/js/ui/site.js
+++ b/wwwroot/js/ui/site.js
@@ -929,21 +929,26 @@ function updateSplitButton() {
 }
 
 // Independent RX / TX VFO selectors (single-receiver radios, #78). RX follows
-// activeVfo (VS / FR), TX follows txVfo (FT); split is derived (TX ≠ RX). The
-// selected RX button is filled grey; the selected TX button is red when split
-// is on and filled grey when TX and RX are the same VFO.
+// activeVfo (VS / FR). TX must use effectiveTxVfo() — the same rule as the
+// Index TX button — because on FTdx10 / FT-710 the FT register often stays
+// at 0 when the operating VFO moves (front-panel A/B or RX selector), so
+// raw txVfo would leave TX stuck on A and falsely light split-red.
+// Selected RX is filled grey; selected TX is red when split is on, grey
+// when RX and TX are the same VFO.
 function updateRxTxSelectors() {
     const rxA = document.getElementById('rxVfoA');
     if (!rxA) return; // group only rendered on single-receiver radios
     const pick = (el, on, onClass) => {
+        if (!el) return;
         el.classList.remove('btn-secondary', 'btn-danger', 'btn-outline-secondary');
         el.classList.add(on ? onClass : 'btn-outline-secondary');
     };
     pick(rxA, activeVfo === 0, 'btn-secondary');
     pick(document.getElementById('rxVfoB'), activeVfo === 1, 'btn-secondary');
-    const split = txVfo !== activeVfo;
-    pick(document.getElementById('txVfoA'), txVfo === 0, split ? 'btn-danger' : 'btn-secondary');
-    pick(document.getElementById('txVfoB'), txVfo === 1, split ? 'btn-danger' : 'btn-secondary');
+    const effTx = effectiveTxVfo();
+    const split = splitMode > 0 || effTx !== activeVfo;
+    pick(document.getElementById('txVfoA'), effTx === 0, split ? 'btn-danger' : 'btn-secondary');
+    pick(document.getElementById('txVfoB'), effTx === 1, split ? 'btn-danger' : 'btn-secondary');
 }
 
 async function setRxVfo(vfo) {
@@ -952,10 +957,12 @@ async function setRxVfo(vfo) {
         if (r.ok) {
             const d = await r.json();
             activeVfo = d.rxVfo;
+            if (typeof d.txVfo === 'number') txVfo = d.txVfo;
             if (typeof d.splitMode === 'number') splitMode = d.splitMode;
             updateRxTxSelectors();
             updateSplitButton();
             applyVfoActiveStyling();
+            updateTxButton();
         }
     } catch {}
 }
@@ -1448,6 +1455,7 @@ connection.on("RadioStateUpdate", function (update) {
         // on (becomes "opposite of activeVfo") but FT often doesn't move on
         // FTdx10 to trigger the TxVfo handler -- so do it here too.
         updateTxButton();
+        updateRxTxSelectors();
         publishTxState();
         if (typeof window.updateToolbarStatus === 'function') window.updateToolbarStatus('split', update.value);
     }

--- a/wwwroot/js/ui/site.js
+++ b/wwwroot/js/ui/site.js
@@ -754,13 +754,13 @@ window.publishTxState = publishTxState;
 window.applySharedTxState = applySharedTxState;
 document.addEventListener('DOMContentLoaded', () => { getTxSyncChannel(); });
 
-// Apply the .vfo-inactive class to whichever VFO panel is NOT the active
-// (RX) one — but only on single-receiver radios (FTdx10, FT-710, FTDX3000).
-// CSS greys only that panel's .card-body (header stays normal so TX looks
-// enabled). Dual-receiver radios leave both panels active because each
-// VFO is its own physical receiver chain. The data-single-receiver
-// attribute on #vfoRow is rendered server-side from RadioCapabilities.cs.
-// See docs/decisions/0003-single-vs-dual-receiver-ui.md.
+// Dual-receiver (FTdx101): highlight which band is active — the MAIN/SUB
+// band the main tuning knob controls — with .vfo-active, driven by
+// activeVfo (VS: 0 = MAIN/A, 1 = SUB/B). The radio auto-broadcasts VS when
+// you press MAIN⇄SUB-select on the front panel, so this follows live.
+// Single-receiver radios do not grey or lock either panel; both stay fully
+// editable. Clears any leftover .vfo-inactive / .vfo-tx-editable from
+// earlier builds. See docs/decisions/0003-single-vs-dual-receiver-ui.md.
 function applyVfoActiveStyling() {
     const vfoRow = document.getElementById('vfoRow');
     if (!vfoRow) return;
@@ -768,79 +768,22 @@ function applyVfoActiveStyling() {
     const bCol = document.getElementById('vfoBCol');
     if (!aCol || !bCol) return;
 
-    // Spectrum panels live OUTSIDE the VFO columns in their own
-    // #spectrumContainer section — so they need the class applied
-    // separately to be greyed when their corresponding VFO is inactive.
-    // Note these can be absent (only one SDR configured, or none).
-    const aSpec = document.getElementById('spectrumContainerA');
-    const bSpec = document.getElementById('spectrumContainerB');
+    aCol.classList.remove('vfo-inactive', 'vfo-tx-editable');
+    bCol.classList.remove('vfo-inactive', 'vfo-tx-editable');
+    document.getElementById('spectrumContainerA')?.classList.remove('vfo-inactive');
+    document.getElementById('spectrumContainerB')?.classList.remove('vfo-inactive');
 
     const singleReceiver = vfoRow.dataset.singleReceiver === 'true';
-    if (!singleReceiver) {
-        // Dual-receiver (FTdx101): both panels are real receivers, so neither
-        // is greyed. But still show WHICH band is active — the MAIN/SUB band
-        // the main tuning knob controls — with a subtle highlight, driven by
-        // activeVfo (VS: 0 = MAIN/A, 1 = SUB/B). The radio auto-broadcasts VS
-        // when you press MAIN⇄SUB-select on the front panel, so this follows
-        // live. (Restores an indicator dropped in the ADR-0003 rework — Pierre
-        // VK6IS #FTdx101.)
-        aCol.classList.remove('vfo-inactive');
-        bCol.classList.remove('vfo-inactive');
-        aSpec?.classList.remove('vfo-inactive');
-        bSpec?.classList.remove('vfo-inactive');
-        aCol.classList.toggle('vfo-active', activeVfo === 0);
-        bCol.classList.toggle('vfo-active', activeVfo === 1);
+    if (singleReceiver) {
+        // No active-band amber ring on single-receiver — RX/TX selectors
+        // already show which VFO is receiving / transmitting.
+        aCol.classList.remove('vfo-active');
+        bCol.classList.remove('vfo-active');
         return;
     }
 
-    // Single-receiver uses greying (below), not the active highlight — clear
-    // any stale highlight in case the RadioModel was switched mid-session.
-    aCol.classList.remove('vfo-active');
-    bCol.classList.remove('vfo-active');
-
-    // Single-receiver: white = active VFO (the one currently RECEIVING),
-    // grey = the other one. This is true in BOTH normal and split mode:
-    //
-    //   Normal mode (R2): white = active VFO (RX), grey = the other.
-    //                     Pressing A/B on the radio swaps which is RX.
-    //
-    //   Split mode  (R7): white = active VFO (RX), grey = TX VFO.
-    //                     Radio receives on active VFO, transmits on the
-    //                     opposite VFO.
-    //
-    // In both cases, "inactive" (= grey) = whichever VFO is NOT the active
-    // RX one. We previously drove split-mode greying from txVfo (FT
-    // command) because the spec implied FT tracks the TX VFO — but the
-    // FTdx10 doesn't reliably move FT when split engages while VFO-B is
-    // the active VFO (Jacek SP3L 2026-06-21 #34 R7 fail). Using activeVfo
-    // (VS command) for both cases is deterministic and matches what the
-    // radio is actually doing.
-    //
-    // The TX button and SPLIT badge land on the inactive panel in split
-    // mode (R8) because updateTxButton / updateSplitButton derive the TX
-    // position as "opposite of active" on single-receiver radios. The
-    // card header is not greyed, so TX stays full-colour and clickable.
-    //
-    // The spectrum panel is NOT greyed — on single-receiver radios the
-    // single spectrum always shows the live receive signal. The second
-    // spectrum panel is hidden permanently by updateContainerVisibility().
-    const splitOn = splitMode > 0;
-    const inactiveCol = (activeVfo === 0) ? bCol : aCol;
-    const activeCol   = (activeVfo === 0) ? aCol : bCol;
-
-    activeCol.classList.remove('vfo-inactive', 'vfo-tx-editable');
-    inactiveCol.classList.add('vfo-inactive');
-    // R10/R11: in split mode the inactive panel IS the TX VFO — operators
-    // must still be able to set the TX frequency from YWC without
-    // un-splitting. .vfo-tx-editable re-enables the frequency field while
-    // leaving every other card-body control read-only.
-    inactiveCol.classList.toggle('vfo-tx-editable', splitOn);
-
-    // Make sure neither spectrum carries a stale inactive class from a
-    // previous render — in case the user switched RadioModel from
-    // dual-receiver to single-receiver mid-session.
-    aSpec?.classList.remove('vfo-inactive');
-    bSpec?.classList.remove('vfo-inactive');
+    aCol.classList.toggle('vfo-active', activeVfo === 0);
+    bCol.classList.toggle('vfo-active', activeVfo === 1);
 }
 
 // Apply the styling at page-load time too, before any SignalR update has


### PR DESCRIPTION
## Summary
- On single-receiver radios (FTdx10, FT-710, FTDX3000) both VFO panels stay fully editable — the inactive panel is no longer greyed out or blocked.
- RX/TX selectors follow the radio’s front-panel colours (RX green, TX red) and keep TX coherent when RX moves: non-split, TX follows RX; already split, TX stays put until RX lands on it.
- FTDX3000 uses FR/FT (including FT2 when split clears); FTdx10 / FT-710 / FT-991A also send ST to engage or clear split.
- Save to Mem and QMB sit under the filter/audio scope, centred in the gap between the band buttons and the AGC column.
- **Mode on the inactive VFO no longer rewrites the active one.** `MD` is per-VFO even on single-receiver radios (P1 0=MAIN/VFO-A, 1=SUB/VFO-B). It was being sent as `MD0` for both panels via the P1=0-Fixed path, so changing mode on VFO B while A was active also set A.

### Screenshots
<img width="1555" height="837" alt="image" src="https://github.com/user-attachments/assets/0effacd3-95e4-4910-8e79-491bd0799f1e" />


## Test plan
- [x] **Single-receiver (FTdx10 / FT-710 / FTDX3000):** both VFO panels stay live and editable; changing the inactive VFO does not grey it out.
- [x] **RX/TX selectors:** RX is green, TX is red. With split off, changing RX also moves TX. With split on, TX stays until RX is set to the same VFO (split clears).
- [ ] **FTDX3000:** RX B / both-on-B does not show reverse split (RX B / TX A). Split still works from the TX selector.
- [x] **FTdx10 / FT-710:** ST engages/clears split with the TX selector.
- [x] **Layout:** Save to Mem (and QMB on VFO A) sit under the filter/audio scope, centred between the band buttons and AGC. Dual-receiver (FTdx101) layout still looks right.
- [ ] **Mode (FTdx10):** with VFO A active, set VFO B to a different mode — A stays put; swapping to B shows the mode you set. Same the other way around.
- [x] Screenshots — to be added.