### PR TITLE
Expand VS Code launch and task configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,20 +1,71 @@
 {
     "version": "0.2.0",
     "configurations": [
-        
         {
-            "name": "Run Yaesu Web Control",
+            "name": "Yaesu Web Control (Windows)",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "build Yaesu_Web_Control",
-            "program": "${workspaceFolder}/bin/Debug/net10.0-windows/Yaesu_Web_Control.exe",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/bin/Debug/net10.0-windows/Yaesu_Web_Control.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,
+            "console": "integratedTerminal",
             "env": {
                 "ASPNETCORE_ENVIRONMENT": "Development",
-                "ASPNETCORE_URLS": "http://localhost:8080"
+                "DOTNET_ENVIRONMENT": "Development"
             }
+        },
+        {
+            "name": "Yaesu Web Control (Windows, Release)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build-release",
+            "program": "${workspaceFolder}/bin/Release/net10.0-windows/Yaesu_Web_Control.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "integratedTerminal",
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Production",
+                "DOTNET_ENVIRONMENT": "Production"
+            }
+        },
+        {
+            "name": "Yaesu Web Control (CAT-only / net10.0)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build-portable",
+            "program": "${workspaceFolder}/bin/Debug/net10.0/Yaesu_Web_Control.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "integratedTerminal",
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development",
+                "DOTNET_ENVIRONMENT": "Development"
+            }
+        },
+        {
+            "name": "Attach to Yaesu Web Control",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        },
+        {
+            "name": "Build Setup Installer",
+            "type": "node",
+            "request": "launch",
+            "runtimeExecutable": "powershell.exe",
+            "runtimeArgs": [
+                "-NoProfile",
+                "-Command",
+                "Write-Host 'Setup build complete: Yaesu_Web_Control_Setup.exe'; exit 0"
+            ],
+            "preLaunchTask": "build-setup",
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,24 +1,131 @@
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"label": "Build Yaesu_Web_Control",
-			"type": "shell",
-			"command": "dotnet build Yaesu_Web_Control.csproj",
-			"isBackground": false,
-			"problemMatcher": [
-				"$msCompile"
-			],
-			"group": "build"
-		},
-		{
-			"label": "build Yaesu_Web_Control",
-			"type": "shell",
-			"command": "dotnet build Yaesu_Web_Control.csproj",
-			"problemMatcher": [
-				"$msCompile"
-			],
-			"group": "build"
-		}
-	]
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Yaesu_Web_Control.csproj",
+                "-c",
+                "Debug",
+                "-f",
+                "net10.0-windows",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": "$msCompile",
+            "detail": "Build Windows product TFM (net10.0-windows)"
+        },
+        {
+            "label": "build-release",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Yaesu_Web_Control.csproj",
+                "-c",
+                "Release",
+                "-f",
+                "net10.0-windows",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile",
+            "detail": "Release build of Windows product TFM (net10.0-windows)"
+        },
+        {
+            "label": "build-portable",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Yaesu_Web_Control.csproj",
+                "-c",
+                "Debug",
+                "-f",
+                "net10.0",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile",
+            "detail": "Build CAT-only portable TFM (net10.0)"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/Yaesu_Web_Control.csproj",
+                "-c",
+                "Release",
+                "-f",
+                "net10.0-windows",
+                "-r",
+                "win-x64",
+                "--self-contained",
+                "true",
+                "--output",
+                "${workspaceFolder}/publish",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile",
+            "detail": "Publish Windows self-contained win-x64 (net10.0-windows)"
+        },
+        {
+            "label": "build-nsis",
+            "type": "shell",
+            "command": "$makensis = (Get-Command makensis.exe -ErrorAction SilentlyContinue).Source; if (-not $makensis) { $makensis = 'C:\\Program Files (x86)\\NSIS\\makensis.exe' }; if (!(Test-Path $makensis)) { Write-Error 'makensis.exe not found. Install NSIS (e.g. choco install nsis).'; exit 1 }; & $makensis installer.nsi; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }; $found = Get-ChildItem -Filter '*Setup*.exe' | Select-Object -First 1; if (-not $found) { Write-Error 'No *Setup*.exe found after NSIS ran'; exit 1 }; if ($found.Name -ne 'Yaesu_Web_Control_Setup.exe') { Rename-Item $found.FullName 'Yaesu_Web_Control_Setup.exe' }; Write-Host \"OK: $($found.DirectoryName)\\Yaesu_Web_Control_Setup.exe\"",
+            "options": {
+                "cwd": "${workspaceFolder}",
+                "shell": {
+                    "executable": "powershell.exe",
+                    "args": [
+                        "-NoProfile",
+                        "-ExecutionPolicy",
+                        "Bypass",
+                        "-Command"
+                    ]
+                }
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "build-setup",
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "publish",
+                "build-nsis"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "detail": "Publish win-x64 self-contained app, then build Yaesu_Web_Control_Setup.exe"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/Yaesu_Web_Control.csproj",
+                "--framework",
+                "net10.0-windows"
+            ],
+            "problemMatcher": "$msCompile",
+            "isBackground": true,
+            "detail": "dotnet watch run for Windows product TFM (net10.0-windows)"
+        }
+    ]
 }


### PR DESCRIPTION
## Summary
- Shared launch profiles for Windows, CAT-only (net10.0), Release, attach, and the NSIS setup installer
- Matching build/publish/watch tasks so both TFMs can be run from VS Code

## Test plan
- [x] Run **Yaesu Web Control (Windows)** from the Run and Debug panel
- [x] Run **Yaesu Web Control (CAT-only / net10.0)**
- [x] Optional: Run **Build Setup Installer** if NSIS is installed