### PR TITLE
Fix the SWR meter freezing and dipping (#124)

### DIFF
--- a/Services/CatCommands.cs
+++ b/Services/CatCommands.cs
@@ -200,12 +200,18 @@
             return 0;
         }
 
-        public static int ParseRm0LeftMeter(string response)
+        // Returns null when the response is missing or malformed -- NOT zero.
+        // These used to return 0 on every failure path, which made "the radio
+        // did not answer" indistinguishable from "the SWR is 1.0:1". A single
+        // dropped CAT response mid-over published a fabricated zero, and on a
+        // genuinely bad load the meter dipped to perfect for one poll cycle
+        // (issue #124). The caller skips the update when it gets null.
+        public static int? ParseRm0LeftMeter(string response)
         {
             // Parse left-side meter from RM0 response: RM0LLLRRR;
             // Positions 3-5 are the left meter value (0-255).
             if (string.IsNullOrEmpty(response) || !response.StartsWith("RM0"))
-                return 0;
+                return null;
             int semicolonIndex = response.IndexOf(';');
             if (semicolonIndex > 0)
                 response = response.Substring(0, semicolonIndex);
@@ -214,15 +220,16 @@
                 if (int.TryParse(response.Substring(3, 3), out int value))
                     return value;
             }
-            return 0;
+            return null;
         }
 
-        public static int ParseRm0RightMeter(string response)
+        // Null on a missing or malformed response -- see ParseRm0LeftMeter.
+        public static int? ParseRm0RightMeter(string response)
         {
             // Parse right-side meter from RM0 response: RM0LLLRRR;
             // Positions 6-8 are the right meter value (0-255).
             if (string.IsNullOrEmpty(response) || !response.StartsWith("RM0"))
-                return 0;
+                return null;
             int semicolonIndex = response.IndexOf(';');
             if (semicolonIndex > 0)
                 response = response.Substring(0, semicolonIndex);
@@ -231,7 +238,7 @@
                 if (int.TryParse(response.Substring(6, 3), out int value))
                     return value;
             }
-            return 0;
+            return null;
         }
 
         public static int ParseMeterReading(string response)

--- a/Services/MeterPollingService.cs
+++ b/Services/MeterPollingService.cs
@@ -286,6 +286,7 @@ namespace Yaesu_Web_Control.Services
                         bool useRm0Pair = settings.RadioModel is "FTdx101MP" or "FTdx101D";
                         int compression;
                         int swr;
+                        bool discardThisRead = false;
                         if (useRm0Pair)
                         {
                             _lastTxSeenUtc = DateTime.UtcNow;
@@ -303,15 +304,34 @@ namespace Yaesu_Web_Control.Services
 
                             var compSwrResponse = await _multiplexer.SendCommandAsync(CatCommands.MeterBoth + ";", "MeterPoll", stoppingToken);
                             _logger.LogDebug("[MeterPolling][DEBUG] RM0 response: '{Raw}'", compSwrResponse);
-                            compression = CatCommands.ParseRm0LeftMeter(compSwrResponse ?? "");
-                            swr         = CatCommands.ParseRm0RightMeter(compSwrResponse ?? "");
+                            int? compRaw = CatCommands.ParseRm0LeftMeter(compSwrResponse ?? "");
+                            int? swrRaw  = CatCommands.ParseRm0RightMeter(compSwrResponse ?? "");
+                            compression = compRaw ?? 0;
+                            swr         = swrRaw  ?? 0;
+
+                            // A dropped or malformed RM0 is not a reading of zero.
+                            // Publishing it as one made the SWR needle dip to 1.0
+                            // for a single poll cycle in the middle of a genuinely
+                            // bad load (issue #124) -- so hold the last value and
+                            // wait for the next poll instead.
+                            if (compRaw is null || swrRaw is null)
+                            {
+                                _logger.LogDebug("[MeterPolling] RM0 read dropped ('{Raw}') — holding previous meter values", compSwrResponse);
+                                discardThisRead = true;
+                            }
 
                             if (DateTime.UtcNow < _borrowSettleUntilUtc)
                             {
                                 // Meters have only just switched — this read may still
-                                // describe the operator's previous selection.
-                                compression = 0;
-                                swr         = 0;
+                                // describe the operator's previous selection. Drop it
+                                // rather than publishing a zero: a fabricated zero is
+                                // indistinguishable from a real reading downstream, and
+                                // FTdx101Meters averages the last three SWR readings, so
+                                // it dragged the needle to half scale on a genuine 10:1
+                                // load for the rest of the over (issue #124). Skipping
+                                // the write leaves the zero the RX branch already
+                                // published, which looks the same and lies to no one.
+                                discardThisRead = true;
                             }
                         }
                         else
@@ -323,11 +343,24 @@ namespace Yaesu_Web_Control.Services
                             var swrResponse = await _multiplexer.SendCommandAsync(CatCommands.MeterSWR + ";", "MeterPoll", stoppingToken);
                             _logger.LogDebug("[MeterPolling][DEBUG] RM6 response: '{Raw}'", swrResponse);
                             swr = CatCommands.ParseMeterReading(swrResponse ?? "");
+
+                            // Same reasoning as the RM0 branch above: a missing or
+                            // malformed answer must not be published as a zero.
+                            // ParseMeterReading is shared with seven other callers,
+                            // so the check is here rather than in its return value.
+                            if (string.IsNullOrEmpty(swrResponse) || !swrResponse.StartsWith("RM"))
+                            {
+                                _logger.LogDebug("[MeterPolling] RM6 read dropped ('{Raw}') — holding previous meter values", swrResponse);
+                                discardThisRead = true;
+                            }
                         }
 
-                        _stateService.SWRMeter = swr;
-                        _stateService.CompressionMeter = compression;
-                        _logger.LogDebug("[MeterPolling][DEBUG] TX Compression={Comp} SWR={SWR}", compression, swr);
+                        if (!discardThisRead)
+                        {
+                            _stateService.SWRMeter = swr;
+                            _stateService.CompressionMeter = compression;
+                            _logger.LogDebug("[MeterPolling][DEBUG] TX Compression={Comp} SWR={SWR}", compression, swr);
+                        }
                     }
                     else
                     {
@@ -338,7 +371,8 @@ namespace Yaesu_Web_Control.Services
                             _stateService.ALCMeter = 0;
                         if (_stateService.CompressionMeter != 0)
                             _stateService.CompressionMeter = 0;
-                        _stateService.SWRMeter = 0;
+                        if (_stateService.SWRMeter != 0)
+                            _stateService.SWRMeter = 0;
 
                         // Return borrowed meters once TX has been quiet for MeterReturnDelay.
                         bool useRm0Pair = settings.RadioModel is "FTdx101MP" or "FTdx101D";

--- a/Services/RadioStateService.cs
+++ b/Services/RadioStateService.cs
@@ -509,6 +509,14 @@ namespace Yaesu_Web_Control.Services
         }
 
         private int? _swrMeter;
+        // No spike filter here -- see issue #124. A "reject anything more than 30
+        // from the last value" test made the first reading of an over the anchor
+        // and then rejected every correction to it, so a genuine 255 latched for
+        // the rest of the over. Worse, a rejected write is not a write, so
+        // SetField never fired and the client stopped receiving SWRMeter updates
+        // altogether -- the gauge froze rather than reading high. Smoothing is
+        // the client's job: FTdx101Meters._processSWR averages the last 3
+        // readings and will not draw until it has 2 of them.
         public int? SWRMeter
         {
             get => _swrMeter;
@@ -516,11 +524,6 @@ namespace Yaesu_Web_Control.Services
             {
                 if (value == null) return;
                 int clamped = Math.Clamp(value.Value, 0, 255);
-                if (_swrMeter.HasValue && _swrMeter.Value != 0 && clamped != 0 && Math.Abs(clamped - _swrMeter.Value) > 30)
-                {
-                    _logger.LogWarning("[SWRMeter] Ignored spike: {Old} -> {New}", _swrMeter, clamped);
-                    return;
-                }
                 SetField(ref _swrMeter, clamped);
             }
         }

--- a/Tests/YaesuWebControl.Tests/Rm0MeterParsingTests.cs
+++ b/Tests/YaesuWebControl.Tests/Rm0MeterParsingTests.cs
@@ -1,0 +1,50 @@
+using Yaesu_Web_Control.Services;
+
+namespace YaesuWebControl.Tests;
+
+// Issue #124, second half. The FTdx101MP reads compression and SWR together
+// from one borrowed-meter response, RM0LLLRRR. Both parsers used to answer 0
+// when the response was missing or malformed, which is also a perfectly valid
+// reading -- 0 raw is SWR 1.0:1, a flat match. So a dropped CAT response, a
+// timeout, or a partial line was published to the browser as "your antenna is
+// perfect", and on a genuinely bad load the needle dipped to 1.0 for one poll
+// cycle before snapping back to full scale.
+//
+// Nothing downstream could tell the two apart, because by then both were the
+// integer 0. The distinction has to survive the parse, so these return null.
+public sealed class Rm0MeterParsingTests
+{
+    [Theory]
+    [InlineData("RM0128255;", 128, 255)]
+    [InlineData("RM0000000;", 0, 0)]      // a real pair of zeroes still parses as zero
+    [InlineData("RM0255000;", 255, 0)]
+    [InlineData("RM0128255", 128, 255)]   // no trailing semicolon
+    public void ParsesBothMetersFromAWellFormedResponse(string response, int left, int right)
+    {
+        Assert.Equal(left, CatCommands.ParseRm0LeftMeter(response));
+        Assert.Equal(right, CatCommands.ParseRm0RightMeter(response));
+    }
+
+    [Theory]
+    [InlineData("")]            // SendCommandAsync returned null -> "" at the call site
+    [InlineData("RM")]          // truncated
+    [InlineData("RM0")]         // prefix only, no digits
+    [InlineData("RM5072000;")]  // a different meter's answer arriving on this read
+    [InlineData("FA014250000;")]// an unrelated CAT line
+    [InlineData("RM0abcdef;")]  // right shape, not numeric
+    public void ReturnsNullRatherThanZeroWhenTheReadFailed(string response)
+    {
+        Assert.Null(CatCommands.ParseRm0LeftMeter(response));
+        Assert.Null(CatCommands.ParseRm0RightMeter(response));
+    }
+
+    // The right meter needs 9 characters; the left needs only 6. A response
+    // carrying just the left value must not report a confident zero for the
+    // right one -- that zero is the SWR needle.
+    [Fact]
+    public void ShortResponseYieldsTheLeftMeterButNullForTheRight()
+    {
+        Assert.Equal(128, CatCommands.ParseRm0LeftMeter("RM0128;"));
+        Assert.Null(CatCommands.ParseRm0RightMeter("RM0128;"));
+    }
+}

--- a/Tests/YaesuWebControl.Tests/SwrMeterBroadcastTests.cs
+++ b/Tests/YaesuWebControl.Tests/SwrMeterBroadcastTests.cs
@@ -1,0 +1,129 @@
+using System.ComponentModel;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Yaesu_Web_Control.Hubs;
+using Yaesu_Web_Control.Services;
+
+namespace YaesuWebControl.Tests;
+
+// Issue #124. RadioStateService.SWRMeter used to carry a spike filter that
+// rejected any reading more than 30 away from the previous one. On a genuinely
+// high SWR the first reading of the over was 255, that became the anchor, and
+// every later reading was then "a spike" and thrown away. Because a rejected
+// write never reaches SetField, no PropertyChanged fired and no SignalR frame
+// went out either -- so the browser did not draw a high SWR, it drew nothing at
+// all and the gauge sat wherever it was, usually 0. The operator's only clue
+// was a wrong needle on a real antenna fault, which is precisely the kind of
+// wrong answer that is silent rather than visible.
+//
+// These tests pin the property to "clamp, then broadcast every change" and
+// nothing else. Smoothing belongs on the client, where FTdx101Meters._processSWR
+// averages the last three readings.
+public sealed class SwrMeterBroadcastTests
+{
+    [Fact]
+    public void SWRMeter_BroadcastsALargeDropAfterAHighReading()
+    {
+        var (state, changed) = NewState();
+
+        state.SWRMeter = 255;   // key down into a bad load
+        state.SWRMeter = 26;    // the ATU catches up -- this used to be discarded
+
+        Assert.Equal(26, state.SWRMeter);
+        Assert.Equal(2, changed.Count(p => p == nameof(state.SWRMeter)));
+    }
+
+    [Fact]
+    public void SWRMeter_KeepsFollowingTheRadioAfterAHighFirstReading()
+    {
+        var (state, changed) = NewState();
+
+        // The exact sequence from Colin's bench log, where every value after
+        // the first was logged as "[SWRMeter] Ignored spike" and dropped.
+        foreach (var reading in new[] { 255, 26, 75, 3, 22, 4 })
+            state.SWRMeter = reading;
+
+        Assert.Equal(4, state.SWRMeter);
+        Assert.Equal(6, changed.Count(p => p == nameof(state.SWRMeter)));
+    }
+
+    [Fact]
+    public void SWRMeter_ClampsToTheMeterRange()
+    {
+        var (state, _) = NewState();
+
+        state.SWRMeter = 300;
+        Assert.Equal(255, state.SWRMeter);
+
+        state.SWRMeter = -5;
+        Assert.Equal(0, state.SWRMeter);
+    }
+
+    [Fact]
+    public void SWRMeter_DoesNotBroadcastAnUnchangedValue()
+    {
+        var (state, changed) = NewState();
+
+        state.SWRMeter = 40;
+        state.SWRMeter = 40;
+
+        Assert.Equal(1, changed.Count(p => p == nameof(state.SWRMeter)));
+    }
+
+    // The service takes its collaborators as concrete types, so this builds the
+    // real persistence service with a null environment -- its constructor does
+    // not use one, and IsInitialized stays false here so nothing is ever saved.
+    // Load() reads the host's radio_state.json if one exists; only the starting
+    // values come from it, and SWRMeter is not among them.
+    private static (RadioStateService State, List<string> Changed) NewState()
+    {
+        var persistence = new RadioStatePersistenceService(
+            NullLogger<RadioStatePersistenceService>.Instance, null!);
+
+        var state = new RadioStateService(
+            NullLogger<RadioStateService>.Instance,
+            persistence,
+            new SilentHubContext(),
+            new UnknownBandPlan());
+
+        var changed = new List<string>();
+        state.PropertyChanged += (_, e) => changed.Add(e.PropertyName ?? "");
+        return (state, changed);
+    }
+
+    // SetField raises PropertyChanged and broadcasts on the same branch, so the
+    // event count is a faithful stand-in for "a SignalR frame went out". The hub
+    // itself only has to not throw.
+    private sealed class SilentHubContext : IHubContext<RadioHub>
+    {
+        public IHubClients Clients { get; } = new SilentClients();
+        public IGroupManager Groups => throw new NotSupportedException();
+    }
+
+    private sealed class SilentClients : IHubClients
+    {
+        private static readonly IClientProxy Proxy = new SilentProxy();
+        public IClientProxy All => Proxy;
+        public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds) => Proxy;
+        public IClientProxy Client(string connectionId) => Proxy;
+        public IClientProxy Clients(IReadOnlyList<string> connectionIds) => Proxy;
+        public IClientProxy Group(string groupName) => Proxy;
+        public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds) => Proxy;
+        public IClientProxy Groups(IReadOnlyList<string> groupNames) => Proxy;
+        public IClientProxy User(string userId) => Proxy;
+        public IClientProxy Users(IReadOnlyList<string> userIds) => Proxy;
+    }
+
+    private sealed class SilentProxy : IClientProxy
+    {
+        public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed class UnknownBandPlan : IBandPlanService
+    {
+        public string CurrentRegion => "Region1";
+        public IReadOnlyList<BandEdge> CurrentEdges => Array.Empty<BandEdge>();
+        public string BandForFrequency(long hz) => "Unknown";
+    }
+}

--- a/wwwroot/js/orchestrators/FTdx101Meters.js
+++ b/wwwroot/js/orchestrators/FTdx101Meters.js
@@ -132,10 +132,30 @@ export class FTdx101Meters {
             this._swrHistory = [];
         }
         this._wasTransmittingSWR = true;
+
+        // A raw zero is not a measurement to be averaged in -- it is the server
+        // saying the over has ended (MeterPollingService zeroes the TX-only
+        // meters on the TX-off edge). Averaging it against the readings from the
+        // over invented a value that was never measured: one real 255 and one
+        // terminal zero average to 127.5, which the SWR table maps to exactly
+        // 3.0, and that is the 3.0 the needle used to stick at (issue #124).
+        // Resetting here is right under either reading of the value, because a
+        // raw zero genuinely is 1.0:1 -- no reflected power.
+        if (raw === 0) {
+            this._swrHistory = [];
+            this._meterPanel.update('swr', 0);
+            return { skip: false, gaugeKey: 'swr', displayValue: { swr: 1.0 } };
+        }
+
         this._swrHistory.push(raw);
         if (this._swrHistory.length > this._swrHistoryLength) this._swrHistory.shift();
-        // Require at least 2 readings before displaying — single-reading bursts are likely noise.
-        if (this._swrHistory.length < 2) return { skip: true };
+        // Draw on the first reading of the over. There used to be a "wait for 2
+        // readings, single bursts are likely noise" gate here, and it made the
+        // gauge dead exactly when it mattered: SWRMeter is broadcast on change
+        // only, so an over that sits at a steady value -- a genuinely bad load
+        // pinned at 255, say -- delivers exactly one update and the gate never
+        // opened. The needle stayed at 0 through a 10:1 SWR (issue #124). Noise
+        // is still handled, by averaging the last three readings below.
         const rawAvg    = this._swrHistory.reduce((s, v) => s + v, 0) / this._swrHistory.length;
         const swr       = this._calibration.calibrateNumeric('SWR', rawAvg);
         const swrClamped = Math.min(swr, 10.0);


### PR DESCRIPTION
Closes #124.

Reported as "the SWR meter freezes at full scale". It was four defects stacked,
each one hidden by the one in front of it. Only the first was the reported bug;
the other three only became visible on the bench once the fix above them landed.

## What was wrong

**1. The spike filter latched.** `RadioStateService.SWRMeter` rejected any
reading more than 30 away from the previous one. On a real high-SWR load the
first reading of the over was 255, that became the anchor, and every correction
was discarded as "a spike". Worse: a rejected write never reaches `SetField`, so
**no SignalR broadcast went out at all**. The gauge did not read high, it froze.

**2. The client would not draw on a single reading.** `_processSWR` waited for
two readings before drawing. But `SWRMeter` is broadcast on change only, so an
over sitting at a steady value delivers exactly ONE update - the gate never
opened and the needle stayed at 0 through the whole over.

**3. The meter-borrow settle window published a fabricated zero** at key-down.

**4. Parse failures published fabricated zeros mid-over.** `ParseRm0LeftMeter`
and `ParseRm0RightMeter` returned 0 for an empty, malformed or short response.
Raw 0 is also a legitimate reading - a flat 1.0:1 match - so one dropped CAT
response appeared as a 200 ms dip to "perfect antenna" in the middle of a bad
load.

The pattern behind 3 and 4: **a fabricated zero is indistinguishable from a real
reading** once it leaves the parser as an int. Any zero meaning "no data" has to
be null.

## Bench evidence

FTdx101MP into a genuinely bad antenna. Diagnostics recording `SWRMeter`; the
monitor prints on change, so silence means the value held.

Before, with only the spike filter removed - note the mid-over zeros, each
exactly one poll cycle wide (200 ms and 196 ms), and the antenna did not become
perfect for 200 ms and then bad again:

```
12:23:13.006  SWRMeter 255
12:23:14.817  SWRMeter 0      <- fabricated, mid-over
12:23:15.017  SWRMeter 255
12:23:18.136  SWRMeter 0      <- unkey
12:23:25.244  SWRMeter 255
12:23:31.780  SWRMeter 0      <- unkey
12:23:36.496  SWRMeter 255
12:23:37.097  SWRMeter 0      <- fabricated, mid-over
12:23:37.293  SWRMeter 255
12:23:43.119  SWRMeter 0      <- unkey
```

After, same antenna, three overs:

```
12:30:18.926  SWRMeter 255
12:30:22.859  SWRMeter 0
12:30:29.371  SWRMeter 255
12:30:35.394  SWRMeter 0
12:30:40.811  SWRMeter 255
12:30:46.834  SWRMeter 1
12:30:46.942  SWRMeter 0
```

255 at key-down, silence through the over, 0 at unkey. Needle at full scale for
the whole of every over and back to the bottom on receive.

The `1` in the last over is genuine, not a leftover of the old behaviour: with
the parsers returning null on failure, a raw 1 can only arrive as a well-formed
`RM0xxx001;`. It is the final poll catching reflected power collapsing as the PA
unkeys, 108 ms before the TX-off edge writes the 0.

## Tests

30 -> 45.

- `SwrMeterBroadcastTests` - every change is broadcast, including the exact
  sequence from the bench log that used to be swallowed.
- `Rm0MeterParsingTests` - null on a failed read, while a genuine `RM0000000;`
  still parses as zero. That distinction is the whole fix, so it is pinned.

Both new files were verified to FAIL against the old code before the fix went
in, so they are not tests that would pass either way.

Both TFMs build clean.

## Not in this PR

The SWR gauge face is labelled 1.0-3.0 and saturates at 3.0, while the text
readout prints the uncapped ratio up to 10.0:1 - so a 3:1 and a 10:1 look
identical on the needle. Real, but a separate concern from the zeros. To be
filed on its own.
