### PR TITLE
Rename the build workflow so PR checks stop reading as a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,14 @@
-name: Build and Release Installer
+# Named "Build" rather than "Build and Release Installer" because it runs on
+# every PR into develop as a build-only smoke test, and the old name made a
+# routine PR check look like it was about to publish a release. Nothing is
+# released except on the `release` event -- see the guards on each upload step.
+name: Build
+
+# Retitles the run itself, so the Actions list says what a given run was for.
+run-name: >-
+  ${{ github.event_name == 'pull_request' && format('Smoke build - PR #{0} (nothing published)', github.event.number)
+   || github.event_name == 'release' && format('Release {0} - building and publishing installers', github.event.release.tag_name)
+   || 'Manual build' }}
 
 on:
   release:


### PR DESCRIPTION
The workflow runs on every PR into develop as a build-only smoke test, but it
was named "Build and Release Installer". So a routine PR check box showed four
entries all prefixed with the word "Release" and read as though the PR was about
to publish something.

It never was. Every upload step is guarded by event name, and the docker push
flag falls to `false` on a `pull_request` event.

- Renames the workflow to `Build`, which is what the check prefix shows.
- Adds a `run-name` so the Actions list separates a PR smoke build from a real
  release run at a glance.

Safe to rename: `required_status_checks` is null on both develop and main, so
nothing references the old check names.

Not in this PR, but noticed while looking: the workflow never runs `dotnet test`
- only `dotnet publish`. A green tick currently means "it compiles and packages",
not "the tests pass". Worth adding separately.
