### PR TITLE
Run the unit tests in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,33 @@ on:
         type: string
 
 jobs:
+  # Runs on every trigger, including pull requests. Until this existed the
+  # workflow only ran `dotnet publish`, so a green tick meant "it compiles and
+  # packages" and said nothing about the tests -- a PR could break every test in
+  # the suite and still show all checks passed.
+  #
+  # The test project targets net10.0 only, so ubuntu is the cheapest host for it.
+  # It is a standalone job rather than a gate on the build jobs: a failure should
+  # be loud on the PR without adding its runtime to the front of every release
+  # build. To make it actually block a merge, add "Build / test" to the required
+  # status checks on develop -- none are configured at present.
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Run unit tests
+        run: dotnet test Tests/YaesuWebControl.Tests/YaesuWebControl.Tests.csproj --configuration Release --verbosity normal
+
   build-windows:
     runs-on: windows-latest
     permissions:


### PR DESCRIPTION
Noticed while merging #125: the workflow only ran `dotnet publish`. It never ran
`dotnet test`. So a green tick meant "it compiles and packages" and said nothing
at all about the 45 tests - a PR could break every one of them and still show
all checks passed.

That is easy to miss precisely because the check list looks thorough.

Adds a standalone `test` job on ubuntu-latest; the test project targets net10.0
only, so it needs nothing Windows-specific.

It is deliberately NOT a gate on the build jobs. A failure should be loud on the
PR without adding its runtime to the front of every release build. To make it
actually block a merge, add `Build / test` to the required status checks on
develop - none are configured there at present, which is also why renaming the
workflow in #126 was safe.

Verified locally in Release configuration: 45 passed, 0 failed.
