### PR TITLE
Say when the SWR needle has run out of scale

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -449,6 +449,14 @@ A scrollable row of meters is displayed above the VFO panels. The leftmost slots
 
 All meters update in real time at approximately 10 times per second. Meters that only apply to transmit automatically read zero when the radio is receiving. The S-meter(s) are always live.
 
+> **Reading the SWR meter above 3:1.** The SWR dial is marked 1.0 to 3.0, so the
+> needle stops climbing once the SWR passes 3:1 — a 3:1 match and a 10:1 match
+> park it in exactly the same place. When that happens the readout under the dial
+> turns amber, shows the true ratio, and adds a **▲** marker: for example
+> **SWR 5.4:1 ▲** means the needle is against the stop and the real figure is
+> 5.4:1. Trust the number, not the needle position, whenever the marker is showing.
+> A screen reader announces the same reading as "5.4:1 - off scale".
+
 The meter scales are calibrated to show meaningful units rather than raw ADC values. See Section 10 (Meter Calibration) if you want to adjust the calibration for your specific radio. Both S-meter gauges share the same calibration table — there's no separate MAIN/SUB calibration.
 
 **S-meter history strip.** A small 30-second strip-chart can be shown to the left of each S-meter gauge in the top meter row (one per VFO on dual-receiver radios). Click the **S-hist** button in the top toolbar to toggle both on or off together (off by default; the choice is remembered between sessions). Each strip shows three things at once:

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -447,7 +447,7 @@ A scrollable row of meters is displayed above the VFO panels. The leftmost slots
 
 **FTdx10, FT-710** — single S-meter (VFO A) plus four TX meters (SWR, Power, Compression, ALC). The Temp, IDD, and VDD meters are not shown because those radios have a different power amplifier design that runs on 13.8 V; the high-voltage PA meters do not apply.
 
-All meters update in real time at approximately 10 times per second. Meters that only apply to transmit automatically read zero when the radio is receiving. The S-meter(s) are always live.
+All meters update in real time — about five times a second at the default 200 ms **Meter Poll Interval** (Settings → Radio Connection). Not everything is read on every cycle: the S-meter(s) and transmit state are, while PA temperature, IDD, VDD and the antenna selection are read every two seconds, because they change slowly and reading them costs bus time the meters need. Meters that only apply to transmit automatically read zero when the radio is receiving. The S-meter(s) are always live.
 
 > **Reading the SWR meter above 3:1.** The SWR dial is marked 1.0 to 3.0, so the
 > needle stops climbing once the SWR passes 3:1 — a 3:1 match and a 10:1 match

--- a/wwwroot/js/orchestrators/FTdx101Meters.js
+++ b/wwwroot/js/orchestrators/FTdx101Meters.js
@@ -159,7 +159,10 @@ export class FTdx101Meters {
         const rawAvg    = this._swrHistory.reduce((s, v) => s + v, 0) / this._swrHistory.length;
         const swr       = this._calibration.calibrateNumeric('SWR', rawAvg);
         const swrClamped = Math.min(swr, 10.0);
-        this._meterPanel.update('swr', (swrClamped - 1.0) * 127.5);
+        // The face stops at 3.0, so pin the needle there rather than handing the
+        // gauge library a value off the end of its own range and trusting it to
+        // clamp. The true ratio still reaches the readout below (issue #128).
+        this._meterPanel.update('swr', Math.min(255, (swrClamped - 1.0) * 127.5));
         return { skip: false, gaugeKey: 'swr', displayValue: { swr: swrClamped } };
     }
 

--- a/wwwroot/js/ui/meter-formatters.js
+++ b/wwwroot/js/ui/meter-formatters.js
@@ -28,8 +28,34 @@ export const MeterFormatters = {
     // SWR  (SWRGauge has no gaugeTitleSuffix — full text goes in span)
     // ----------------------------------------------------------------
 
+    // The gauge face is labelled 1.0 to 3.0 (see SWRGauge in gauge.js), so the
+    // needle pins at the top for anything above 3:1. A dead-flat 3:1 and a
+    // rig-damaging 10:1 therefore look identical on the dial — issue #128, and
+    // it is not academic: it cost real time while diagnosing #124, because a
+    // genuinely pinned reading and a fabricated 3.0 parked the needle in the
+    // same place. Rather than redraw the face non-linearly, the readout says
+    // when the needle has run out of scale.
+    SWR_GAUGE_FULL_SCALE: 3.0,
+
+    swrIsOffScale(ratio) {
+        return ratio > this.SWR_GAUGE_FULL_SCALE;
+    },
+
+    // Badge text. Short by necessity — the badge is absolutely positioned and
+    // centred under a 165px meter cell, so words would overflow into the
+    // neighbouring gauges. The marker plus the colour change carries it for a
+    // sighted operator; swrAnnouncement() below carries it for everyone else.
     swr(ratio) {
-        return `${ratio.toFixed(1)}:1`;
+        const text = `${ratio.toFixed(1)}:1`;
+        return this.swrIsOffScale(ratio) ? `${text} ▲` : text;
+    },
+
+    // What goes in canvas.dataset.reading, which is what the a11y live region
+    // announces on hover. No layout constraint here, so it gets the words. This
+    // is deliberately not identical to the badge text.
+    swrAnnouncement(ratio) {
+        const text = `${ratio.toFixed(1)}:1`;
+        return this.swrIsOffScale(ratio) ? `${text} — off scale` : text;
     },
 
     // ----------------------------------------------------------------

--- a/wwwroot/js/ui/site.js
+++ b/wwwroot/js/ui/site.js
@@ -482,11 +482,26 @@ function updateMeterDomLabel(property, result) {
             break;
         }
         case 'SWRMeter': {
+            const offScale = window.MeterFormatters.swrIsOffScale(dv.swr);
             const formatted = window.MeterFormatters.swr(dv.swr);
             const el = document.getElementById('swrMeterValue');
-            if (el) el.textContent = formatted;
+            if (el) {
+                el.textContent = formatted;
+                // The badge is the <div> the gauge builds around this span
+                // (gauge.js, gaugeTitle block). Its background is set inline
+                // there, so it has to be overridden inline here — a CSS class
+                // would lose to the inline style.
+                const badge = el.parentElement;
+                if (badge) {
+                    badge.style.background = offScale ? '#ffc107' : '#dc3545';
+                    badge.style.color      = offScale ? '#000000' : '#ffffff';
+                }
+            }
             const canvas = document.getElementById('swrMeterCanvas');
-            if (canvas) canvas.dataset.reading = formatted;
+            if (canvas) {
+                canvas.dataset.reading = window.MeterFormatters.swrAnnouncement(dv.swr);
+                canvas.dataset.offScale = offScale ? 'true' : 'false';
+            }
             break;
         }
         case 'CompressionMeter': {


### PR DESCRIPTION
Closes #128.

## The problem

The SWR dial is labelled 1.0 to 3.0. Anything above 3:1 pins the needle in
exactly the same place, so a 3:1 you might work through and a 10:1 that means
"stop transmitting now" look identical.

This is not theoretical. It cost real time diagnosing #124: a genuinely pinned
raw 255 and a fabricated (255+0)/2 average both map to exactly 3.0, so the
needle could not distinguish them and every bench run had to be read off the
Diagnostics trace instead of the meter.

## The approach

I kept the 1.0-3.0 face rather than rescaling it non-linearly - Colin's call,
and it is the smaller change. Instead the readout says when the needle has
stopped carrying information.

- **Badge** turns amber-on-black and gains a triangle marker, so `SWR 5.4:1 [tri]`
  reads as off-scale rather than as a number that happens to be large.
  Short by necessity: the badge is absolutely positioned and centred under a
  165px meter cell, so words would overflow into the neighbouring gauges.
- **`canvas.dataset.reading`** - which is what the accessibility live region
  announces on hover - gets the words `5.4:1 - off scale` instead. No layout
  constraint there, and a screen reader makes nothing useful of a triangle.
  The badge text and the announced text are deliberately not identical.
- **Needle** is now pinned to 255 explicitly rather than being handed a value
  off the end of the gauge's own range on the assumption that the library
  clamps it.

Colour is not the only cue, which matters for this app's users.

The threshold lives in `MeterFormatters.SWR_GAUGE_FULL_SCALE`, next to the two
formatters that use it, so a future rescale of the face has one place to change.

## Verification

Formatter exercised directly under node:

```
1.0  | badge: "1.0:1"     | announce: "1.0:1"            | off: false
2.5  | badge: "2.5:1"     | announce: "2.5:1"            | off: false
3.0  | badge: "3.0:1"     | announce: "3.0:1"            | off: false
3.1  | badge: "3.1:1 [tri]"  | announce: "3.1:1 - off scale"  | off: true
5.4  | badge: "5.4:1 [tri]"  | announce: "5.4:1 - off scale"  | off: true
10.0 | badge: "10.0:1 [tri]" | announce: "10.0:1 - off scale" | off: true
```

Both modified files pass `node --check`. The boundary is `> 3.0`, so an exact
3.0 is not marked - the needle is telling the truth there.

## What is NOT covered

No automated test. This is entirely in the JS half of the app and there is no
JS test runner in the repo, so the CI `test` job added in #127 does not see any
of it. Worth knowing when reading a green check on this PR.

Still wants a bench run into a bad load to confirm the badge actually changes
colour on the real rig - the same test that produced the #124 traces.

## Also

`USER_MANUAL.md` gains a short note in the meters section explaining that the
dial stops at 3:1 and what the marker means.
