### PR TITLE
Drop the wrong 10 Hz meter-poll figure from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ First arrow-press with no digit selected just highlights the kHz digit — a sec
 
 Optional on-screen **▲/▼ buttons** sit next to each VFO's frequency display when **Settings → Accessibility → Show frequency up/down arrow buttons** is on. Each click steps the selected digit by 1, the same as a single ArrowUp/ArrowDown. Off by default so users with mouse wheels see the uncluttered default. Useful for head-tracking input, on-screen keyboard users, and reduced-dexterity operators.
 
-The selected digit highlights yellow. Selection persists across the ~10 Hz polling cycles so you can press ArrowUp ten times in a row and the selection stays put. Click outside the display + ▲/▼ controls to deselect.
+The selected digit highlights yellow. Selection persists across the meter polling cycles so you can press ArrowUp ten times in a row and the selection stays put. Click outside the display + ▲/▼ controls to deselect.
 
 USER_MANUAL chapter 13 (Keyboard Shortcuts) has the full reference table; §16.7 covers the accessibility-focused summary.
 
@@ -846,7 +846,7 @@ Critical hotfix on v2.3.3. **If you have v2.3.3 installed, please update.**
   initialization sequence the app uses on launch (multiplexer connect
   + ~30 CAT read queries + state restoration). That's safe at startup
   when nothing else is running yet — but on a running system it races
-  with the 10 Hz meter poller, the SDR workers, and any in-flight
+  with the meter poller, the SDR workers, and any in-flight
   WebUI commands, and on my bench it consistently crashed the
   YWC process on the first or second click.
 
@@ -1220,8 +1220,8 @@ report rather than from me hypothesising.
   (#17, SP3L-Jacek)
 
 - **Power gauge jitter during transmit.** Smoothing window extended from
-  7 to 15 samples (≈1.5 s at 10 Hz polling) to handle the steepness of
-  the PWR calibration curve above 100 W. SWR smoothing stays at 7 samples
+  7 to 15 samples to handle the steepness of the PWR calibration curve
+  above 100 W. SWR smoothing stays at 7 samples
   so high-SWR faults are still seen quickly.
 
 ### Documentation


### PR DESCRIPTION
Follow-on from #130, which fixed the same wrong figure in USER_MANUAL.md.

Three places in the README described the CAT meter poller as running at 10 Hz.
It never did:

- before `MeterPollIntervalMs` existed (added 2026-08-19, 7a4c662) the loop was
  a flat `Task.Delay(500)` - about 2 Hz
- today it is a 200 ms target cycle - about 5 Hz

So this is not a figure that went stale; it was wrong in every release that
quoted it. CLAUDE.md already records the 10 Hz numbers as wrong and they were
stripped from the code comments some time ago.

## The three

| Line | Was | Now |
|---|---|---|
| 618 | "persists across the ~10 Hz polling cycles" | "persists across the meter polling cycles" |
| 849 | "races with the 10 Hz meter poller" | "races with the meter poller" |
| 1223 | "7 to 15 samples (~1.5 s at 10 Hz polling)" | "7 to 15 samples" |

The first two only mention the rate in passing, so the number just goes - the
sentences say the same thing without it.

The third is different: the sample count is a historical fact worth keeping,
but the derived time was computed from the wrong rate. I could not state the
right one for that release without guessing at what the loop actually did at
the time, so the parenthetical is dropped rather than replaced with another
invented number.

## Why edit release notes at all

Normally I would not - dated entries are a record. But a number that was never
true is not history, and this one is the kind someone sizes a timeout or a
smoothing window off. Note the same entry says "SWR smoothing stays at 7
samples"; it is 3 today. That one I left, because it was true when written.

## Left alone

The remaining `10 Hz` hits at lines 672, 1398 and 1616 are the Diagnostics
render throttle, the CW pitch step size, and the canvas-gauges title
re-injection rate. None is the CAT poller.

Docs only - no code touched.
