### PR TITLE
Skip Windows SDR worker restore on macOS/Linux publish

### DIFF
--- a/Workers/Yaesu_Sdr_Worker/Yaesu_Sdr_Worker.csproj
+++ b/Workers/Yaesu_Sdr_Worker/Yaesu_Sdr_Worker.csproj
@@ -3,6 +3,10 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0-windows</TargetFramework>
+    <!-- Same reason as the main project: a Mac/Linux `dotnet restore` of the
+         Windows TFM graph must be allowed to evaluate this companion exe
+         even though it is never published there. -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <Platforms>x64</Platforms>
     <PlatformTarget>x64</PlatformTarget>
     <Nullable>enable</Nullable>

--- a/Yaesu_Web_Control.csproj
+++ b/Yaesu_Web_Control.csproj
@@ -191,8 +191,17 @@
     worker is an .exe, not a library — we don't want to link against it,
     we just want MSBuild to build it before us and the post-build copy
     target below to land its output next to YWC's exe.
+
+    `dotnet publish -f net10.0 -r osx-*` (macOS DMGs) still restores every
+    TFM, so the Windows inner graph would otherwise pull this worker and
+    forward RuntimeIdentifier=osx-arm64 / SelfContained into a
+    net10.0-windows + PlatformTarget=x64 project. That restore fails in
+    milliseconds with MSB4181 and no inner error (SDK 10.0.400 on
+    macos-latest). Restrict the reference to an empty RID (local
+    `dotnet build`) or a win-* RID (Windows publish); CAT-only osx/linux
+    publishes never ship the worker.
   -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows' AND ('$(RuntimeIdentifier)' == '' OR $([System.String]::Copy('$(RuntimeIdentifier)').StartsWith('win')))">
     <ProjectReference Include="Workers\Yaesu_Sdr_Worker\Yaesu_Sdr_Worker.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <Private>false</Private>


### PR DESCRIPTION
## Summary
- macOS DMG publish (`dotnet publish -f net10.0 -r osx-*`) still restores every TFM, so the Windows graph pulled `Yaesu_Sdr_Worker` (`net10.0-windows`) and forwarded the osx RID into it. Restore then failed in milliseconds with MSB4181 and no inner error.
- Restrict that ProjectReference to an empty RID (local `dotnet build`) or a `win-*` RID (Windows installer). CAT-only osx/linux publishes never ship the worker.
- Enable Windows targeting on the worker so a Mac/Linux restore of the Windows TFM graph can still evaluate it.

Windows installer, local Windows builds, and tests are unchanged.

## Test plan
- [ ] Confirm `build-macos` on this branch restores only the main project + core (no `Yaesu_Sdr_Worker`) and produces both DMGs
- [ ] Confirm `build-windows` still builds and copies `Yaesu_Sdr_Worker.exe`
- [ ] Confirm `build-docker` / unit tests still pass