### PR TITLE
Split macOS DMG builds per RID and verify on this PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,27 +173,32 @@ jobs:
   # build-docker cover the same compile, and macOS still runs on dispatch and
   # on release. If a change is macOS-specific, hit "Run workflow" on the branch.
   #
-  # timeout-minutes exists because this job can stall indefinitely. Observed
-  # three times on 2026-08-13: build-dmg.sh runs two sequential publishes, and
-  # the FIRST RID finished in under a minute while the SECOND stopped dead
-  # straight after restore and never recovered — 36, 38 and 54 minutes before
-  # being cancelled, with an orphaned dotnet/VBCSCompiler killed at cleanup.
-  # Not our code: it reproduced on tag v2.4.3-pre6, which has no core/ subtree
-  # in it at all and had built both DMGs in 1m50s three days earlier. Hosted
-  # arm64 macOS runners, nothing in this repo.
+  # One RID per matrix leg (fresh VM). Sequential `build-dmg.sh all` on a
+  # hosted arm64 runner hangs the SECOND publish after restore — VBCSCompiler
+  # wedged, 36/38/54 min on 2026-08-13 and again 2026-08-28 until the job
+  # timeout. Not our code; it reproduced on v2.4.3-pre6 with no core/ at all.
+  # Splitting removes that reuse. timeout-minutes stays so a single-RID hang
+  # still fails loud (~10x a normal ~2 min publish) instead of sitting until
+  # the runner is cancelled.
   #
-  # Why a timeout and not a retry: these jobs are independent — no `needs:` —
-  # so a stalled macOS job does not hold up build-windows or build-docker, and
-  # on a release that is the trap. The tag ships with the Windows installer and
-  # the Docker image while the DMGs never upload, and the release looks
-  # finished. Failing at 20 minutes (~10x the 1m50s normal, so a merely slow
-  # runner won't trip it) makes that visible instead of silent.
+  # Why a timeout and not a retry: these jobs are independent — no `needs:`
+  # from windows/docker — so a stalled macOS job does not hold up those, and
+  # on a release that is the trap. The tag ships with the Windows installer
+  # and the Docker image while the DMGs never upload, and the release looks
+  # finished. Failing at 10 minutes makes that visible instead of silent.
   build-macos:
     if: github.event_name != 'pull_request' && (github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'unstable-'))
     runs-on: macos-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
     permissions:
       contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        rid: [osx-arm64, osx-x64]
+    env:
+      MSBUILDDISABLENODEREUSE: 1
+      DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER: 1
 
     steps:
       - name: Checkout
@@ -204,22 +209,20 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      - name: Build macOS DMGs (arm64 + x64)
+      - name: Build macOS DMG (${{ matrix.rid }})
         run: |
           chmod +x scripts/macos/build-dmg.sh
-          ./scripts/macos/build-dmg.sh all
+          ./scripts/macos/build-dmg.sh "${{ matrix.rid }}"
+          ls -lh publish/dmg/*.dmg
 
-      - name: List DMG output
-        run: ls -lh publish/dmg/*.dmg
-
-      - name: Upload DMGs as workflow artifacts
+      - name: Upload DMG as workflow artifact
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v7
         with:
-          name: Yaesu_Web_Control_macOS_DMGs
+          name: Yaesu_Web_Control_macOS_DMG_${{ matrix.rid }}
           path: publish/dmg/*.dmg
 
-      - name: Upload DMGs to GitHub Release
+      - name: Upload DMG to GitHub Release
         if: github.event_name == 'release' || github.event.inputs.tag != ''
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
@@ -227,7 +230,7 @@ jobs:
           else
             tag="${{ github.event.inputs.tag }}"
           fi
-          echo "Uploading macOS DMGs to release: $tag"
+          echo "Uploading macOS DMG (${{ matrix.rid }}) to release: $tag"
           gh release upload "$tag" publish/dmg/*.dmg --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,8 @@ on:
   # gets version=smoke, push=false, the GHCR login skips and the image is built
   # and discarded.
   #
-  # build-macos is deliberately excluded (see its `if:`).
+  # build-macos is normally skipped on PRs (wall-clock; see its comment).
+  # Temporarily enabled for #133 so the RID-split can be verified on the PR.
   pull_request:
     branches: [develop]
 
@@ -168,10 +169,10 @@ jobs:
   # Unsigned CAT-only .app DMGs (arm64 + x64). No Apple Developer ID / notarization.
   # workflow_dispatch with empty tag → artifacts only (safe branch smoke test).
   #
-  # Skipped on pull requests, on wall-clock grounds rather than cost — both
-  # repos are public, so Actions minutes are free. build-windows and
-  # build-docker cover the same compile, and macOS still runs on dispatch and
-  # on release. If a change is macOS-specific, hit "Run workflow" on the branch.
+  # Normally skipped on pull requests, on wall-clock grounds rather than
+  # cost — both repos are public, so Actions minutes are free. Temporarily
+  # running on PRs for #133 to prove the RID-split; restore
+  # `github.event_name != 'pull_request' &&` on the `if:` after that.
   #
   # One RID per matrix leg (fresh VM). Sequential `build-dmg.sh all` on a
   # hosted arm64 runner hangs the SECOND publish after restore — VBCSCompiler
@@ -187,7 +188,7 @@ jobs:
   # and the Docker image while the DMGs never upload, and the release looks
   # finished. Failing at 10 minutes makes that visible instead of silent.
   build-macos:
-    if: github.event_name != 'pull_request' && (github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'unstable-'))
+    if: github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'unstable-')
     runs-on: macos-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,7 @@ on:
   # gets version=smoke, push=false, the GHCR login skips and the image is built
   # and discarded.
   #
-  # build-macos is normally skipped on PRs (wall-clock; see its comment).
-  # Temporarily enabled for #133 so the RID-split can be verified on the PR.
+  # build-macos is deliberately excluded (see its `if:`).
   pull_request:
     branches: [develop]
 
@@ -169,10 +168,10 @@ jobs:
   # Unsigned CAT-only .app DMGs (arm64 + x64). No Apple Developer ID / notarization.
   # workflow_dispatch with empty tag → artifacts only (safe branch smoke test).
   #
-  # Normally skipped on pull requests, on wall-clock grounds rather than
-  # cost — both repos are public, so Actions minutes are free. Temporarily
-  # running on PRs for #133 to prove the RID-split; restore
-  # `github.event_name != 'pull_request' &&` on the `if:` after that.
+  # Skipped on pull requests, on wall-clock grounds rather than cost — both
+  # repos are public, so Actions minutes are free. build-windows and
+  # build-docker cover the same compile, and macOS still runs on dispatch and
+  # on release. If a change is macOS-specific, hit "Run workflow" on the branch.
   #
   # One RID per matrix leg (fresh VM). Sequential `build-dmg.sh all` on a
   # hosted arm64 runner hangs the SECOND publish after restore — VBCSCompiler
@@ -188,7 +187,7 @@ jobs:
   # and the Docker image while the DMGs never upload, and the release looks
   # finished. Failing at 10 minutes makes that visible instead of silent.
   build-macos:
-    if: github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'unstable-')
+    if: github.event_name != 'pull_request' && (github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'unstable-'))
     runs-on: macos-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -113,13 +113,20 @@ jobs:
           name: windows-installer
           path: Yaesu_Web_Control_Setup.exe
 
-  # Same timeout rationale as release.yml (hosted arm64 macOS runners can stall).
+  # One RID per VM — see release.yml build-macos (sequential second-RID hang).
   build-macos:
     needs: prep
     runs-on: macos-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        rid: [osx-arm64, osx-x64]
+    env:
+      MSBUILDDISABLENODEREUSE: 1
+      DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER: 1
 
     steps:
       - name: Checkout
@@ -135,18 +142,18 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      - name: Build macOS DMGs (arm64 + x64)
+      - name: Build macOS DMG (${{ matrix.rid }})
         env:
           VERSION: ${{ needs.prep.outputs.version }}
         run: |
           chmod +x scripts/macos/build-dmg.sh
-          ./scripts/macos/build-dmg.sh all
+          ./scripts/macos/build-dmg.sh "${{ matrix.rid }}"
           ls -lh publish/dmg/*.dmg
 
-      - name: Upload DMGs as workflow artifacts
+      - name: Upload DMG as workflow artifact
         uses: actions/upload-artifact@v7
         with:
-          name: macos-dmgs
+          name: macos-dmg-${{ matrix.rid }}
           path: publish/dmg/*.dmg
 
   build-docker:

--- a/scripts/macos/build-dmg.sh
+++ b/scripts/macos/build-dmg.sh
@@ -18,6 +18,13 @@
 
 set -euo pipefail
 
+# Hosted arm64 macOS runners have been seen to leave VBCSCompiler / MSBuild
+# nodes alive after the first RID publish; the second then hangs forever
+# immediately after restore (release.yml 2026-08-13, again 2026-08-28).
+# CI now builds each RID in its own job. These still apply for local `all`.
+export MSBUILDDISABLENODEREUSE=1
+export DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1
+
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
 
@@ -145,7 +152,8 @@ build_one() {
     -r "$rid" \
     --self-contained true \
     -o "$publish_dir" \
-    /p:UseAppHost=true
+    /p:UseAppHost=true \
+    /p:UseSharedCompilation=false
 
   if [[ ! -x "$publish_dir/$EXEC_NAME" && ! -f "$publish_dir/$EXEC_NAME" ]]; then
     echo "error: apphost missing after publish: $publish_dir/$EXEC_NAME" >&2
@@ -200,6 +208,9 @@ ARG="${1:-$(detect_host_rid)}"
 case "$ARG" in
   all)
     build_one osx-arm64
+    # Drop the compiler/MSBuild servers from the first RID so the second
+    # cannot inherit a wedged VBCSCompiler (the hang CI used to hit).
+    dotnet build-server shutdown >/dev/null 2>&1 || true
     build_one osx-x64
     ;;
   osx-arm64|osx-x64)


### PR DESCRIPTION
## Summary
- #133 already landed the worker-restore fix. These two commits were pushed after that merge, so they never ran as PR checks.
- Build each macOS RID in its own matrix job (fresh VM) so the second publish cannot hang on a wedged VBCSCompiler.
- **Temporarily** run `build-macos` on pull requests so this PR actually exercises both legs. Artifact/release uploads stay gated. Restore the PR skip after both matrix jobs go green.

## Test plan
- [x] `build-macos (osx-arm64)` completes (build only; nothing uploaded)
- [x] `build-macos (osx-x64)` completes the same way (no hang after restore)
- [x] `build-windows` / `build-docker` / `test` still pass
- [x] After green: restore `github.event_name != 'pull_request' &&` on `build-macos` before merge