### PR TITLE
Skip Docker GHA cache when assembling the unstable snapshot

### DIFF
--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -216,9 +216,20 @@ jobs:
       contents: write
 
     steps:
-      - name: Download build artifacts
+      # Named artifacts only. `download-artifact` with no name/pattern fetches
+      # every artifact on the run, including docker/build-push-action's GHA
+      # cache blob (`*.dockerbuild`). That download failed after 5 retries on
+      # 2026-08-28 even though the installer and both DMGs had already landed.
+      - name: Download Windows installer
         uses: actions/download-artifact@v7
         with:
+          name: windows-installer
+          path: dist
+
+      - name: Download macOS DMGs
+        uses: actions/download-artifact@v7
+        with:
+          pattern: macos-dmg-*
           merge-multiple: true
           path: dist
 


### PR DESCRIPTION
## Summary
- Unstable `publish-release` uses `download-artifact` with no name/pattern, so it fetched every artifact on the run — including docker/build-push-action's GHA cache blob (`mm5agm~…~JO8PIF.dockerbuild`).
- The installer and both DMGs downloaded fine; that cache blob failed after 5 retries and aborted the snapshot.
- Download only `windows-installer` and `macos-dmg-*`.

## Test plan
- [x] After merge, the next `develop` push completes `publish-release` (installer + both DMGs attached; no `*.dockerbuild` download)